### PR TITLE
BugFix#307

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -196,11 +196,13 @@ All notable changes to Vanilla 'War Of The Chosen' Behaviour will be documented 
   any damage upgrades in the UI. (#237)
 - Allow Human Pawns to freely switch between custom heads and base pawn heads,
   eliminating the need for head mods to include invisible heads (#219)
-- Changes to "Legacy Operations" squad loadout and ability selections are now always applied for the first mission. Note any abilities added need to exist in the Soldier Classes ability tree (#307)
+- Changes to "Legacy Operations" squad loadout and ability selections are now always applied for the first mission. Note any non-AWC-eligble abilities added need to exist in the Soldier Classes ability tree (#307)
 - For "Legacy Operations" changes to squad members' Soldier Class, and changes to the Soldier Classes themselves, are taken into account for pre-existing operations.
-Particularly important for Central and Shen, whose custom Soldier Classes ability tree contain only the abilities granted by their squad progression (#307)
+  Particularly important for Central and Shen, whose custom Soldier Classes ability tree contain only the abilities granted by their squad progression (#307)
 - Better Photobooth support for custom Soldier Classes and Spark-like units,
   no broken duo poses for units that can't play them (#309)
+- Tweaks to "Resistance Archives" random Legacy Operations UI. Restarts show the correct locked difficulty, and a crash condition on backing out of a restart fixed. (#307)
+
 
 ### Fixes
 - Fix Chosen Assassin receiving weaknesses that are exclusive to the

--- a/X2WOTCCommunityHighlander/Src/XComGame/Classes/UITLE_LadderModeMenu.uc
+++ b/X2WOTCCommunityHighlander/Src/XComGame/Classes/UITLE_LadderModeMenu.uc
@@ -385,6 +385,12 @@ simulated function OnDifficultySelectionCallback(name eAction, int selectedDiffi
 
 	if (eAction != 'eUIAction_Accept')
 	{
+		// Start Issue #307
+		if (ClickedList == List)
+		{
+			clickedIndex -= NarrativeList.GetItemCount() - 1;
+		}
+		// End Issue #307
 		return;
 	}
 
@@ -417,19 +423,17 @@ simulated function StartLadder(int LadderIndex, int DifficultySelection, bool Na
 	// Start Issue #307
 	// Mr. Nice since we are bypassing XComCheatManager::StartLadder(), have to do house keeping on
 	// StartTime, GameIndex, and Difficulty ourselves.
-	History.ReadHistoryFromFile("Ladders/", "Ladder_" $ LadderIndex);
+	History.ReadHistoryFromFile("Ladders/", "Mission_" $ LadderIndex $ "_1_" $ DifficultySelection);
 	CurrentCampaign = XComGameState_CampaignSettings(History.GetSingleGameStateObjectForClass(class'XComGameState_CampaignSettings'));
 	CurrentCampaign.SetStartTime( class'XComCheatManager'.static.GetCampaignStartTime( ) );
 	CurrentCampaign.SetGameIndexFromProfile( );
 
-	if (LadderIndex >= 10) // replaying a procedural ladder, difficulty is locked to what was generated
-	{
-		DifficultySelection = CurrentCampaign.DifficultySetting;
-	}
-	else
-	{
-		CurrentCampaign.SetDifficulty(DifficultySelection);
-	}
+	// Mr. Nice: DifficultySelection is now correctly carried through even if difficulty is locked
+	//if (LadderIndex >= 10) // replaying a procedural ladder, difficulty is locked to what was generated
+	//{
+		//DifficultySelection = CurrentCampaign.DifficultySetting;
+	//}
+	
 	// starting an existing ladder from scratch
 	//XComCheatManager(GetALocalPlayerController().CheatManager).StartLadder(LadderIndex, DifficultySelection);
 	
@@ -746,7 +750,8 @@ simulated function InitializeLadderList()
 		LadderData = XComGameState_LadderProgress(History.GetSingleGameStateObjectForClass(class'XComGameState_LadderProgress', true));
 		LadderIndex = int( m_LadderList[ i ] );
 
-		CampaignSettings = XComGameState_CampaignSettings(History.GetSingleGameStateObjectForClass(class'XComGameState_LadderProgress', false));
+		// Single Line Change for Issue #307, so so dumb, Firaxis...
+		CampaignSettings = XComGameState_CampaignSettings(History.GetSingleGameStateObjectForClass(class'XComGameState_CampaignSettings', false));
 		m_LadderDifficulties[i] = CampaignSettings.DifficultySetting;
 		
 		if (LadderIndex < 10)

--- a/X2WOTCCommunityHighlander/Src/XComGame/Classes/XComGameState_LadderProgress.uc
+++ b/X2WOTCCommunityHighlander/Src/XComGame/Classes/XComGameState_LadderProgress.uc
@@ -1047,7 +1047,9 @@ private static function UpdateUnitState( XComGameState StartState, XComGameState
 		ClassTemplate = UnitState.GetSoldierClassTemplate();
 		Progression.iRank = 0;
 		Progression.iBranch = UnitState.GetRankAbilities(0).Length;
-		// Issue #307 check classes random ability decks, if any
+		// #307 The SoldierProgression array contains references to entries in the units AbilityTree, not ability names directly.
+		// In order to create the missing AbilityTree entry, the abilityname isn't enough, due to possible weapon slot linking etc.
+		// First check the classes random ability decks, if any
 		for (j = 0; j < ClassTemplate.RandomAbilityDecks.Length; ++j)
 		{
 			AbilityTree = ClassTemplate.RandomAbilityDecks[j].Abilities;
@@ -1056,6 +1058,8 @@ private static function UpdateUnitState( XComGameState StartState, XComGameState
 				Index = AbilityTree.Find ('AbilityName', AbilitiestoFind[i]);
 				if (Index != INDEX_NONE)
 				{
+					// #307 The ability has to exist in the Units ability tree, where doesn't matter,
+					// So just add it to the end of the first Rank.
 					UnitState.AbilityTree[0].Abilities.AddItem(AbilityTree[Index]);
 					SoldierProgression.AddItem( Progression );
 					Progression.iBranch++;
@@ -1065,13 +1069,15 @@ private static function UpdateUnitState( XComGameState StartState, XComGameState
 		}
 		if (AbilitiestoFind.Length!=0)
 		{
-			//check AWC Abilities;
+			// #307 If we still can't find some abilities, check AWC Abilities.
 			AbilityTree = class'X2SoldierClassTemplateManager'.static.GetSoldierClassTemplateManager().GetCrossClassAbilities_CH(UnitState.AbilityTree);
 			for (i = 0; i < AbilitiestoFind.Length; i++)
 			{
 				Index = AbilityTree.Find ('AbilityName', AbilitiestoFind[i]);
 				if (Index != INDEX_NONE)
 				{
+					// #307 The ability has to exist in the Units ability tree, where doesn't matter,
+					// So just add it to the end of the first Rank.
 					UnitState.AbilityTree[0].Abilities.AddItem(AbilityTree[Index]);
 					SoldierProgression.AddItem( Progression );
 					Progression.iBranch++;
@@ -1079,7 +1085,7 @@ private static function UpdateUnitState( XComGameState StartState, XComGameState
 			}
 		}
 	}
-	// Endi Issue #307
+	// End Issue #307
 	UnitState.SetSoldierProgression( SoldierProgression );
 
 	UnitState.AppearanceStore.Length = 0;


### PR DESCRIPTION
Fixes issue with starting with the last mission, not the first, when restarting an Op which was last completed, not abandoned. Also fixed that the greyed out difficulty selection for random Ops did not reflect the locked difficulty. For technical reasons, this fix was required for the first fix. Lastly, a crash condition from Vanilla when backing out from a random op restart, then immediately re-entering and confirming. This was caused by not resetting an index correctly on backing out. #307 #308 

Closes #307 -- @robojumper 