### PR TITLE
Improve Log message accuracy

### DIFF
--- a/X2WOTCCommunityHighlander/Src/X2WOTCCommunityHighlander/Classes/X2DownloadableContentInfo_X2WOTCCommunityHighlander.uc
+++ b/X2WOTCCommunityHighlander/Src/X2WOTCCommunityHighlander/Classes/X2DownloadableContentInfo_X2WOTCCommunityHighlander.uc
@@ -14,7 +14,7 @@ class X2DownloadableContentInfo_X2WOTCCommunityHighlander extends X2Downloadable
 /// </summary>
 static event OnPostTemplatesCreated()
 {
-	`log("x2wotccommunityhighlander :: present and correct");
+	`log("Companion script package loaded", , 'X2WOTCCommunityHighlander');
 
 	// Begin Issue #123
 	class'CHHelpers'.static.RebuildPerkContentCache();

--- a/X2WOTCCommunityHighlander/Src/X2WOTCCommunityHighlander/Classes/X2WOTCCH_UIScreenListener_ShellSplash.uc
+++ b/X2WOTCCommunityHighlander/Src/X2WOTCCommunityHighlander/Classes/X2WOTCCH_UIScreenListener_ShellSplash.uc
@@ -3,6 +3,7 @@ class X2WOTCCH_UIScreenListener_ShellSplash extends UIScreenListener config(Game
 var config bool bEnableVersionDisplay;
 
 var localized string strCHLVersion;
+var string HelpLink;
 
 event OnInit(UIScreen Screen)
 {
@@ -34,11 +35,15 @@ event OnInit(UIScreen Screen)
 		iMinor = CHVersion.MinorVersion;
 		iPatch = CHVersion.PatchVersion;
 	}
+	else
+	{
+		`log("Companion script package loaded, but XComGame replacement is not! Please see" @ HelpLink @ "for help.", , 'X2WOTCCommunityHighlander');
+	}
 	VersionString = Repl(VersionString, "%MAJOR", iMajor);
 	VersionString = Repl(VersionString, "%MINOR", iMinor);
 	VersionString = Repl(VersionString, "%PATCH", iPatch);
 
-	`log("X2CH SCREEN LISTENER ON SPLASH" @ VersionString);
+	`log("Showing version" @ VersionString @ "on shell screen...", , 'X2WOTCCommunityHighlander');
 	VersionText = ShellScreen.Spawn(class'UIText', ShellScreen);
 	VersionText.InitText('theVersionText');
 	VersionText.SetText(VersionString, OnTextSizeRealized);
@@ -62,5 +67,6 @@ function OnTextSizeRealized()
 
 defaultProperties
 {
-    ScreenClass = none
+	ScreenClass = none
+	HelpLink = "https://github.com/X2CommunityCore/X2WOTCCommunityHighlander/wiki/Troubleshooting"
 }

--- a/X2WOTCCommunityHighlander/Src/XComGame/Classes/CHXComGameVersion.uc
+++ b/X2WOTCCommunityHighlander/Src/XComGame/Classes/CHXComGameVersion.uc
@@ -16,8 +16,9 @@ static function array<X2DataTemplate> CreateTemplates()
 {
 	local array<X2DataTemplate> Templates;
 	local CHXComGameVersionTemplate XComGameVersion;
-	`log("Creating CHXCOMGameVersionTemplate");
+	`log("Creating CHXCOMGameVersionTemplate...", , 'X2WOTCCommunityHighlander');
 	`CREATE_X2TEMPLATE(class'CHXComGameVersionTemplate', XComGameVersion, 'CHXComGameVersion');
+	`log("Created CHXCOMGameVersionTemplate with version" @ XComGameVersion.MajorVersion $ "." $ XComGameVersion.MinorVersion $ "." $ XComGameVersion.PatchVersion, , 'X2WOTCCommunityHighlander');
 	Templates.AddItem(XComGameVersion);
 
 	return Templates;

--- a/X2WOTCCommunityHighlander/Src/XComGame/Classes/CHXComGameVersion.uc
+++ b/X2WOTCCommunityHighlander/Src/XComGame/Classes/CHXComGameVersion.uc
@@ -16,9 +16,9 @@ static function array<X2DataTemplate> CreateTemplates()
 {
 	local array<X2DataTemplate> Templates;
 	local CHXComGameVersionTemplate XComGameVersion;
-	`log("Creating CHXCOMGameVersionTemplate...", , 'X2WOTCCommunityHighlander');
+	class'X2TacticalGameRuleset'.static.ReleaseScriptLog("X2WOTCCommunityHighlander: Creating CHXCOMGameVersionTemplate...");
 	`CREATE_X2TEMPLATE(class'CHXComGameVersionTemplate', XComGameVersion, 'CHXComGameVersion');
-	`log("Created CHXCOMGameVersionTemplate with version" @ XComGameVersion.MajorVersion $ "." $ XComGameVersion.MinorVersion $ "." $ XComGameVersion.PatchVersion, , 'X2WOTCCommunityHighlander');
+	class'X2TacticalGameRuleset'.static.ReleaseScriptLog("X2WOTCCommunityHighlander: "Created CHXCOMGameVersionTemplate with version" @ XComGameVersion.MajorVersion $ "." $ XComGameVersion.MinorVersion $ "." $ XComGameVersion.PatchVersion");
 	Templates.AddItem(XComGameVersion);
 
 	return Templates;


### PR DESCRIPTION
The old log messages are kind of inaccurate and don't give a full picture. In particular:

* `present and correct` is wrong. That message only checks for the companion script package.
* `X2CH SCREEN LISTENER ON SPLASH` doesn't give any warning about a missing core package replacement.
* `Creating CHXCOMGameVersionTemplate` is pretty bad too -- we want to show a version here as well in case the companion script package fails.

This PR addresses these issues and adds the `X2WOTCCommunityHighlander` log tag to all log messages.