### PR TITLE
Edited XComGameState_HeadquartersResistance for avoided classes variable

### DIFF
--- a/X2WOTCCommunityHighlander/Src/XComGame/Classes/CHHelpers.uc
+++ b/X2WOTCCommunityHighlander/Src/XComGame/Classes/CHHelpers.uc
@@ -26,3 +26,9 @@ var config bool CHECK_CURED_TRAITS;
 // These classes have bAllowAWCAbilities set to true just to participate in the ComInt / AP system
 var config array<name> ClassesExcludedFromAWCRoll;
 // End Issue #80
+
+// start issue #113
+// list of classes to exclude from being considered "needed" by XComGameState_HeadquartersResistance
+// these are for classes which are meant to be rarely acquired via rookie level up, though others may also be here for their own reasons
+var config array<name> ClassesExcludedFromResHQ;
+//end issue #113

--- a/X2WOTCCommunityHighlander/Src/XComGame/Classes/XComGameState_HeadquartersResistance.uc
+++ b/X2WOTCCommunityHighlander/Src/XComGame/Classes/XComGameState_HeadquartersResistance.uc
@@ -227,7 +227,7 @@ function name SelectNextSoldierClass()
 	local XComGameState_HeadquartersXCom XComHQ;
 	local name RetName;
 	local int idx;
-	local array<name> NeededClasses, RewardClasses;
+	local array<name> NeededClasses, RewardClasses, AvoidedClasses; //issue #113: added AvoidedClasses array
 
 	History = `XCOMHISTORY;
 
@@ -238,10 +238,12 @@ function name SelectNextSoldierClass()
 	 
 	XComHQ = XComGameState_HeadquartersXCom(History.GetSingleGameStateObjectForClass(class'XComGameState_HeadquartersXCom'));
 	NeededClasses = XComHQ.GetNeededSoldierClasses();
-
+	//start Issue #113: we use AvoidedClasses to not count classes that mod authors do not want used here
+	AvoidedClasses = class'CHHelpers'.default.ClassesExcludedFromResHQ;
+	
 	for(idx = 0; idx < SoldierClassDeck.Length; idx++)
 	{
-		if(NeededClasses.Find(SoldierClassDeck[idx]) != INDEX_NONE)
+		if(NeededClasses.Find(SoldierClassDeck[idx]) != INDEX_NONE && AvoidedClasses.Find(SoldierClassDeck[idx]) == INDEX_NONE)
 		{
 			RewardClasses.AddItem(SoldierClassDeck[idx]);
 		}
@@ -253,13 +255,14 @@ function name SelectNextSoldierClass()
 
 		for(idx = 0; idx < SoldierClassDeck.Length; idx++)
 		{
-			if(NeededClasses.Find(SoldierClassDeck[idx]) != INDEX_NONE)
+			if(NeededClasses.Find(SoldierClassDeck[idx]) != INDEX_NONE && AvoidedClasses.Find(SoldierClassDeck[idx]) == INDEX_NONE)
 			{
 				RewardClasses.AddItem(SoldierClassDeck[idx]);
 			}
 		}
 	}
-
+	//end issue #113
+	
 	`assert(SoldierClassDeck.Length != 0);
 	`assert(RewardClasses.Length != 0);
 	RetName = RewardClasses[`SYNC_RAND(RewardClasses.Length)];


### PR DESCRIPTION
Issue #113 - lets mods specify classes that Resistance HQ shouldn't give out as rewards. Is configured in XComGame.ini 