### PR TITLE
Fixes issue #310 and bug fix to issue #153

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -31,6 +31,8 @@ All notable changes to Vanilla 'War Of The Chosen' Behaviour will be documented 
   factions and then assigns Chosen to them instead of the base game factions.
   (#82)
 - Allow specifying Second Wave options for Strategy Debug Start (#197)
+- bDontUnequipCovertOps prevents soldiers gear gets stripped when sending on covert op with no ambush risk (#153)
+- bDontUnequipWhenWounded prevents soldiers gear gets stripped when getting wounded (#310)
 
 ### Improvements
 - Allow `UIStrategyMap` to display custom Faction HQ icons (#76)

--- a/X2WOTCCommunityHighlander/Config/XComGame.ini
+++ b/X2WOTCCommunityHighlander/Config/XComGame.ini
@@ -21,3 +21,6 @@ bEnableVersionDisplay=true
 
 ;GrenadeRespectUniqueRule=false ; Set to true to make grenade slot respect unique items rule.
 ;AmmoSlotBypassUniqueRule=false ; Set to true to make ammo slot ignore unique items rule.
+
+;bDontUnequipWhenWounded=true ; Set to true to make soldier keep their gear when wounded
+;bDontUnequipCovertOps=true ; Uncomment to make soldiers on covert ops keep their gear even if ambush risk is 0

--- a/X2WOTCCommunityHighlander/Config/XComGameBoard.ini
+++ b/X2WOTCCommunityHighlander/Config/XComGameBoard.ini
@@ -1,2 +1,0 @@
-[XComGameState_CovertOps]
-;bDontUnequipCovertOps=true ;Uncomment to make soldiers on covert ops keep their gear even if ambush risk is 0

--- a/X2WOTCCommunityHighlander/Src/XComGame/Classes/CHHelpers.uc
+++ b/X2WOTCCommunityHighlander/Src/XComGame/Classes/CHHelpers.uc
@@ -92,6 +92,15 @@ var config(Content) array<name> HeadSuppressesHelmet;
 var config(Content) array<name> HeadSuppressesBeard;
 // End Issue #219
 
+
+// Issue #153
+var config bool bDontUnequipCovertOps; // true skips unequipping soldiers on covert actions even if ambush risk is 0
+// End Issue #153
+
+// Start Issue #310
+var config bool bDontUnequipWhenWounded; // true skips unequipping soldiers after mission when being wounded
+// End Issue #310
+
 // Start Issue #123
 simulated static function RebuildPerkContentCache() {
 	local XComContentManager		Content;

--- a/X2WOTCCommunityHighlander/Src/XComGame/Classes/X2StrategyElement_XpackStaffSlots.uc
+++ b/X2WOTCCommunityHighlander/Src/XComGame/Classes/X2StrategyElement_XpackStaffSlots.uc
@@ -646,7 +646,10 @@ static function EmptyCovertActionSlot(XComGameState NewGameState, StateObjectRef
 			// Issue #230 end
 
 			// Then try to equip the rest of the old items
-			NewUnitState.EquipOldItems(NewGameState);
+			if (!class'CHHelpers'.default.bDontUnequipCovertOps) // Issue #153
+			{
+				NewUnitState.EquipOldItems(NewGameState);
+			}
 
 			// Try to restart any psi training projects
 			class'XComGameStateContext_StrategyGameRule'.static.PostMissionUpdatePsiOperativeTraining(NewGameState, NewUnitState);

--- a/X2WOTCCommunityHighlander/Src/XComGame/Classes/XComGameStateContext_StrategyGameRule.uc
+++ b/X2WOTCCommunityHighlander/Src/XComGame/Classes/XComGameStateContext_StrategyGameRule.uc
@@ -1481,7 +1481,13 @@ static function RemoveInvalidSoldiersFromSquad()
 						}
 					}
 
-					UnitState.MakeItemsAvailable(NewGameState, false, SlotsToClear);
+					// Start Issue #310
+					if (!class'CHHelpers'.default.bDontUnequipWhenWounded)
+					{
+						UnitState.MakeItemsAvailable(NewGameState, false, SlotsToClear);
+					}
+					// End Issue #310
+
 					UnitState.bIsShaken = false;
 				}
 			}

--- a/X2WOTCCommunityHighlander/Src/XComGame/Classes/XComGameState_CovertAction.uc
+++ b/X2WOTCCommunityHighlander/Src/XComGame/Classes/XComGameState_CovertAction.uc
@@ -24,9 +24,6 @@ var() bool									bNeedsAmbushPopup; // Does this Action need a popup to alert 
 var() bool									bNewAction; // Flag for VO and popup alerts to indicate that this Covert Action was newly made available in the facility
 var() bool									bBondmateDurationBonusApplied; // Are bondmates staffed on this Covert Action?
 
-// Issue #153 variable
-var() config bool							bDontUnequipCovertOps; // true skips unequipping soldiers on covert actions even if ambush risk is 0
-
 var() TDateTime								StartDateTime; // When did this Action begin
 var() TDateTime								EndDateTime; // When does this Action end
 var() float									HoursToComplete;
@@ -356,7 +353,7 @@ function RemoveStaffedUnitsFromSquad(XComGameState NewGameState)
 			}
 			
 			if (!HasAmbushRisk() && !UnitState.bIsSuperSoldier
-				&& !bDontUnequipCovertOps) // Issue #153
+				&& !class'CHHelpers'.default.bDontUnequipCovertOps) // Issue #153
 			{
 				// Drop all of the unit's unique items if there is no chance of an Ambush
 				UnitState.MakeItemsAvailable(NewGameState, true);

--- a/X2WOTCCommunityHighlander/X2WOTCCommunityHighlander.x2proj
+++ b/X2WOTCCommunityHighlander/X2WOTCCommunityHighlander.x2proj
@@ -27,9 +27,6 @@
     <Folder Include="Src\XComGame\Classes" />
   </ItemGroup>
   <ItemGroup>
-    <Content Include="Config\XComGameBoard.ini">
-      <SubType>Content</SubType>
-    </Content>
     <Content Include="Config\XComGameCore.ini">
       <SubType>Content</SubType>
     </Content>


### PR DESCRIPTION
Adds `bDontUnequipWhenWounded` to `CHHelpers` which when true skips unequipping soldiers after mission when being wounded

Moves`bDontUnequipCovertOps` from `XComGameState_CovertAction` to `CHHelpers` and removes then unused `XComGameBoard.ini`