### PR TITLE
Fix final_release flag in powershell build script

### DIFF
--- a/.scripts/build.ps1
+++ b/.scripts/build.ps1
@@ -254,6 +254,17 @@ if ($LASTEXITCODE -ne 0)
 }
 Write-Host "Compiled base game scripts."
 
+# If we build in final release, we must build the normal scripts too
+if ($final_release -eq $true)
+{
+    Write-Host "Compiling base game scripts without final_release..."
+    Invoke-Make "$sdkPath/binaries/Win64/XComGame.com" "make -nopause -unattended" $sdkPath $modSrcRoot
+    if ($LASTEXITCODE -ne 0)
+    {
+        FailureMessage "Failed to compile base game scripts without final_release!"
+    }
+}
+
 # build the mod's scripts
 Write-Host "Compiling mod scripts..."
 Invoke-Make "$sdkPath/binaries/Win64/XComGame.com" "make -nopause -mods $modNameCanonical $stagingPath" $sdkPath $modSrcRoot


### PR DESCRIPTION
There used to be a small problem that can cause the editor to skip producing an `X2WOTCCommunityHighlander.u` (companion script package) without erroring out!