### PR TITLE
Add support for adding earned soldier abilities

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,8 @@ All notable changes to Vanilla 'War Of The Chosen' Behaviour will be documented 
   List (#112)
 - `CanWeaponApplyUpgrade` allows mods to restrict what upgrades can be applied
   to a specific weapon (#260)
+- `ModifyEarnedSoldierAbilities` allows mods to add their own abilities to soldiers,
+  such as officer abilites (#409)
 
 ### Event Hooks
 - Triggers the event `OnArmoryMainMenuUpdate` that allows adding elements into

--- a/X2WOTCCommunityHighlander/Src/XComGame/Classes/X2DownloadableContentInfo.uc
+++ b/X2WOTCCommunityHighlander/Src/XComGame/Classes/X2DownloadableContentInfo.uc
@@ -499,3 +499,12 @@ static function DLCAppendWeaponSockets(out array<SkeletalMeshSocket> NewSockets,
 	return;
 }
 /// End Issue #281
+
+/// Start Issue #409
+/// <summary>
+/// Called from XComGameState_Unit:GetEarnedSoldierAbilities
+/// Allows DLC/Mods to add to and modify a unit's EarnedSoldierAbilities
+/// Has no return value, just modify the EarnedAbilities out variable array
+static function ModifyEarnedSoldierAbilities(out array<SoldierClassAbilityType> EarnedAbilities, XComGameState_Unit UnitState)
+{}
+/// End Issue #409

--- a/X2WOTCCommunityHighlander/Src/XComGame/Classes/XComGameState_Unit.uc
+++ b/X2WOTCCommunityHighlander/Src/XComGame/Classes/XComGameState_Unit.uc
@@ -3643,6 +3643,11 @@ function array<SoldierClassAbilityType> GetEarnedSoldierAbilities()
 	local SoldierClassAbilityType Ability;
 	local int i;
 
+	// Variables for issue #409
+	local array<X2DownloadableContentInfo> DLCInfos;
+	local X2DownloadableContentInfo DLCInfo;
+	// End issue #409
+
 	ClassTemplate = GetSoldierClassTemplate();
 	if (ClassTemplate != none)
 	{
@@ -3665,6 +3670,18 @@ function array<SoldierClassAbilityType> GetEarnedSoldierAbilities()
 			EarnedAbilities.AddItem(AWCAbilities[i].AbilityType);
 		}
 	}
+
+	// Start Issue #409
+	// Allow mods to add to or otherwise modify this unit's earned abilities.
+	// For example, the Officer Pack can use this to attach learned officer
+	// abilities to the unit and those abilities will automatically be reflected
+	// in various UI elements.
+	DLCInfos = `ONLINEEVENTMGR.GetDLCInfos(false);
+	foreach DLCInfos(DLCInfo)
+	{
+		DLCInfo.ModifyEarnedSoldierAbilities(EarnedAbilities, self);
+	}
+	// End Issue #409
 
 	return EarnedAbilities;
 }


### PR DESCRIPTION
This change introduces a new DLC hook, `ModifyEarnedSoldierAbilities`,
that allows mods to add to or modify a soldier's abilities. For example,
you could add officer or psi abilities to existing soldier classes.