### PR TITLE
Issue #328 Torso/Arms/Legs Localization

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -37,6 +37,11 @@ All notable changes to Vanilla 'War Of The Chosen' Behaviour will be documented 
 ### Improvements
 - Allow `UIStrategyMap` to display custom Faction HQ icons (#76)
 - Allow customization of auto-equipment removal behavior in 'UISquadSelect' (#134)
+- Customization localizations now picked up for Torso/Legs/Arms. If the TemplateName already
+  contains the parttype name (ie Torso/Legs/Arms), then the object name in the localization file
+  matches as for other parts (in particular this means Anarchy's Children localizations which already exist in the files
+  are picked up automatically). Otherwise, "_Torso"/"_Legs"/"_Arms" is appended to the template name
+  to create the unique object name.
 
 ### Fixes
 - Fix an issue in base game where strategy X2EventListenerTemplates only

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -41,7 +41,7 @@ All notable changes to Vanilla 'War Of The Chosen' Behaviour will be documented 
   contains the parttype name (ie Torso/Legs/Arms), then the object name in the localization file
   matches as for other parts (in particular this means Anarchy's Children localizations which already exist in the files
   are picked up automatically). Otherwise, "_Torso"/"_Legs"/"_Arms" is appended to the template name
-  to create the unique object name.
+  to create the unique object name. (#328)
 
 ### Fixes
 - Fix an issue in base game where strategy X2EventListenerTemplates only

--- a/X2WOTCCommunityHighlander/Src/XComGame/Classes/X2BodyPartTemplateManager.uc
+++ b/X2WOTCCommunityHighlander/Src/XComGame/Classes/X2BodyPartTemplateManager.uc
@@ -1,0 +1,142 @@
+//---------------------------------------------------------------------------------------
+//  *********   FIRAXIS SOURCE CODE   ******************
+//  FILE:    X2BodyPartTemplateManager.uc
+//  AUTHOR:  Timothy Talley  --  11/04/2013
+//---------------------------------------------------------------------------------------
+//  Copyright (c) 2013 Firaxis Games Inc. All rights reserved.
+//--------------------------------------------------------------------------------------- 
+
+class X2BodyPartTemplateManager extends X2DataTemplateManager
+    native(Core)
+	config(Content);
+
+var protected config array<X2PartInfo> BodyPartTemplateConfig;
+var protected config array<string> ValidPartTypes;
+var config bool DisableCharacterVoices; //Allow unilateral disabling of character voices from INI at Jake's request.
+var config bool DisablePostProcessWhenCustomizing;
+var private bool bPartTypeInitDone;
+
+var private native Map_Mirror   BodyPartTemplateCache{TMap<FName, TMap<FName, UX2BodyPartTemplate*> *>};
+
+
+
+
+native static function X2BodyPartTemplateManager GetBodyPartTemplateManager();
+
+native function InitPartTypes( array<string> PartTypes);
+native function bool AddUberTemplate(string BodyPartType, X2BodyPartTemplate Template, bool ReplaceDuplicate = false);
+native function X2BodyPartTemplate FindUberTemplate(string BodyPartType, name PartName);
+native function GetUberTemplates(string BodyPartType,  out array<X2BodyPartTemplate> Templates );
+native function GetFilteredUberTemplates(string BodyPartType,  Object CallbackObject, delegate<X2BodyPartFilter.FilterCallback> CallbackFn, out array<X2BodyPartTemplate> Templates );
+native function X2BodyPartTemplate GetRandomUberTemplate(string BodyPartType, Object CallbackObject, delegate<X2BodyPartFilter.FilterCallback> CallbackFn);
+native function array<name> GetPartPackNames();
+
+
+
+//Returns true if ArmorTemplates, gender, pristine, etc. all match up between the two templates
+native static function bool DoArmorPartsMatch(X2BodyPartTemplate TemplateA, X2BodyPartTemplate TemplateB);
+
+
+
+
+native function InitTemplates();
+
+protected event InitTemplatesInternal()
+{
+	local int i;
+	local X2PartInfo PartInfo;
+	local X2BodyPartTemplate Template;
+
+	InitPartTypes(ValidPartTypes);
+
+	//== General Parts
+	for (i = 0; i < BodyPartTemplateConfig.Length; ++i)
+	{
+		PartInfo = BodyPartTemplateConfig[i];
+
+		// HAX: Load 'Torso', 'Arms' and 'Legs' templates the old way to prevent template name collisions:
+		// TODO: @rmcfall - make all body part template names unique so they can be individually localized
+		switch(PartInfo.PartType)
+		{
+		case "Torso":
+		case "Arms":
+		case "Legs":
+			Template = new class'X2BodyPartTemplate';
+			break;
+		default:
+			// This is the "new", proper way of instantiating a template (requires unique TemplateName)
+			Template = new(None, string(PartInfo.TemplateName)) class'X2BodyPartTemplate';
+		}
+		
+		Template.PartType			= PartInfo.PartType;
+
+		Template.Gender				= PartInfo.Gender;
+		Template.Race				= PartInfo.Race;
+		Template.ArchetypeName		= PartInfo.ArchetypeName;
+
+		// Body template
+		Template.Type				= PartInfo.CivilianType;
+
+		// Hair template
+		Template.bCanUseOnCivilian	= PartInfo.bCanUseOnCivilian;
+		Template.bIsHelmet			= PartInfo.bIsHelmet;
+
+		// Armor
+		Template.bVeteran			= PartInfo.bVeteran;
+		Template.bAnyArmor			= PartInfo.bAnyArmor;
+		Template.ArmorTemplate		= PartInfo.ArmorTemplate;
+		Template.CharacterTemplate  = PartInfo.CharacterTemplate;
+		Template.SpecializedType	= PartInfo.SpecializedType;
+		Template.Tech				= PartInfo.Tech;
+		Template.ReqClass			= PartInfo.ReqClass;
+		Template.SetNames			= PartInfo.SetNames;
+
+		// Language
+		Template.Language			= PartInfo.Language;
+
+		// Which content pack this part belongs to, either DLC or Mod
+		Template.DLCName			= name(PartInfo.DLCName);
+
+		Template.bGhostPawn = PartInfo.bGhostPawn;
+
+		Template.SetTemplateName(PartInfo.TemplateName);
+		AddUberTemplate(Template.PartType, Template, true);
+
+		`log(`location @ "Adding BodyPartTemplate: " @ `ShowVar(Template.DataName) @ `ShowVar(Template) @ `ShowVar(Template.PartType),,'XCom_Templates');
+	}
+
+}
+
+function LoadAllContent()
+{
+	local array<X2BodyPartTemplate> TemplateList;
+	local XComContentManager ContentMgr;	
+	local int Index, TemplateListIndex;
+
+	ContentMgr = `CONTENT;
+	for(Index = 0; Index < ValidPartTypes.Length; ++Index)
+	{
+		GetUberTemplates(ValidPartTypes[Index], TemplateList);
+
+		//Skip voices, those will still be loaded on demand - as they are numerous and memory intensive
+		if(ValidPartTypes[Index] == "Voice")
+		{
+			continue;
+		}
+
+		for(TemplateListIndex = 0; TemplateListIndex < TemplateList.Length; ++TemplateListIndex)
+		{
+			ContentMgr.RequestGameArchetype(TemplateList[TemplateListIndex].ArchetypeName, none, none, true);
+		}
+	}
+}
+
+cpptext
+{
+	TMap<FName, UX2BodyPartTemplate*> *GetPartMap( const TCHAR *BodyPartType );
+
+}
+
+defaultproperties
+{
+}

--- a/X2WOTCCommunityHighlander/Src/XComGame/Classes/X2BodyPartTemplateManager.uc
+++ b/X2WOTCCommunityHighlander/Src/XComGame/Classes/X2BodyPartTemplateManager.uc
@@ -61,7 +61,8 @@ protected event InitTemplatesInternal()
 		case "Torso":
 		case "Arms":
 		case "Legs":
-			Template = new class'X2BodyPartTemplate';
+			// Single Line Change for issue '#328 Instad of giving up, decorate TemplateName to get unique Object Name
+			Template = new(None, string(PartInfo.TemplateName) $ "_" $ PartInfo.PartType) class'X2BodyPartTemplate';
 			break;
 		default:
 			// This is the "new", proper way of instantiating a template (requires unique TemplateName)

--- a/X2WOTCCommunityHighlander/Src/XComGame/Classes/X2BodyPartTemplateManager.uc
+++ b/X2WOTCCommunityHighlander/Src/XComGame/Classes/X2BodyPartTemplateManager.uc
@@ -61,9 +61,14 @@ protected event InitTemplatesInternal()
 		case "Torso":
 		case "Arms":
 		case "Legs":
-			// Single Line Change for issue '#328 Instad of giving up, decorate TemplateName to get unique Object Name
-			Template = new(None, string(PartInfo.TemplateName) $ "_" $ PartInfo.PartType) class'X2BodyPartTemplate';
-			break;
+			// Begin issue #328 - Check if the TemplateName indentifies the Part Type.
+			if(InStr(PartInfo.TemplateName, PartInfo.PartType,, true)==INDEX_NONE)
+			{
+				// Instead of giving up, decorate TemplateName to get unique Object Name
+				Template = new(None, string(PartInfo.TemplateName) $ "_" $ PartInfo.PartType) class'X2BodyPartTemplate';
+				break;
+			}
+			// End issue #328 - Fall through to default case if template name indenties the part type
 		default:
 			// This is the "new", proper way of instantiating a template (requires unique TemplateName)
 			Template = new(None, string(PartInfo.TemplateName)) class'X2BodyPartTemplate';

--- a/X2WOTCCommunityHighlander/Src/XComGame/Classes/XComCharacterCustomization.uc
+++ b/X2WOTCCommunityHighlander/Src/XComGame/Classes/XComCharacterCustomization.uc
@@ -1045,13 +1045,22 @@ function string GetCategoryDisplayName( string BodyPart, name PartToMatch, deleg
 	local int PartIndex;
 	local name DefaultTemplateName;
 	local array<X2BodyPartTemplate> BodyParts;
+	//Variable for Issue #329
+	local string DisplayName;
 
 	PartManager.GetFilteredUberTemplates(BodyPart, self, FilterFn, BodyParts);
 	for( PartIndex = 0; PartIndex < BodyParts.Length; ++PartIndex )
 	{
 		if( PartToMatch == BodyParts[PartIndex].DataName )
 		{
-			return BodyParts[PartIndex].DisplayName;
+			//Begin Issue #328
+			DisplayName = BodyParts[PartIndex].DisplayName;
+			if (DisplayName == "")
+			{
+				return string(GetCategoryValue(BodyPart, PartToMatch, BodyPartFilter.FilterByTorsoAndArmorMatch));
+			}
+			return DisplayName;
+			//End Issue #328
 		}
 	}
 
@@ -1088,17 +1097,13 @@ simulated function string GetCategoryDisplay(int catType)
 		Result = UpdatedUnitState.GetItemInSlot(eInvSlot_PrimaryWeapon, CheckGameState).Nickname;
 		break;
 	case eUICustomizeCat_Torso:  
-		Result = string(GetCategoryValue("Torso", UpdatedUnitState.kAppearance.nmTorso, BodyPartFilter.FilterByTorsoAndArmorMatch));
+		//Singeline Change for Issue #328        
+		Result = GetCategoryDisplayName("Torso", UpdatedUnitState.kAppearance.nmTorso, BodyPartFilter.FilterByTorsoAndArmorMatch);
 		break;
 	case eUICustomizeCat_Arms:              
-		if(UpdatedUnitState.kAppearance.nmArms == '')
-		{
-			Result = "";
-		}
-		else
-		{
-			Result = string(GetCategoryValue("Arms", UpdatedUnitState.kAppearance.nmArms, BodyPartFilter.FilterByTorsoAndArmorMatch));
-		}
+		//Begin Issue #328        
+		Result = GetCategoryDisplayName("Arms", UpdatedUnitState.kAppearance.nmArms, BodyPartFilter.FilterByTorsoAndArmorMatch);
+		//End Issue #328        
 		break;
 	case eUICustomizeCat_LeftArm:
 		Result = GetCategoryDisplayName("LeftArm", UpdatedUnitState.kAppearance.nmLeftArm, BodyPartFilter.FilterByTorsoAndArmorMatch);
@@ -1118,14 +1123,16 @@ simulated function string GetCategoryDisplay(int catType)
 	case eUICustomizeCat_RightForearm:
 		Result = GetCategoryDisplayName("RightForearm", UpdatedUnitState.kAppearance.nmRightForearm, BodyPartFilter.FilterByTorsoAndArmorMatch);
 		break;
-	case eUICustomizeCat_Legs:              
-		Result = string(GetCategoryValue("Legs", UpdatedUnitState.kAppearance.nmLegs, BodyPartFilter.FilterByTorsoAndArmorMatch));
+	case eUICustomizeCat_Legs:      
+		//Singeline Change for Issue #328
+		Result = GetCategoryDisplayName("Legs", UpdatedUnitState.kAppearance.nmLegs, BodyPartFilter.FilterByTorsoAndArmorMatch);
 		break;
 	case eUICustomizeCat_Thighs:
 		Result = GetCategoryDisplayName("Thighs", UpdatedUnitState.kAppearance.nmThighs, BodyPartFilter.FilterByTorsoAndArmorMatch);
 		break;
 	case eUICustomizeCat_Shins:
-		Result = string(GetCategoryValue("Shins", UpdatedUnitState.kAppearance.nmShins, BodyPartFilter.FilterByTorsoAndArmorMatch));
+		//Singeline Change for Issue #328
+		Result = GetCategoryDisplayName("Shins", UpdatedUnitState.kAppearance.nmShins, BodyPartFilter.FilterByTorsoAndArmorMatch);
 		break;
 	case eUICustomizeCat_TorsoDeco:
 		Result = GetCategoryDisplayName("TorsoDeco", UpdatedUnitState.kAppearance.nmTorsoDeco, BodyPartFilter.FilterByTorsoAndArmorMatch);

--- a/X2WOTCCommunityHighlander/X2WOTCCommunityHighlander.x2proj
+++ b/X2WOTCCommunityHighlander/X2WOTCCommunityHighlander.x2proj
@@ -245,6 +245,9 @@
     <Content Include="Src\XComGame\Classes\X2Ability_GrenadierAbilitySet.uc">
       <SubType>Content</SubType>
     </Content>
+    <Content Include="Src\XComGame\Classes\X2BodyPartTemplateManager.uc">
+      <SubType>Content</SubType>
+    </Content>
     <Content Include="Src\XComGame\Classes\X2Effect_ApplyWeaponDamage.uc">
       <SubType>Content</SubType>
     </Content>


### PR DESCRIPTION
#328 
Uses '_*PartType*' as the suffix for Torso/Arms/Legs object names. Also fixes Shins not having their display name shown in the overview of selected parts. Due to allowing for Torso/Arms/Legs not necessarily having a DisplayName set, showing the Index number in the overview is used as a fallback (which is what Vanilla shows for these parts). As a consequence of the implementation, this fall back is used for all parts, not just these 3 (and Shins). Essentially, the Vanilla code assumed that all other part types would have correctly set localized DisplayNames. This will only affect mod parts, which before would have shown nothing at all in the overview if selected.