### PR TITLE
Add wrapper function to CHUIItemSlotEnumerator

### DIFF
--- a/X2WOTCCommunityHighlander/Src/XComGame/Classes/CHUIItemSlotEnumerator.uc
+++ b/X2WOTCCommunityHighlander/Src/XComGame/Classes/CHUIItemSlotEnumerator.uc
@@ -48,7 +48,7 @@ var protected bool UseUnlockHints;
 // Parameters:
 //     _UnitState: The unit state (required)
 //     _CheckGameState: For MP, if the changes are made to a unit within a game state (optional)
-//     _SlotPriorities: A list of 2-tuples associating a slot with a priority override (optional
+//     _SlotPriorities: A list of 2-tuples associating a slot with a priority override (optional)
 //     _UseUnlockHints: For Multi-item slots, the slot may provide locked indicator slots (ex: locked utility slots in UISquadSelect), (optional)
 //     _OverrideSlotsList: Instead of considering UnitShowSlot on the Slot Templates (and using the default vanilla slots that should be shown), 
 //                         provide a slot list that overrides the default slots. Yields varying results when slots don't implement the functions UI code expects them to.
@@ -61,6 +61,22 @@ static function CHUIItemSlotEnumerator CreateEnumerator(XComGameState_Unit _Unit
 	En.Init(_UnitState, _CheckGameState, _SlotPriorities, _UseUnlockHints, _OverrideSlotsList);
 
 	return En;
+}
+
+// Same as in CreateEnumerator, but instead of accepting an array<CHSlotPriority> to override slot priorities, accept two arrays that are zipped into a struct array
+// This allows mods to optionally support the highlander without crashing if it isn't present
+static function CHUIItemSlotEnumerator CreateEnumeratorZipPriorities(XComGameState_Unit _UnitState, optional XComGameState _CheckGameState, optional array<EInventorySlot> _PriorityOverrideSlots, optional array<int> _PriorityOverridePriorities, optional bool _UseUnlockHints, optional array<EInventorySlot> _OverrideSlotsList)
+{
+	local array<CHSlotPriority> arr;
+	local int i;
+
+	arr.Add(_PriorityOverrideSlots.Length);
+	for (i = 0; i < arr.Length; i++)
+	{
+		arr[i].Slot = _PriorityOverrideSlots[i];
+		arr[i].Priority = _PriorityOverridePriorities[i];
+	}
+	return CreateEnumerator(_UnitState, _CheckGameState, arr, _UseUnlockHints, _OverrideSlotsList);
 }
 
 protected function Init(XComGameState_Unit _UnitState, optional XComGameState _CheckGameState, optional array<CHSlotPriority> _SlotPriorities, optional bool _UseUnlockHints, optional array<EInventorySlot> _OverrideSlotsList)


### PR DESCRIPTION
Use case: want my squad select to optionally support the Highlander. Declaring an array of a struct that is not present crashes the game at startup.