### PR TITLE
Arithmetic fix for loot table to not mess up all the chances

### DIFF
--- a/X2WOTCCommunityHighlander/Src/XComGame/Classes/X2LootTable.uc
+++ b/X2WOTCCommunityHighlander/Src/XComGame/Classes/X2LootTable.uc
@@ -251,11 +251,11 @@ private static function RecalculateChancesForRollGroup(X2LootTable LootTable, in
 				}
 				else
 				{
-					NewChance = 100 / SumChances * OldChance;
+					NewChance = 100 * OldChance / SumChances;
 				}
 				NewSumChances += NewChance;
 
-				EntryRemainder.ChanceRemainder = (100 / SumChances * OldChance) - NewChance;
+				EntryRemainder.ChanceRemainder = (100 * OldChance / SumChances) - NewChance;
 				EntryRemainder.EntryIndex = TableEntryIndex;
 				Remainders.AddItem(EntryRemainder);
 


### PR DESCRIPTION
This fixes an issue in the feature added in PR #9, beating [my previous record](https://github.com/X2CommunityCore/X2WOTCCommunityHighlander/issues/302) for the time a bug we introduced staying undiscovered. Congrats @Musashi1584 😃 

On a more serious note: The previous calculation did the right thing on paper, but fell victim to a bad calculation order, making the loot chances not particularly proportional. This PR fixes this -- theoretically only making the calculations more accurate, but practically actually making sure that our odds aren't all the same.

Before:
```
[0014.70] X2LootTableManager: Adding LootEntry AdventGremlinM2 None from LootTable AdvShieldBearerM2_TimedLoot
[0014.70] X2LootTableManager: Recalculating loot chances for Loot Table AdvShieldBearerM2_TimedLoot RollGroup 1  Equally Distributed False
[0014.71] X2LootTableManager:   Chances before recalculation:
[0014.71] X2LootTableManager:            None ADVENTMidTimedLoot 100
[0014.71] X2LootTableManager:            AdventGremlinM2 None 20
[0014.71] X2LootTableManager:   Sum Chances  120
[0014.71] X2LootTableManager:   Chances after recalculation:
[0014.71] X2LootTableManager:            None ADVENTMidTimedLoot 50
[0014.71] X2LootTableManager:            AdventGremlinM2 None 50
[0014.71] X2LootTableManager:   Sum Chances  100
```

After:
```
[0015.46] X2LootTableManager: Adding LootEntry AdventGremlinM2 None from LootTable AdvShieldBearerM2_TimedLoot
[0015.46] X2LootTableManager: Recalculating loot chances for Loot Table AdvShieldBearerM2_TimedLoot RollGroup 1  Equally Distributed False
[0015.46] X2LootTableManager:   Chances before recalculation:
[0015.46] X2LootTableManager:            None ADVENTMidTimedLoot 100
[0015.46] X2LootTableManager:            AdventGremlinM2 None 20
[0015.46] X2LootTableManager:   Sum Chances  120
[0015.46] X2LootTableManager:   Chances after recalculation:
[0015.47] X2LootTableManager:            None ADVENTMidTimedLoot 83
[0015.47] X2LootTableManager:            AdventGremlinM2 None 17
[0015.47] X2LootTableManager:   Sum Chances  100
```