### PR TITLE
#371 Break Through Damage UI Fix

### DIFF
--- a/X2WOTCCommunityHighlander/Src/XComGame/Classes/XComGameState_Item.uc
+++ b/X2WOTCCommunityHighlander/Src/XComGame/Classes/XComGameState_Item.uc
@@ -1615,12 +1615,15 @@ simulated function EUISummary_WeaponStats GetUpgradeModifiersForUI(X2WeaponUpgra
 					if (BonusDamage != none)
 					{
 						TotalUpgradeSummary.bIsDamageModified = true;
-						TotalUpgradeSummary.Damage += BonusDamage.BonusDmg;
+						// Single Line for #371
+						TotalUpgradeSummary.DamageValue.Damage += BonusDamage.BonusDmg;
 					}
 				}
 			}
 		}
 	}
+	// Single Line for #371 : Just for consistency!
+	TotalUpgradeSummary.Damage = TotalUpgradeSummary.DamageValue.Damage;
 
 	return TotalUpgradeSummary;
 }


### PR DESCRIPTION
An Intellisense reference search says that `EUISummary_WeaponStats.Damage` isn't referenced anywhere else in the CHL or SDK, so shouldn't be any lingering Issues. I did `TotalUpgradeSummary.Damage = TotalUpgradeSummary.DamageValue.Damage;` at the end of the method, for consistency and so that any CHL unaware or agnostic mods will see the value they expect there.
(Closes #371 -- @robojumper)