### PR TITLE
Better AnimateIn

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -211,3 +211,5 @@ Particularly important for Central and Shen, whose custom Soldier Classes abilit
   an argument in the CreateCharacter function (#70)
 - Fixes game terminating SoundCue narrative moments after three seconds because
   it assumes they didn't play at all. (#66)
+- Fixes UIPanels animating in with a huge delay when they are direct child panels of
+  UIScreen (#341)

--- a/X2WOTCCommunityHighlander/Src/XComGame/Classes/UIPanel.uc
+++ b/X2WOTCCommunityHighlander/Src/XComGame/Classes/UIPanel.uc
@@ -777,7 +777,7 @@ simulated function RemoveTweens()
 simulated function AnimateIn(optional float Delay = -1.0)
 {
 	if( Delay == -1.0 && ParentPanel != none)
-		Delay = ParentPanel.GetChildIndex(self) * class'UIUtilities'.const.INTRO_ANIMATION_DELAY_PER_INDEX; 
+		Delay = ParentPanel.GetDirectChildIndex(self) * class'UIUtilities'.const.INTRO_ANIMATION_DELAY_PER_INDEX; // Issue #341
 
 	AddTweenBetween("_alpha", 0, Alpha, class'UIUtilities'.const.INTRO_ANIMATION_TIME, Delay);
 }
@@ -785,7 +785,7 @@ simulated function AnimateIn(optional float Delay = -1.0)
 simulated function AnimateOut(optional float Delay = -1.0)
 {
 	if( Delay == -1.0 && ParentPanel != none )
-		Delay = ParentPanel.GetChildIndex(self) * class'UIUtilities'.const.INTRO_ANIMATION_DELAY_PER_INDEX; 
+		Delay = ParentPanel.GetDirectChildIndex(self) * class'UIUtilities'.const.INTRO_ANIMATION_DELAY_PER_INDEX; // Issue #341
 
 	AddTweenBetween("_alpha", Alpha, 0, class'UIUtilities'.const.INTRO_ANIMATION_TIME, Delay);
 }
@@ -921,6 +921,31 @@ simulated function int GetChildIndex(UIPanel Child, optional bool ErrorIfNotFoun
 	}
 	return -1;
 }
+
+// Start Issue #341: Function to be used when actually getting the "direct" child index.
+// UIScreens get all their recursive child panels added, so GetChildIndex is unusable for AnimateIn
+simulated function int GetDirectChildIndex(UIPanel Child, optional bool ErrorIfNotFound = true)
+{
+	local int i, index;
+
+	for(i = 0; i < ChildPanels.Length; ++i)
+	{
+		if( ChildPanels[i] == Child )
+			return index; 
+
+		if (ChildPanels[i].ParentPanel == self)
+			index++;
+	}
+
+	// Don't print errors when recursing through children.
+	if( ErrorIfNotFound )
+	{
+		ScriptTrace();
+		`warn("UI ERROR: could not find Index of the child control '" $ Child.MCName $ "' in '" $ self.MCName $ "'.");
+	}
+	return -1;
+}
+// End Issue #341
 
 // TODO: Nativize
 simulated function GetChildrenOfType(class ClassType, out array<UIPanel> ChildrenOfType)
@@ -1078,7 +1103,6 @@ simulated function PrintPanelNavigationInfo(optional bool bCascade = false, opti
 	{
 		Navigator.PrintDebug(false, Indentation);
 	}
-
 	if( bCascade )
 	{
 		for( i = 0; i < ChildPanels.length; i++ )


### PR DESCRIPTION
Closes #341. I decided to write an extra function. This doesn't fix the occasional panel that calls GetChildIndex itself, but those panels usually aren't direct children of UIScreen and this way, the fix ends up being way less risky.