### PR TITLE
Fix UIPanel:SwapChildren with UINavigator:SwapControls

### DIFF
--- a/X2WOTCCommunityHighlander/Src/XComGame/Classes/UINavigator.uc
+++ b/X2WOTCCommunityHighlander/Src/XComGame/Classes/UINavigator.uc
@@ -118,12 +118,21 @@ public function RemoveControl(UIPanel Control)
 
 // Start Issue #47
 // Add SwapControls function to handle control reordering from the owning UI element.
-public function SwapControls(int ControlIndexA, int ControlIndexB)
+public function SwapControls(UIPanel ChildA, UIPanel ChildB)
 {
 	local UIPanel Panel;
-	Panel = NavigableControls[ControlIndexA];
-	NavigableControls[ControlIndexA] = NavigableControls[ControlIndexB];
-	NavigableControls[ControlIndexB] = Panel;
+	local int ControlIndexA, ControlIndexB;
+
+	ControlIndexA = NavigableControls.Find(ChildA);
+	ControlIndexB = NavigableControls.Find(ChildB);
+
+	// It is perfectly valid for children to not actually be navigable, hence the explicit check here
+	if (ControlIndexA > INDEX_NONE && ControlIndexB > INDEX_NONE)
+	{
+		Panel = NavigableControls[ControlIndexA];
+		NavigableControls[ControlIndexA] = NavigableControls[ControlIndexB];
+		NavigableControls[ControlIndexB] = Panel;
+	}
 }
 // End Issue #47
 

--- a/X2WOTCCommunityHighlander/Src/XComGame/Classes/UIPanel.uc
+++ b/X2WOTCCommunityHighlander/Src/XComGame/Classes/UIPanel.uc
@@ -932,6 +932,7 @@ simulated function GetChildrenOfType(class ClassType, out array<UIPanel> Childre
 simulated function SwapChildren(int ChildIndexA, int ChildIndexB)
 {
 	local UIPanel Panel;
+
 	Panel = ChildPanels[ChildIndexA];
 	ChildPanels[ChildIndexA] = ChildPanels[ChildIndexB];
 	ChildPanels[ChildIndexB] = Panel;
@@ -939,7 +940,8 @@ simulated function SwapChildren(int ChildIndexA, int ChildIndexB)
 	// Start Issue #47
 	// Tell the navigator to swap its controls too
 	// or keyboard nav will be out of sync.
-	Navigator.SwapControls(ChildIndexA, ChildIndexB);
+	// Note the swap of B and A, we already changed them in the array above
+	Navigator.SwapControls(ChildPanels[ChildIndexB], ChildPanels[ChildIndexA]);
 	// End Issue #47
 }
 


### PR DESCRIPTION
`UIPanel:SwapChildren` (called by `UIList:MoveItemToTop/Bottom`) calls `UINavigator:SwapControls` with its child indices. This is a problem if not all list items are navigable. This doesn't really happen in the vanilla game, but should be fixed in case it becomes a problem with users of the `MoveItemToTop/Bottom` functions.

Side note, if anyone called `UINavigator:SwapControls` manually before, this would be a breaking change, but I don't think anyone ever did that.