### PR TITLE
Allow mods to override displayed ranks (#408)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -162,6 +162,9 @@ All notable changes to Vanilla 'War Of The Chosen' Behaviour will be documented 
 - `OverrideItemMinEquipped` added to allow mods to override the min number of equipped items in a slot (#171)
 - `AddConversation` added to allow mods to change narrative behavior before they are played (#204)
 - `OverrideRandomizeAppearance` added to allow mods to block updating appearance when switching armors (#299)
+- `XComGameState_Unit` triggers `SoldierRankName`, `SoldierShortRankName` and
+  `SoldierRankIcon` events that allow listeners to override the those particular
+  properties of a soldier's rank, i.e. rank name, short name and icon.
 
 ### Configuration
 - Able to list classes as excluded from AWC Skill Rolling, so they can still

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -164,7 +164,7 @@ All notable changes to Vanilla 'War Of The Chosen' Behaviour will be documented 
 - `OverrideRandomizeAppearance` added to allow mods to block updating appearance when switching armors (#299)
 - `XComGameState_Unit` triggers `SoldierRankName`, `SoldierShortRankName` and
   `SoldierRankIcon` events that allow listeners to override the those particular
-  properties of a soldier's rank, i.e. rank name, short name and icon.
+  properties of a soldier's rank, i.e. rank name, short name and icon (#408)
 
 ### Configuration
 - Able to list classes as excluded from AWC Skill Rolling, so they can still

--- a/X2WOTCCommunityHighlander/Src/XComGame/Classes/UIAfterAction_ListItem.uc
+++ b/X2WOTCCommunityHighlander/Src/XComGame/Classes/UIAfterAction_ListItem.uc
@@ -133,15 +133,15 @@ simulated function UpdateData(optional StateObjectReference UnitRef)
 	else
 		ClassStr = "";
 
-	// Start Issue #106
-	AS_SetData( class'UIUtilities_Text'.static.GetColoredText(Caps(class'X2ExperienceConfig'.static.GetRankName(Unit.GetRank(), Unit.GetSoldierClassTemplateName())), eUIState_Faded, 18),
+	// Start Issue #106, #408
+	AS_SetData( class'UIUtilities_Text'.static.GetColoredText(Caps(Unit.GetSoldierRankName()), eUIState_Faded, 18),
 				class'UIUtilities_Text'.static.GetColoredText(Caps(Unit.GetName(eNameType_Last)), eUIState_Normal, 22),
 				class'UIUtilities_Text'.static.GetColoredText(Caps(Unit.GetName(eNameType_Nick)), eUIState_Header, 28),
-				Unit.GetSoldierClassIcon(), class'UIUtilities_Image'.static.GetRankIcon(Unit.GetRank(), Unit.GetSoldierClassTemplateName()),
+				Unit.GetSoldierClassIcon(), Unit.GetSoldierRankIcon(),
 				(bCanPromote) ? class'UISquadSelect_ListItem'.default.m_strPromote : "",
 				statusLabel, statusText, daysLabel, daysText, m_strMissionsLabel, string(Unit.GetNumMissions()),
 				m_strKillsLabel, string(Unit.GetNumKills()), false, ClassStr);
-	// End Issue #106
+	// End Issue #106, #408
 
 	AS_SetUnitHealth(class'UIUtilities_Strategy'.static.GetUnitCurrentHealth(Unit, true), class'UIUtilities_Strategy'.static.GetUnitMaxHealth(Unit));
 

--- a/X2WOTCCommunityHighlander/Src/XComGame/Classes/UIAlert.uc
+++ b/X2WOTCCommunityHighlander/Src/XComGame/Classes/UIAlert.uc
@@ -2873,7 +2873,7 @@ simulated function BuildTrainingCompleteAlert(string TitleLabel)
 	ClassName = Caps(UnitState.GetSoldierClassDisplayName());
 	ClassIcon = UnitState.GetSoldierClassIcon();
 	// End Issue #106
-	RankName = Caps(class'X2ExperienceConfig'.static.GetRankName(UnitState.GetRank(), ClassTemplate.DataName));
+	RankName = Caps(UnitState.GetSoldierRankName()); // Issue #408
 	
 	FactionState = UnitState.GetResistanceFaction();
 
@@ -2973,7 +2973,7 @@ simulated function BuildPsiTrainingCompleteAlert(string TitleLabel)
 	ClassName = Caps(UnitState.GetSoldierClassDisplayName());
 	ClassIcon = UnitState.GetSoldierClassIcon();
 	// End Issue #106
-	RankName = Caps(class'X2ExperienceConfig'.static.GetRankName(UnitState.GetRank(), ClassTemplate.DataName));
+	RankName = Caps(UnitState.GetSoldierRankName()); // Issue #408
 
 	kTag = XGParamTag(`XEXPANDCONTEXT.FindTag("XGParam"));
 	kTag.StrValue0 = "";
@@ -3029,7 +3029,7 @@ simulated function BuildSoldierPromotedAlert()
 	ClassName = Caps(UnitState.GetSoldierClassDisplayName());
 	ClassIcon = UnitState.GetSoldierClassIcon();
 	// End Issue #106
-	RankName = Caps(class'X2ExperienceConfig'.static.GetRankName(UnitState.GetRank(), ClassTemplate.DataName));
+	RankName = Caps(UnitState.GetSoldierRankName()); // Issue #408
 
 	kTag = XGParamTag(`XEXPANDCONTEXT.FindTag("XGParam"));
 	kTag.StrValue0 = UnitState.GetFullName();
@@ -4072,7 +4072,7 @@ simulated function BuildNegativeTraitAcquiredAlert()
 	// Start Issue #106
 	ClassIcon = UnitState.GetSoldierClassIcon();
 	// End Issue #106
-	RankName = Caps(class'X2ExperienceConfig'.static.GetRankName(UnitState.GetRank(), ClassTemplate.DataName));
+	RankName = Caps(UnitState.GetSoldierRankName()); // Issue #408
 
 	TraitDesc = NegativeTrait.TraitDescription;
 	if (NegativeTrait.TraitQuotes.Length > 0)
@@ -5285,7 +5285,7 @@ simulated function BuildConfirmCovertActionAlert()
 			StaffUnit = SlotState.GetAssignedStaff(); 
 			if (StaffUnit.IsSoldier())
 			{
-				RankImage = class'UIUtilities_Image'.static.GetRankIcon(StaffUnit.GetRank(), StaffUnit.GetSoldierClassTemplateName());
+				RankImage = StaffUnit.GetSoldierRankIcon(); // Issue #408
 				// Start Issue #106
 				ClassImage = StaffUnit.GetSoldierClassIcon();
 				// End Issue #106

--- a/X2WOTCCommunityHighlander/Src/XComGame/Classes/UIArmory_ImplantSlot.uc
+++ b/X2WOTCCommunityHighlander/Src/XComGame/Classes/UIArmory_ImplantSlot.uc
@@ -1,0 +1,119 @@
+//---------------------------------------------------------------------------------------
+//  *********   FIRAXIS SOURCE CODE   ******************
+//  FILE:    UIArmory_ImplantSlot.uc
+//  AUTHOR:  Samuel Batista
+//  PURPOSE: List item slot for Soldier Implants.
+//---------------------------------------------------------------------------------------
+//  Copyright (c) 2016 Firaxis Games, Inc. All rights reserved.
+//--------------------------------------------------------------------------------------- 
+
+class UIArmory_ImplantSlot extends UIPanel;
+
+var int SlotIndex;
+var bool bIsLocked;
+
+var XComGameState_Item ImplantItem;
+
+var UIButton Button;
+var UIScrollingText Label;
+var UIScrollingText Description;
+var UIImage Icon;
+
+var localized string m_strAvailableLabel;
+var localized string m_strAvailableDescription;
+
+var localized string m_strLockedLabel;
+var localized string m_strLockedDescription;
+
+simulated function UIArmory_ImplantSlot InitImplantSlot(int InitIndex)
+{
+	SlotIndex = InitIndex;
+
+	InitPanel();
+
+	Width = UIArmory_Implants(Screen).List.Width;
+
+	Button = Spawn(class'UIButton', self).InitButton();
+	Button.SetSize(Width, Height);
+	Button.OnMouseEventDelegate = OnChildMouseEvent;
+	
+	Label = Spawn(class'UIScrollingText', self).InitScrollingText(,, Width - 110, 100, 15, true);
+	Description = Spawn(class'UIScrollingText', self).InitScrollingText(,, Width - 110, 100, 50, false);
+
+	Icon = Spawn(class'UIImage', self).InitImage();
+	Icon.SetPosition(18, 15);
+
+	return self;
+}
+
+simulated function SetAvailable(optional XComGameState_Item Item, optional eUIState TextState = eUIState_Normal)
+{
+	local X2ItemTemplate ItemTemplate;
+
+	ImplantItem = Item;
+
+	if(ImplantItem != none)
+	{
+		ItemTemplate = ImplantItem.GetMyTemplate();
+		Label.SetTitle(class'UIUtilities_Text'.static.GetColoredText(ItemTemplate.GetItemFriendlyName(ImplantItem.ObjectID), TextState));
+		Icon.LoadImage(class'UIUtilities_Image'.static.GetPCSImage(Item));
+		Description.SetText();
+	}
+	else
+	{
+		Label.SetTitle(class'UIUtilities_Text'.static.GetColoredText(m_strAvailableLabel, TextState));
+		Description.SetText(class'UIUtilities_Text'.static.GetColoredText(m_strAvailableDescription, TextState));
+		Icon.LoadImage(class'UIUtilities_Image'.const.PersonalCombatSim_Empty);
+	}
+
+	Button.EnableButton();
+	bIsLocked = false;
+}
+
+simulated function SetLocked(XComGameState_Unit Unit)
+{
+	local XGParamTag LocTag;
+	local array<int> UnlockRanks;
+
+	UnlockRanks = Unit.GetPCSRanks();
+
+	LocTag = XGParamTag(`XEXPANDCONTEXT.FindTag("XGParam"));
+	// Start Issue #408
+	LocTag.StrValue0 = Unit.GetSoldierRankName(UnlockRanks[SlotIndex]);
+	// End Issue #408
+
+	Label.SetTitle(class'UIUtilities_Text'.static.GetColoredText(m_strLockedLabel, eUIState_Disabled));
+	Description.SetText(class'UIUtilities_Text'.static.GetColoredText(`XEXPAND.ExpandString(m_strLockedDescription), eUIState_Disabled));
+	Icon.LoadImage(class'UIUtilities_Image'.const.PersonalCombatSim_Locked);
+	Button.DisableButton();
+
+	ImplantItem = none;
+	bIsLocked = true;
+}
+
+simulated function OnChildMouseEvent(UIPanel Control, int Cmd)
+{
+	switch(Cmd)
+	{
+		case class'UIUtilities_Input'.const.FXS_L_MOUSE_UP:
+			if(!bIsLocked)
+				`HQPRES.UIInventory_Implants();
+			else
+				`HQPRES.PlayUISound(eSUISound_MenuClickNegative);
+		break;
+		case class'UIUtilities_Input'.const.FXS_L_MOUSE_IN:
+			if(!bIsLocked)
+				SetAvailable(ImplantItem, -1);
+		break;
+		case class'UIUtilities_Input'.const.FXS_L_MOUSE_OUT:
+			if(!bIsLocked)
+				SetAvailable(ImplantItem);
+		break;
+	}
+}
+
+defaultproperties
+{
+	// Width is derived from the list this item is contained in
+	Height = 95;
+}

--- a/X2WOTCCommunityHighlander/Src/XComGame/Classes/UIArmory_Promotion.uc
+++ b/X2WOTCCommunityHighlander/Src/XComGame/Classes/UIArmory_Promotion.uc
@@ -379,7 +379,9 @@ simulated function PopulateData()
 	}
 
 	ClassRowItem.ClassName = ClassTemplate.DataName;
-	ClassRowItem.SetRankData(class'UIUtilities_Image'.static.GetRankIcon(1, ClassTemplate.DataName), Caps(class'X2ExperienceConfig'.static.GetRankName(1, ClassTemplate.DataName)));
+	// Start Issue #408
+	ClassRowItem.SetRankData(Unit.GetSoldierRankIcon(1), Caps(Unit.GetSoldierRankName(1)));
+	// End Issue #408
 
 	AbilityTree = Unit.GetRankAbilities(ClassRowItem.Rank);
 	AbilityTemplate2 = AbilityTemplateManager.FindAbilityTemplate(AbilityTree[0].AbilityName);
@@ -411,7 +413,9 @@ simulated function PopulateData()
 
 		Item.Rank = i - 1;
 		Item.ClassName = ClassTemplate.DataName;
-		Item.SetRankData(class'UIUtilities_Image'.static.GetRankIcon(i, ClassTemplate.DataName), Caps(class'X2ExperienceConfig'.static.GetRankName(i, ClassTemplate.DataName)));
+		// Start Issue #408
+		Item.SetRankData(Unit.GetSoldierRankIcon(i), Caps(Unit.GetSoldierRankName(i)));
+		// End Issue #408
 
 		AbilityTree = Unit.GetRankAbilities(Item.Rank);
 

--- a/X2WOTCCommunityHighlander/Src/XComGame/Classes/UIArmory_PromotionHero.uc
+++ b/X2WOTCCommunityHighlander/Src/XComGame/Classes/UIArmory_PromotionHero.uc
@@ -137,7 +137,7 @@ simulated function PopulateData()
 
 	FactionState = Unit.GetResistanceFaction();
 	
-	rankIcon = class'UIUtilities_Image'.static.GetRankIcon(Unit.GetRank(), ClassTemplate.DataName);
+	rankIcon = Unit.GetSoldierRankIcon();// Issue #408
 	// Start Issue #106
 	classIcon = Unit.GetSoldierClassIcon();
 	// End Issue #106
@@ -199,7 +199,9 @@ simulated function PopulateData()
 		bHasColumnAbility = UpdateAbilityIcons(Column);
 		bHighlightColumn = (!bHasColumnAbility && (iRank+1) == Unit.GetRank());
 
-		Column.AS_SetData(bHighlightColumn, m_strNewRank, class'UIUtilities_Image'.static.GetRankIcon(iRank+1, ClassTemplate.DataName), Caps(class'X2ExperienceConfig'.static.GetRankName(iRank+1, ClassTemplate.DataName)));
+		// Start Issue #408
+		Column.AS_SetData(bHighlightColumn, m_strNewRank, Unit.GetSoldierRankIcon(iRank+1), Caps(Unit.GetSoldierRankName(iRank+1)));
+		// End Issue #408
 	}
 
 	HidePreview();

--- a/X2WOTCCommunityHighlander/Src/XComGame/Classes/UIArmory_PromotionPsiOp.uc
+++ b/X2WOTCCommunityHighlander/Src/XComGame/Classes/UIArmory_PromotionPsiOp.uc
@@ -72,7 +72,9 @@ simulated function PopulateData()
 	}
 
 	ClassRowItem.ClassName = ClassTemplate.DataName;
-	ClassRowItem.SetRankData(class'UIUtilities_Image'.static.GetRankIcon(1, ClassTemplate.DataName), Caps(class'X2ExperienceConfig'.static.GetRankName(1, ClassTemplate.DataName)));
+	// Start Issue #408
+	ClassRowItem.SetRankData(Unit.GetSoldierRankIcon(1), Caps(Unit.GetSoldierRankName(1)));
+	// End Issue #408
 		
 	AbilityTemplate2 = AbilityTemplateManager.FindAbilityTemplate(AbilityTree[0].AbilityName);
 	if (AbilityTemplate2 != none)
@@ -102,7 +104,9 @@ simulated function PopulateData()
 
 		Item.Rank = i - 1;
 		Item.ClassName = ClassTemplate.DataName;
-		Item.SetRankData(class'UIUtilities_Image'.static.GetRankIcon(i, ClassTemplate.DataName), Caps(class'X2ExperienceConfig'.static.GetRankName(i, ClassTemplate.DataName)));
+		// Start Issue #408
+		Item.SetRankData(Unit.GetSoldierRankIcon(i), Caps(Unit.GetSoldierRankName(i)));
+		// End Issue #408
 
 		AbilityTree = Unit.GetRankAbilities(Item.Rank);
 		AbilityTemplate1 = AbilityTemplateManager.FindAbilityTemplate(AbilityTree[0].AbilityName);

--- a/X2WOTCCommunityHighlander/Src/XComGame/Classes/UIChosenMissionSummary.uc
+++ b/X2WOTCCommunityHighlander/Src/XComGame/Classes/UIChosenMissionSummary.uc
@@ -1,0 +1,268 @@
+//---------------------------------------------------------------------------------------
+//  FILE:    UIChosenMissionSummary.uc
+//  AUTHOR:  Mark Nauta  --  11/08/2016
+//  PURPOSE: Summarizes encounter with the Chosen on the current mission
+//           
+//---------------------------------------------------------------------------------------
+//  Copyright (c) 2016 Firaxis Games, Inc. All rights reserved.
+//---------------------------------------------------------------------------------------
+class UIChosenMissionSummary extends UIScreen;
+
+var XComGameState_Unit UnitState;
+var XComGameState_Unit AffectedUnit;
+var XComGameState_AdventChosen ChosenState;
+
+var UINavigationHelp NavHelp;
+
+var localized string ChosenDefeatedLabel;
+var localized string ChosenEncounterTitle;
+var localized string ChosenEncounterSubtitle;
+var localized string ChosenActionsLabel;
+var localized string CasualtiesLabel;
+var localized string StrengthsLabel;
+var localized string WeaknessesLabel;
+var localized string ChosenKnowledgeLabel;
+var localized string ChosenKnowledgeText;
+var localized string SoldierCapturedLabel;
+var localized string RewardLabel;
+var localized string RewardType;
+
+//---------------------------------------------------------------------------------------
+simulated function InitScreen(XComPlayerController InitController, UIMovie InitMovie, optional name InitName)
+{
+	// Using base sound manager and PlaySoundEvent instead of Tactical sound manager and PlayPersistentSoundEvent
+	// so that this plays on the same game object that super.InitScreen uses.
+	`SOUNDMGR.PlaySoundEvent("PreventNextMenuOpen");
+
+	super.InitScreen(InitController, InitMovie, InitName);
+
+	NavHelp = Spawn(class'UINavigationHelp', self).InitNavHelp();
+	NavHelp.AddContinueButton(CloseScreen);
+}
+
+//---------------------------------------------------------------------------------------
+simulated function OnInit()
+{
+	local XComGameStateHistory History;
+	local XComGameState NewGameState;
+	local XComGameState_HeadquartersAlien AlienHQ;
+	local XComGameState_Effect KidnapEffect, ExtractEffect;
+
+	super.OnInit();
+
+	// Grab Alien HQ
+	History = `XCOMHISTORY;
+	AlienHQ = XComGameState_HeadquartersAlien(History.GetSingleGameStateObjectForClass(class'XComGameState_HeadquartersAlien'));
+
+	// Set Chosen UnitState
+	UnitState = AlienHQ.GetChosenOnMission();
+
+	// Set Chosen State
+	ChosenState = AlienHQ.GetChosenOfTemplate(UnitState.GetMyTemplateGroupName());
+
+	// Play Chosen fanfare
+	`XTACTICALSOUNDMGR.PlayPersistentSoundEvent(ChosenState.GetMyTemplate().FanfareEvent);
+
+	// Set Data
+	SetChosenData();
+
+	SetChosenIcon( ChosenState.GetChosenIcon() );
+
+	KidnapEffect = UnitState.GetUnitApplyingEffectState('ChosenKidnapTarget');
+	ExtractEffect = UnitState.GetUnitApplyingEffectState('ChosenExtractKnowledgeTarget');
+	
+	NewGameState = class'XComGameStateContext_ChangeContainer'.static.CreateChangeState("Trigger Event: Chosen Tactical Summary");
+	if( UnitState.IsDead() )
+	{
+		`XEVENTMGR.TriggerEvent('ChosenSummaryDefeated', , , NewGameState);
+		SetChosenImage(true);
+		OnChosenDefeat();
+	}
+	else if(KidnapEffect != none)
+	{
+		`XEVENTMGR.TriggerEvent('ChosenSummaryCapture', , , NewGameState);
+		SetChosenImage();
+		AffectedUnit = XComGameState_Unit(History.GetGameStateForObjectID(KidnapEffect.ApplyEffectParameters.TargetStateObjectRef.ObjectID));
+		OnChosenCapture();
+	}
+	else if(ExtractEffect != none)
+	{
+		`XEVENTMGR.TriggerEvent('ChosenSummaryExtract', , , NewGameState);
+		SetChosenImage();
+		AffectedUnit = XComGameState_Unit(History.GetGameStateForObjectID(ExtractEffect.ApplyEffectParameters.TargetStateObjectRef.ObjectID));
+		OnChosenExtract();
+	}
+	else
+	{
+		SetChosenImage();
+		// Pass in Blank data
+		MC.BeginFunctionOp("SetChosenReward");
+		MC.QueueString("");
+		MC.QueueString("");
+		MC.QueueString("");
+		MC.EndOp();
+	}
+	`XCOMGAME.GameRuleset.SubmitGameState(NewGameState);
+}
+
+//---------------------------------------------------------------------------------------
+simulated function SetChosenImage(optional bool bWasDefeated = false)
+{
+	local string DefeatedString;
+
+	DefeatedString = "";
+
+	if(bWasDefeated)
+	{
+		DefeatedString = ChosenDefeatedLabel;
+	}
+
+	MC.BeginFunctionOp("SetChosenImage");
+	MC.QueueString(ChosenState.GetChosenPortraitImage());
+	MC.QueueString(DefeatedString);
+	MC.EndOp();
+}
+
+//---------------------------------------------------------------------------------------
+simulated function SetChosenData()
+{
+	MC.BeginFunctionOp("SetChosenData");
+	MC.QueueString(ChosenEncounterTitle);
+	MC.QueueString(ChosenEncounterSubtitle);
+	MC.QueueString(ChosenState.GetChosenClassName());
+	MC.QueueString(ChosenState.GetChosenName());
+	MC.QueueString(ChosenState.GetChosenNickname());
+	MC.QueueString(ChosenState.GetChosenNarrativeFlavor());
+	MC.QueueString(StrengthsLabel);
+	MC.QueueString(ChosenState.GetStrengthsList());
+	MC.QueueString(WeaknessesLabel);
+	MC.QueueString(ChosenState.GetWeaknessesList());
+	MC.EndOp();
+}
+
+//---------------------------------------------------------------------------------------
+simulated function SetChosenIcon(StackedUIIconData IconInfo)
+{
+	local int i;
+
+	MC.BeginFunctionOp("SetChosenIcon");
+	MC.QueueBoolean(IconInfo.bInvert);
+	for (i = 0; i < IconInfo.Images.Length; i++)
+	{
+		MC.QueueString("img:///" $ IconInfo.Images[i]);
+	}
+
+	MC.EndOp();
+}
+
+//---------------------------------------------------------------------------------------
+simulated function OnChosenExtract()
+{
+	local int ChosenKnowledgeStartValue, ChosenKnowledgeEndValue;
+
+	ChosenKnowledgeStartValue = ChosenState.GetKnowledgePercent(true);
+	ChosenKnowledgeEndValue = ChosenState.GetKnowledgePercent(true, ChosenState.MissionKnowledgeExtracted);
+
+	MC.BeginFunctionOp("SetChosenKnowledge");
+	MC.QueueString(ChosenKnowledgeLabel);
+	MC.QueueNumber(ChosenKnowledgeStartValue);
+	MC.QueueNumber(ChosenKnowledgeEndValue);
+	MC.QueueString(ChosenKnowledgeText);
+	MC.EndOp();
+}
+
+//---------------------------------------------------------------------------------------
+simulated function OnChosenCapture()
+{
+	local XComGameState_CampaignSettings SettingsState;
+	local Texture2D SoldierPicture;
+
+	SettingsState = XComGameState_CampaignSettings(`XCOMHISTORY.GetSingleGameStateObjectForClass(class'XComGameState_CampaignSettings'));
+	SoldierPicture = `XENGINE.m_kPhotoManager.GetHeadshotTexture(SettingsState.GameIndex, AffectedUnit.ObjectID, 128, 128);
+
+	MC.BeginFunctionOp("SetSoldierCapture");
+	MC.QueueString(SoldierCapturedLabel);
+	// Start Issue #106, #408
+	MC.QueueString(AffectedUnit.GetSoldierClassIcon());
+	MC.QueueString(AffectedUnit.GetSoldierRankIcon());
+	MC.QueueString(AffectedUnit.GetSoldierRankName());
+	MC.QueueString(AffectedUnit.GetName(eNameType_RankFull));
+	MC.QueueString(AffectedUnit.GetSoldierClassDisplayName());
+	// End Issue #106, #408
+	MC.QueueString(class'UIUtilities_Image'.static.ValidateImagePath(PathName(SoldierPicture)));
+	MC.EndOp();
+}
+
+//---------------------------------------------------------------------------------------
+simulated function OnChosenDefeat()
+{
+	local X2AbilityPointTemplate APTemplate;
+	local XComGameState_HeadquartersXCom XComHQ;
+	local int NumPointsAwarded;
+
+	APTemplate = class'X2EventListener_AbilityPoints'.static.GetAbilityPointTemplate( 'ChosenKilled' );
+	`assert( APTemplate != none );
+
+	XComHQ = XComGameState_HeadquartersXCom( `XCOMHISTORY.GetSingleGameStateObjectForClass( class'XComGameState_HeadquartersXCom' ) );
+	`assert( XComHQ != none );
+
+	NumPointsAwarded = APTemplate.NumPointsAwarded * XComHQ.BonusAbilityPointScalar;
+
+	MC.BeginFunctionOp("SetChosenReward");
+	MC.QueueString(RewardLabel);
+	MC.QueueString("+"$NumPointsAwarded);
+	MC.QueueString(RewardType);
+	MC.EndOp();
+}
+
+//==============================================================================
+//		INPUT HANDLING:
+//==============================================================================
+simulated function bool OnUnrealCommand(int ucmd, int arg)
+{
+	if(!CheckInputIsReleaseOrDirectionRepeat(ucmd, arg))
+		return false;
+
+	switch(ucmd)
+	{
+		// Consume 'B' button here so there is no UI functionality in Mission Summary
+	case (class'UIUtilities_Input'.const.FXS_BUTTON_B):
+	case (class'UIUtilities_Input'.const.FXS_KEY_ESCAPE):
+		// Consume
+		return true;
+
+		// Consume the 'A' button so that it doesn't cascade down the input chain
+	case (class'UIUtilities_Input'.const.FXS_BUTTON_A):
+	case (class'UIUtilities_Input'.const.FXS_KEY_ENTER):
+	case (class'UIUtilities_Input'.const.FXS_KEY_SPACEBAR):
+		CloseScreen();
+		return true;
+
+	case class'UIUtilities_Input'.const.FXS_BUTTON_START :
+		XComPresentationLayer(Movie.Pres).UIPauseMenu(true);
+		return true;
+	}
+
+	return super.OnUnrealCommand(ucmd, arg);
+}
+
+//==============================================================================
+//		CLEANUP:
+//==============================================================================
+simulated function CloseScreen()
+{
+	super.CloseScreen();
+
+	`PRES.UIMissionSummaryScreen();
+}
+
+//---------------------------------------------------------------------------------------
+DefaultProperties
+{
+	Package = "/ package/gfxXPACK_ChosenPostMission/XPACK_ChosenPostMission";
+	MCName = "theScreen";
+
+	InputState = eInputState_Consume;
+
+	bConsumeMouseEvents = true;
+}

--- a/X2WOTCCommunityHighlander/Src/XComGame/Classes/UICovertActionStaffSlot.uc
+++ b/X2WOTCCommunityHighlander/Src/XComGame/Classes/UICovertActionStaffSlot.uc
@@ -150,7 +150,7 @@ function UpdateData()
 		}
 
 		Unit = XComGameState_Unit(`XCOMHISTORY.GetGameStateForObjectID(UnitRef.ObjectID));
-		RankImage = Unit.IsSoldier() ? class'UIUtilities_Image'.static.GetRankIcon(Unit.GetRank(), Unit.GetSoldierClassTemplateName()) : "";
+		RankImage = Unit.IsSoldier() ? Unit.GetSoldierRankIcon() : ""; // Issue #408
 		// Start Issue #106
 		ClassImage = Unit.IsSoldier() ? Unit.GetSoldierClassIcon() : Unit.GetMPCharacterTemplate().IconImage;
 		// End Issue #106

--- a/X2WOTCCommunityHighlander/Src/XComGame/Classes/UIHackingScreen.uc
+++ b/X2WOTCCommunityHighlander/Src/XComGame/Classes/UIHackingScreen.uc
@@ -344,15 +344,15 @@ simulated function PopulateSoldierInfo()
 
 	Unit = XGUnit(UnitState.GetVisualizer());
 	
-	// Start Issue #106
-	AS_SetSoldierInfo(class'UIUtilities_Text'.static.GetColoredText(Caps(`GET_RANK_STR(Unit.GetCharacterRank(), Unit.GetVisualizedGameState().GetSoldierClassTemplateName())), euiState_Faded, 17), 
+	// Start Issue #106, #408
+	AS_SetSoldierInfo(class'UIUtilities_Text'.static.GetColoredText(Caps(UnitState.GetSoldierRankName()), euiState_Faded, 17), 
 						class'UIUtilities_Text'.static.GetColoredText(Caps(UnitState.GetName(eNameType_Full)), eUIState_Normal, 22), 
 						class'UIUtilities_Text'.static.GetColoredText(Caps(UnitState.GetNickName(false)), eUIState_Header, 30),
-						class'UIUtilities_Image'.static.GetRankIcon(Unit.GetCharacterRank(), Unit.GetVisualizedGameState().GetSoldierClassTemplateName()),
+						UnitState.GetSoldierRankIcon(),
 						UnitState.GetSoldierClassIcon(),
 						strHackAbilityLabel,
 						string(int(HackOffense)));
-	// End Issue #106
+	// End Issue #106, #408
 }
 
 simulated function PopulateEnemyInfo()

--- a/X2WOTCCommunityHighlander/Src/XComGame/Classes/UIPersonnel_DropDownListItem.uc
+++ b/X2WOTCCommunityHighlander/Src/XComGame/Classes/UIPersonnel_DropDownListItem.uc
@@ -1,0 +1,219 @@
+
+class UIPersonnel_DropDownListItem extends UIButton dependson(XComGameState_Unit);
+
+var StaffUnitInfo UnitInfo;
+var StateObjectReference SlotRef;
+
+var UIPersonnel_DropDownToolTip ItemToolTip;
+var UIPersonnel_DropDown OwningMenu;
+var bool bSizeRealized;
+
+delegate OnDimensionsRealized();
+
+simulated function InitListItem(UIPersonnel_DropDown Menu, StaffUnitInfo initUnitInfo, StateObjectReference initSlotRef)
+{
+	OwningMenu = Menu;
+	UnitInfo = initUnitInfo;
+	SlotRef = initSlotRef;
+
+	InitPanel(); // must do this before adding children or setting data
+	
+	// Only spawn a tooltip if this is not an Empty item
+	if (UnitInfo.UnitRef.ObjectID != 0)
+	{
+		ItemToolTip = Spawn(class'UIPersonnel_DropDownToolTip', Movie.Pres.m_kTooltipMgr);
+		ItemToolTip.InitDropDownToolTip();
+		ItemToolTip.UnitInfo = UnitInfo;
+		ItemToolTip.SlotRef = SlotRef;
+		ItemToolTip.targetPath = string(MCPath);
+		ItemToolTip.tDelay = 0;
+
+		ItemToolTip.ID = Movie.Pres.m_kTooltipMgr.AddPreformedTooltip(ItemToolTip);
+		bHasTooltip = true;
+	}
+
+	ProcessMouseEvents(OnChildMouseEvent);
+
+	UpdateData();
+}
+
+simulated function OnMouseEvent(int cmd, array<string> args)
+{
+	switch(cmd)
+	{
+		case class'UIUtilities_Input'.const.FXS_L_MOUSE_IN:
+			`SOUNDMGR.PlaySoundEvent("Play_Mouseover");
+			OwningMenu.ClearDelayTimer();
+			break; 
+
+		case class'UIUtilities_Input'.const.FXS_L_MOUSE_RELEASE_OUTSIDE: //Snap this shut when you've clicked elsewhere. 
+			OwningMenu.CloseMenu();
+			break;
+
+		case class'UIUtilities_Input'.const.FXS_L_MOUSE_DRAG_OUT:
+		case class'UIUtilities_Input'.const.FXS_L_MOUSE_OUT:
+			OwningMenu.TryToStartDelayTimer(args);
+			break;
+	}
+
+	super.OnMouseEvent(cmd, args);
+}
+
+simulated function OnCommand(string cmd, string arg)
+{
+	local array<string> sizeData;
+
+	super.OnCommand(cmd, arg);
+
+	if( cmd == "RealizeDimensions" )
+	{
+		sizeData = SplitString(arg, ",");
+		X = float(sizeData[0]);
+		Y = float(sizeData[1]);
+		Width = float(sizeData[2]);
+		Height = float(sizeData[3]);
+
+		bSizeRealized = true;
+
+		if (OnDimensionsRealized != none)
+		{
+			OnDimensionsRealized();
+		}
+	}
+}
+
+simulated function UpdateData()
+{
+	local XComGameStateHistory History;
+	local XComGameState_Unit Unit, PairUnit;
+	local string UnitName, UnitStatus, UnitTypeImage;
+	local EUIPersonnelType UnitPersonnelType; 
+	local EStaffStatus StafferStatus;
+	local int StatusState;
+
+	bSizeRealized = false;
+	
+	History = `XCOMHISTORY;
+	Unit = XComGameState_Unit(History.GetGameStateForObjectID(UnitInfo.UnitRef.ObjectID));
+	PairUnit = XComGameState_Unit(History.GetGameStateForObjectID(UnitInfo.PairUnitRef.ObjectID));
+	if(Unit != none) //May be none of the slots are being cleared
+	{
+		StafferStatus = class'X2StrategyGameRulesetDataStructures'.static.GetStafferStatus(UnitInfo, , , StatusState);
+		UnitStatus = class'UIUtilities_Text'.static.GetColoredText(class'UIUtilities_Strategy'.default.m_strStaffStatus[StafferStatus], StatusState);
+		UnitName = Caps(Unit.GetFullName());
+		
+		if(Unit.IsSoldier())
+		{
+			UnitName = Caps(Unit.GetName(eNameType_RankFull));
+			UnitPersonnelType = eUIPersonnel_Soldiers;
+			if (PairUnit != none && PairUnit.IsSoldier())
+			{
+				UnitName @= class'UIUtilities_Text'.default.m_strAmpersand @ Caps(PairUnit.GetName(eNameType_RankFull));
+				UnitTypeImage = "";
+			}
+			else
+			{
+				UnitTypeImage = Unit.GetSoldierRankIcon(); // Issue #408
+			}
+		}
+		else if(Unit.IsEngineer())
+		{
+			if(UnitInfo.bGhostUnit) // If the unit is a ghost, replace Eng name with the Ghost name
+				UnitName = Caps(Repl(Unit.GetStaffSlot().GetMyTemplate().GhostName, "%UNITNAME", UnitName));
+			UnitPersonnelType = eUIPersonnel_Engineers;
+			UnitTypeImage = class'UIUtilities_Image'.const.EventQueue_Engineer;
+		}
+		else if(Unit.IsScientist())
+		{
+			UnitPersonnelType = eUIPersonnel_Scientists;
+			UnitTypeImage = class'UIUtilities_Image'.const.EventQueue_Science;
+		}
+		else // Passed in an empty ref
+		{
+			UnitName = class'UIUtilities_Strategy'.default.m_strEmptyStaff;
+			UnitStatus = " "; // send a space specifically to clear out this field. 
+			UnitPersonnelType = -1;
+			UnitTypeImage = "";
+		}
+	}
+	else // Passed in an empty ref
+	{
+		UnitName = class'UIUtilities_Strategy'.default.m_strEmptyStaff;
+		UnitStatus = " "; // send a space specifically to clear out this field. 
+		UnitPersonnelType = -1;
+		UnitTypeImage = "";
+	}
+
+	AS_UpdateData(
+		UnitName,
+		"0", //string(Unit.GetSkillLevel()),
+		UnitStatus,
+		UnitPersonnelType,
+		UnitTypeImage);
+}
+
+simulated function AS_UpdateData(string UnitName, 
+								 string UnitSkill, 
+								 string UnitStatus, 
+								 int SkillType, 
+								 string SkillImage )
+{
+	MC.BeginFunctionOp("update");
+	MC.QueueString(UnitName);
+	MC.QueueString(UnitSkill);
+	MC.QueueString(UnitStatus);
+	MC.QueueNumber(SkillType);
+	MC.QueueString(SkillImage);
+	MC.EndOp();
+}
+
+simulated function AnimateIn(optional float delay = -1.0)
+{
+	// this needs to be percent of total time in sec 
+	if( delay == -1.0)
+		delay = ParentPanel.GetChildIndex(self) * class'UIUtilities'.const.INTRO_ANIMATION_DELAY_PER_INDEX; 
+
+	AddTweenBetween( "_alpha", 0, alpha, class'UIUtilities'.const.INTRO_ANIMATION_TIME, delay );
+	AddTweenBetween( "_y", Y+10, Y, class'UIUtilities'.const.INTRO_ANIMATION_TIME*2, delay, "easeoutquad" );
+}
+
+simulated function OnChildMouseEvent(UIPanel control, int cmd)
+{
+	switch( control )
+	{
+	default:
+		switch( cmd )
+		{
+		case class'UIUtilities_Input'.const.FXS_L_MOUSE_IN:
+			OnReceiveFocus();
+			MC.FunctionVoid("mouseIn");
+			break;
+		case class'UIUtilities_Input'.const.FXS_L_MOUSE_OUT:
+			OnLoseFocus();
+			MC.FunctionVoid("mouseOut");
+			break;
+		}
+	}
+}
+
+
+simulated function OnReceiveFocus()
+{
+	MC.FunctionVoid("mouseIn");
+}
+
+simulated function OnLoseFocus()
+{
+	MC.FunctionVoid("mouseOut");
+}
+
+defaultproperties
+{
+	LibID = "StaffRowItem";
+
+	height = 38;
+	bProcessesMouseEvents = true;
+	bIsNavigable = true;
+	
+	bShouldPlayGenericUIAudioEvents = false;
+}

--- a/X2WOTCCommunityHighlander/Src/XComGame/Classes/UIPersonnel_SoldierListItem.uc
+++ b/X2WOTCCommunityHighlander/Src/XComGame/Classes/UIPersonnel_SoldierListItem.uc
@@ -21,7 +21,7 @@ simulated function InitListItem(StateObjectReference initUnitRef)
 {
 	local XComGameState_Unit Unit;
 	local string UnitLoc, status, statusTimeLabel, statusTimeValue, classIcon, rankIcon, flagIcon, mentalStatus;	
-	local int iRank, iTimeNum;
+	local int iTimeNum;
 	local X2SoldierClassTemplate SoldierClass;
 	local XComGameState_ResistanceFaction FactionState;
 	local SoldierBond BondData;
@@ -30,9 +30,7 @@ simulated function InitListItem(StateObjectReference initUnitRef)
 	local int BondLevel; 
 	
 	Unit = XComGameState_Unit(`XCOMHISTORY.GetGameStateForObjectID(UnitRef.ObjectID));
-
-	iRank = Unit.GetRank();
-
+	
 	SoldierClass = Unit.GetSoldierClassTemplate();
 	FactionState = Unit.GetResistanceFaction();
 
@@ -59,7 +57,7 @@ simulated function InitListItem(StateObjectReference initUnitRef)
 		statusTimeValue = "---";
 
 	flagIcon = Unit.GetCountryTemplate().FlagImage;
-	rankIcon = class'UIUtilities_Image'.static.GetRankIcon(iRank, SoldierClass.DataName);
+	rankIcon = Unit.GetSoldierRankIcon(); // Issue #408
 	// Start Issue #106
 	classIcon = Unit.GetSoldierClassIcon();
 	// End Issue #106
@@ -111,10 +109,10 @@ simulated function InitListItem(StateObjectReference initUnitRef)
 		BondLevel = -1; 
 	}
 
-	// Start Issue #106
+	// Start Issue #106, #408
 	AS_UpdateDataSoldier(Caps(Unit.GetName(eNameType_Full)),
 					Caps(Unit.GetName(eNameType_Nick)),
-					Caps(`GET_RANK_ABBRV(Unit.GetRank(), SoldierClass.DataName)),
+					Caps(Unit.GetSoldierShortRankName()),
 					rankIcon,
 					Caps(SoldierClass != None ? Unit.GetSoldierClassDisplayName() : ""),
 					classIcon,
@@ -127,7 +125,7 @@ simulated function InitListItem(StateObjectReference initUnitRef)
 					false, // psi soldiers can't rank up via missions
 					mentalStatus,
 					BondLevel);
-	// End Issue #106
+	// End Issue #106, #408
 
 	AS_SetFactionIcon(FactionState.GetFactionIcon());
 }

--- a/X2WOTCCommunityHighlander/Src/XComGame/Classes/UISoldierBondAlert.uc
+++ b/X2WOTCCommunityHighlander/Src/XComGame/Classes/UISoldierBondAlert.uc
@@ -37,7 +37,6 @@ function UpdateData()
 {
 	local XComGameState_Unit Unit1, Unit2;
 	local string ClassIcon1, ClassIcon2, RankIcon1, RankIcon2;
-	local X2SoldierClassTemplate SoldierClass1, SoldierClass2;
 	local SoldierBond BondData;
 	local XGParamTag kTag;
 	local UIButton OKButton, CancelButton;
@@ -46,14 +45,12 @@ function UpdateData()
 	Unit1 = XComGameState_Unit(`XCOMHISTORY.GetGameStateForObjectID(UnitRef1.ObjectID));
 	Unit2 = XComGameState_Unit(`XCOMHISTORY.GetGameStateForObjectID(UnitRef2.ObjectID));
 
-	SoldierClass1 = Unit1.GetSoldierClassTemplate();
-	RankIcon1 = class'UIUtilities_Image'.static.GetRankIcon(Unit1.GetRank(), SoldierClass1.DataName);
+	RankIcon1 = Unit1.GetSoldierRankIcon(); // Issue #408
 	// Start Issue #106
 	ClassIcon1 = Unit1.GetSoldierClassIcon();
 	// End Issue #106
 
-	SoldierClass2 = Unit2.GetSoldierClassTemplate();
-	RankIcon2 = class'UIUtilities_Image'.static.GetRankIcon(Unit2.GetRank(), SoldierClass2.DataName);
+	RankIcon2 = Unit2.GetSoldierRankIcon(); // Issue #408
 	// Start Issue #106
 	ClassIcon2 = Unit2.GetSoldierClassIcon();
 	// End Issue #106

--- a/X2WOTCCommunityHighlander/Src/XComGame/Classes/UISoldierBondConfirmScreen.uc
+++ b/X2WOTCCommunityHighlander/Src/XComGame/Classes/UISoldierBondConfirmScreen.uc
@@ -28,8 +28,7 @@ var UIButton ConfirmButton;
 simulated function OnInit()
 {
 	local string classIcon1, rankIcon1, classIcon2, rankIcon2;
-	local int iRank1, iRank2, i;
-	local X2SoldierClassTemplate SoldierClass1, SoldierClass2;
+	local int i;
 	local SoldierBond BondData;
 	local X2DataTemplate BondedAbilityTemplate;
 	local UISummary_Ability Data;
@@ -48,11 +47,7 @@ simulated function OnInit()
 
 	NavHelp = `HQPRES.m_kAvengerHUD.NavHelp;
 
-	iRank1 = Soldier1State.GetRank();
-
-	SoldierClass1 = Soldier1State.GetSoldierClassTemplate();
-
-	rankIcon1 = class'UIUtilities_Image'.static.GetRankIcon(iRank1, SoldierClass1.DataName);
+	rankIcon1 = Soldier1State.GetSoldierRankIcon(); // Issue #408
 	// Start Issue #106
 	classIcon1 = Soldier1State.GetSoldierClassIcon();
 	// End Issue #106
@@ -60,11 +55,7 @@ simulated function OnInit()
 	Soldier1State.HasSoldierBond(unitRef, BondData);
 
 
-	iRank2 = Soldier2State.GetRank();
-
-	SoldierClass2 = Soldier2State.GetSoldierClassTemplate();
-
-	rankIcon2 = class'UIUtilities_Image'.static.GetRankIcon(iRank2, SoldierClass2.DataName);
+	rankIcon2 = Soldier2State.GetSoldierRankIcon(); // Issue #408
 	// Start Issue #106
 	classIcon2 = Soldier2State.GetSoldierClassIcon();
 	

--- a/X2WOTCCommunityHighlander/Src/XComGame/Classes/UISoldierBondListItem.uc
+++ b/X2WOTCCommunityHighlander/Src/XComGame/Classes/UISoldierBondListItem.uc
@@ -45,7 +45,6 @@ simulated function UpdateData()
 	local XComGameState_Unit Unit, ScreenUnit;
 	local StateObjectReference BondmateRef;
 	local string classIcon, rankIcon, flagIcon;
-	local int iRank;
 	local X2SoldierClassTemplate SoldierClass;
 	local SoldierBond BondData;
 	local float CohesionPercent, CohesionMax;
@@ -56,12 +55,10 @@ simulated function UpdateData()
 
 	ScreenUnit.GetBondData(UnitRef, BondData);
 
-	iRank = Unit.GetRank();
-
 	SoldierClass = Unit.GetSoldierClassTemplate();
 
 	flagIcon = Unit.GetCountryTemplate().FlagImage;
-	rankIcon = class'UIUtilities_Image'.static.GetRankIcon(iRank, SoldierClass.DataName);
+	rankIcon = Unit.GetSoldierRankIcon(); // Issue #408
 	// Start Issue #106
 	classIcon = Unit.GetSoldierClassIcon();
 	// End Issue #106
@@ -108,10 +105,10 @@ simulated function UpdateData()
 		ActivateBondButton.Hide();
 		MC.FunctionBool("CanShowBondButton", false);
 	}
-	// Start Issue #106
+	// Start Issue #106, #408
 	AS_UpdateDataSoldier(Caps(Unit.GetName(eNameType_Full)),
 						 Caps(Unit.GetName(eNameType_Nick)),
-						 Caps(`GET_RANK_ABBRV(Unit.GetRank(), SoldierClass.DataName)),
+						 Caps(Unit.GetSoldierShortRankName()),
 						rankIcon,
 						Caps(SoldierClass != None ? Unit.GetSoldierClassDisplayName() : ""),
 						classIcon,
@@ -119,7 +116,7 @@ simulated function UpdateData()
 						class'X2StrategyGameRulesetDataStructures'.static.GetSoldierCompatibilityLabel(BondData.Compatibility),
 						CohesionPercent,
 						IsDisabled);
-	// End Issue #106
+	// End Issue #106, #408
 }
 
 simulated function AS_UpdateDataSoldier(string UnitName,

--- a/X2WOTCCommunityHighlander/Src/XComGame/Classes/UISoldierBondScreen.uc
+++ b/X2WOTCCommunityHighlander/Src/XComGame/Classes/UISoldierBondScreen.uc
@@ -113,7 +113,6 @@ function RefreshHeader()
 {
 	local XComGameState_Unit Unit, Bondmate;
 	local string classIcon, rankIcon, flagIcon;
-	local int iRank;
 	local X2SoldierClassTemplate SoldierClass;
 	local SoldierBond BondData;
 	local float CohesionPercent, CohesionMax;
@@ -121,33 +120,31 @@ function RefreshHeader()
 
 	Unit = XComGameState_Unit(`XCOMHISTORY.GetGameStateForObjectID(UnitRef.ObjectID));
 	
-	iRank = Unit.GetRank();
-
 	SoldierClass = Unit.GetSoldierClassTemplate();
 
 	flagIcon = Unit.GetCountryTemplate().FlagImage;
-	rankIcon = class'UIUtilities_Image'.static.GetRankIcon(iRank, SoldierClass.DataName);
+	rankIcon = Unit.GetSoldierRankIcon(); // Issue #408
 	// Start Issue #106
 	classIcon = Unit.GetSoldierClassIcon();
 	// End Issue #106
 
-	SetPlayerInfo(Caps(`GET_RANK_STR(Unit.GetRank(), SoldierClass.DataName)), 
+	// Start Issue 408
+	SetPlayerInfo(Caps(Unit.GetSoldierRankName()), 
 					Caps(Unit.GetName(eNameType_FullNick)),
 					classIcon,
 					rankIcon, 
 					"", 
 					0);
+	// End Issue #408
 
 	if( Unit.HasSoldierBond(BondmateRef, BondData) )
 	{
 		Bondmate = XComGameState_Unit(`XCOMHISTORY.GetGameStateForObjectID(BondmateRef.ObjectID));
 
-		iRank = Bondmate.GetRank();
-
 		SoldierClass = Bondmate.GetSoldierClassTemplate();
 
 		flagIcon = Bondmate.GetCountryTemplate().FlagImage;
-		rankIcon = class'UIUtilities_Image'.static.GetRankIcon(iRank, SoldierClass.DataName);
+		rankIcon = Unit.GetSoldierRankIcon(); // Issue #408
 		// Start Issue #106
 		classIcon = Bondmate.GetSoldierClassIcon();
 		// End Issue #106
@@ -156,12 +153,12 @@ function RefreshHeader()
 		CohesionMax = float(CohesionThresholds[Clamp(BondData.BondLevel + 1, 0, CohesionThresholds.Length - 1)]);
 		CohesionPercent = float(BondData.Cohesion) / CohesionMax;
 
-		// Start Issue #106
+		// Start Issue #106, #408
 		SetBondMateInfo(BondMateTitle, 
 						BondData.BondLevel,
 						Caps(Bondmate.GetName(eNameType_Full)),
 						Caps(Bondmate.GetName(eNameType_Nick)),
-						Caps(`GET_RANK_ABBRV(Bondmate.GetRank(), SoldierClass.DataName)),
+						Caps(Unit.GetSoldierShortRankName()),
 						rankIcon,
 						Caps(SoldierClass != None ? Bondmate.GetSoldierClassDisplayName() : ""),
 						classIcon,
@@ -169,7 +166,7 @@ function RefreshHeader()
 						class'X2StrategyGameRulesetDataStructures'.static.GetSoldierCompatibilityLabel(BondData.Compatibility),
 						CohesionPercent,
 						false /*todo: is disabled*/ );
-		// End Issue #106
+		// End Issue #106, #408
 	}
 	else
 	{

--- a/X2WOTCCommunityHighlander/Src/XComGame/Classes/UISoldierCaptured.uc
+++ b/X2WOTCCommunityHighlander/Src/XComGame/Classes/UISoldierCaptured.uc
@@ -73,7 +73,7 @@ simulated function BuildScreen()
 
 	AS_SetChosenIcon(ChosenState.GetChosenIcon());
 
-	// Start Issue #106
+	// Start Issue #106, #408
 	AS_UpdateData(  GetOrStartWaitingForPosterImage(),
 				  ""/*InspectingChosen.GetChosenIcon()*/,
 					string(ChosenState.Level),
@@ -81,12 +81,12 @@ simulated function BuildScreen()
 					strChosenName,
 					Caps(strChosenNickname),
 					UnitState.IsSoldier() ? UnitState.GetSoldierClassIcon() : UnitState.GetMPCharacterTemplate().IconImage,
-					Caps(class'UIUtilities_Image'.static.GetRankIcon(UnitState.GetRank(), UnitState.GetSoldierClassTemplateName())),
+					Caps(UnitState.GetSoldierRankIcon()),
 					Caps(SoldierClass != None ? UnitState.GetSoldierClassDisplayName() : ""),
 					Caps(UnitState.GetFullName()),
-					Caps(UnitState.IsSoldier() ? `GET_RANK_STR(UnitState.GetRank(), UnitState.GetSoldierClassTemplateName()) : ""),
+					Caps(UnitState.IsSoldier() ? UnitState.GetSoldierRankName() : ""),
 					strBody);
-	// End Issue #106
+	// End Issue #106, #408
 
 	GetOrStartWaitingForStaffImage();
 	if( `SCREENSTACK.IsTopScreen(self) )

--- a/X2WOTCCommunityHighlander/Src/XComGame/Classes/UISoldierHeader.uc
+++ b/X2WOTCCommunityHighlander/Src/XComGame/Classes/UISoldierHeader.uc
@@ -166,7 +166,7 @@ public function PositionTopRight()
 
 public function PopulateData(optional XComGameState_Unit Unit, optional StateObjectReference NewItem, optional StateObjectReference ReplacedItem, optional XComGameState NewCheckGameState)
 {
-	local int iRank, WillBonus, AimBonus, HealthBonus, MobilityBonus, TechBonus, PsiBonus, ArmorBonus, DodgeBonus;
+	local int WillBonus, AimBonus, HealthBonus, MobilityBonus, TechBonus, PsiBonus, ArmorBonus, DodgeBonus;
 	local string classIcon, rankIcon, flagIcon, Will, Aim, Health, Mobility, Tech, Psi, Armor, Dodge;
 	local X2SoldierClassTemplate SoldierClass;
 	local X2EquipmentTemplate EquipmentTemplate;
@@ -186,15 +186,15 @@ public function PopulateData(optional XComGameState_Unit Unit, optional StateObj
 		else
 			Unit = XComGameState_Unit(History.GetGameStateForObjectID(UnitRef.ObjectID));
 	}
-	
-	iRank = Unit.GetRank();
 
 	SoldierClass = Unit.GetSoldierClassTemplate();
 
 	FactionState = Unit.GetResistanceFaction();
 
 	flagIcon  = (Unit.IsSoldier() && !bHideFlag) ? Unit.GetCountryTemplate().FlagImage : "";
-	rankIcon  = Unit.IsSoldier() ? class'UIUtilities_Image'.static.GetRankIcon(iRank, Unit.GetSoldierClassTemplateName()) : Unit.GetMPCharacterTemplate().IconImage;
+	// Start Issue #408
+	rankIcon  = Unit.IsSoldier() ? Unit.GetSoldierRankIcon() : Unit.GetMPCharacterTemplate().IconImage;
+	// End Issue #408
 	// Start Issue #106
 	classIcon = Unit.IsSoldier() ? Unit.GetSoldierClassIcon() : Unit.GetMPCharacterTemplate().IconImage;
 	// End Issue #106
@@ -217,26 +217,28 @@ public function PopulateData(optional XComGameState_Unit Unit, optional StateObj
 
 	if(Unit.IsMPCharacter())
 	{
+		// Start Issue #408
 		SetSoldierInfo( Caps(strMPForceName == "" ? Unit.GetName( eNameType_FullNick ) : strMPForceName),
 							  StatusLabel, StatusValue,
 							  class'XGBuildUI'.default.m_strLabelCost, 
 							  string(Unit.GetUnitPointValue()),
 							  "", "",
 							  classIcon, Caps(SoldierClass != None ? SoldierClass.DisplayName : ""),
-							  rankIcon, Caps(Unit.IsSoldier() ? `GET_RANK_STR(Unit.GetRank(), Unit.GetSoldierClassTemplateName()) : Unit.IsAlien() ? class'UIHackingScreen'.default.m_strAlienInfoTitle : class'UIHackingScreen'.default.m_strAdventInfoTitle),
+							  rankIcon, Caps(Unit.IsSoldier() ? Unit.GetSoldierRankName() : Unit.IsAlien() ? class'UIHackingScreen'.default.m_strAlienInfoTitle : class'UIHackingScreen'.default.m_strAdventInfoTitle),
 							  flagIcon, false, DaysValue);
+		// End Issue #408
 	}
 	else
 	{
-		// Start Issue #106
+		// Start Issue #106, #408
 		SetSoldierInfo( Caps(Unit.GetName( eNameType_FullNick )),
 							  StatusLabel, StatusValue,
 							  m_strMissionsLabel, string(Unit.GetNumMissions()),
 							  m_strKillsLabel, string(Unit.GetNumKills()),
 							  classIcon, Caps(SoldierClass != None ? Unit.GetSoldierClassDisplayName() : ""),
-							  rankIcon, Caps(`GET_RANK_STR(Unit.GetRank(), Unit.GetSoldierClassTemplateName())),
+							  rankIcon, Caps(Unit.GetSoldierRankName()),
 							  flagIcon, (Unit.ShowPromoteIcon()), DaysValue);
-		// End Issue #106
+		// End Issue #106, #408
 	}
 
 	SetFactionIcon(FactionState.GetFactionIcon());

--- a/X2WOTCCommunityHighlander/Src/XComGame/Classes/UISquadSelect_ListItem.uc
+++ b/X2WOTCCommunityHighlander/Src/XComGame/Classes/UISquadSelect_ListItem.uc
@@ -300,11 +300,11 @@ simulated function UpdateData(optional int Index = -1, optional bool bDisableEdi
 		bEditDisabled = bDisableEdit; //Used in controller nav
 		bDismissDisabled = bDisableDismiss; //used in controller nav
 
-		// Start Issue #106
-		AS_SetFilled( class'UIUtilities_Text'.static.GetColoredText(Caps(class'X2ExperienceConfig'.static.GetRankName(Unit.GetRank(), Unit.GetSoldierClassTemplateName())), eUIState_Normal, 18),
+		// Start Issue #106, #408
+		AS_SetFilled( class'UIUtilities_Text'.static.GetColoredText(Caps(Unit.GetSoldierRankName()), eUIState_Normal, 18),
 					  class'UIUtilities_Text'.static.GetColoredText(Caps(NameStr), eUIState_Normal, 22),
 					  class'UIUtilities_Text'.static.GetColoredText(Caps(Unit.GetName(eNameType_Nick)), eUIState_Header, 28),
-					  Unit.GetSoldierClassIcon(), class'UIUtilities_Image'.static.GetRankIcon(Unit.GetRank(), Unit.GetSoldierClassTemplateName()),
+					  Unit.GetSoldierClassIcon(), Unit.GetSoldierRankIcon(),
 					  class'UIUtilities_Text'.static.GetColoredText(m_strEdit, bDisableEdit ? eUIState_Disabled : eUIState_Normal),
 					  class'UIUtilities_Text'.static.GetColoredText(m_strDismiss, bDisableDismiss ? eUIState_Disabled : eUIState_Normal),
 					  class'UIUtilities_Text'.static.GetColoredText(PrimaryWeaponTemplate.GetItemFriendlyName(PrimaryWeapon.ObjectID), bDisableLoadout ? eUIState_Disabled : eUIState_Normal),
@@ -312,7 +312,7 @@ simulated function UpdateData(optional int Index = -1, optional bool bDisableEdi
 					  class'UIUtilities_Text'.static.GetColoredText(GetHeavyWeaponName(), bDisableLoadout ? eUIState_Disabled : eUIState_Normal),
 					  class'UIUtilities_Text'.static.GetColoredText(GetHeavyWeaponDesc(), bDisableLoadout ? eUIState_Disabled : eUIState_Normal),
 					  (bCanPromote ? m_strPromote : ""), Unit.IsPsiOperative() || (Unit.HasPsiGift() && Unit.GetRank() < 2), ClassStr);
-		// End Issue #106
+		// End Issue #106, #408
 
 		AS_SetUnitHealth(class'UIUtilities_Strategy'.static.GetUnitCurrentHealth(Unit), class'UIUtilities_Strategy'.static.GetUnitMaxHealth(Unit));
 

--- a/X2WOTCCommunityHighlander/Src/XComGame/Classes/UITLE_LadderModeMenu.uc
+++ b/X2WOTCCommunityHighlander/Src/XComGame/Classes/UITLE_LadderModeMenu.uc
@@ -964,7 +964,7 @@ simulated function UpdateData(int LadderIndex)
 		}
 
 		MC.QueueString(SoldierClass.IconImage); //Class Icon Image
-		MC.QueueString(class'UIUtilities_Image'.static.GetRankIcon(UnitState.GetRank(), UnitState.GetSoldierClassTemplateName())); //Rank image
+		MC.QueueString(UnitState.GetSoldierRankIcon()); //Rank image, Issue #408
 		if (LadderData.LadderIndex < 10)
 		{
 			MC.QueueString(class'XComGameState_LadderProgress'.static.GetUnitName(m_HeadshotsRecieved - 1, LadderData.LadderIndex)); //Unit Name
@@ -973,7 +973,9 @@ simulated function UpdateData(int LadderIndex)
 		{
 			MC.QueueString(UnitState.GetFullName());
 		}
-		MC.QueueString(SoldierClass.DisplayName); //Class Name
+		// Start Issue #106
+		MC.QueueString(UnitState.GetSoldierClassDisplayName()); //Class Name
+		// End Issue #106
 		MC.EndOp();
 
 	}

--- a/X2WOTCCommunityHighlander/Src/XComGame/Classes/UITacticalCharInfoScreen.uc
+++ b/X2WOTCCommunityHighlander/Src/XComGame/Classes/UITacticalCharInfoScreen.uc
@@ -101,7 +101,7 @@ simulated function PopulateCharacterData()
 	{
 		//compile the displayed character name
 		Nickname = kGameStateUnit.GetNickName(); //will not be used if returned empty
-		RankAbbrev = `GET_RANK_ABBRV(kGameStateUnit.GetSoldierRank(), kGameStateUnit.GetSoldierClassTemplateName());
+		RankAbbrev = kGameStateUnit.GetSoldierShortRankName(); // Issue #408
 		NameString = kGameStateUnit.SafeGetCharacterFirstName() @ (Nickname != "\"\"" ? Nickname : "") @ kGameStateUnit.SafeGetCharacterLastName();
 
 		SoldierClassTemplate = kGameStateUnit.GetSoldierClassTemplate();

--- a/X2WOTCCommunityHighlander/Src/XComGame/Classes/UITacticalHUD_SoldierInfo.uc
+++ b/X2WOTCCommunityHighlander/Src/XComGame/Classes/UITacticalHUD_SoldierInfo.uc
@@ -258,7 +258,7 @@ simulated function SetStats( XGUnit kActiveUnit )
 
 		if( StateUnit.IsSoldier() )
 		{
-			charRank = class'UIUtilities_Image'.static.GetRankIcon(StateUnit.GetRank(), StateUnit.GetSoldierClassTemplateName());
+			charRank = StateUnit.GetSoldierRankIcon(); // Issue #408
 			// Start Issue #106
 			charClass = StateUnit.GetSoldierClassIcon();
 			// End Issue #106

--- a/X2WOTCCommunityHighlander/Src/XComGame/Classes/X2Photobooth.uc
+++ b/X2WOTCCommunityHighlander/Src/XComGame/Classes/X2Photobooth.uc
@@ -2735,7 +2735,7 @@ function SetAutoTextStrings(Photobooth_AutoTextUsage Usage, optional Photobooth_
 				opLineChance = 0; // no nickname most likely no kills so this looks bad
 			}
 
-			LocTag.RankName0 = `GET_RANK_STR(Unit1.GetRank(), Unit1.GetSoldierClassTemplateName());
+			LocTag.RankName0 = Unit1.GetSoldierRankName(); // Issue #408
 			//LocTag.Flag = ;
 
 			if (LocTag.RankName0 == LocTag.Class0)
@@ -2850,8 +2850,10 @@ function SetAutoTextStrings(Photobooth_AutoTextUsage Usage, optional Photobooth_
 				}
 			}
 
-			LocTag.RankName0 = `GET_RANK_STR(Unit1.GetRank(), Unit1.GetSoldierClassTemplateName());
-			LocTag.RankName1 = `GET_RANK_STR(Unit2.GetRank(), Unit2.GetSoldierClassTemplateName());
+			// Start Issue #408
+			LocTag.RankName0 = Unit1.GetSoldierRankName();
+			LocTag.RankName1 = Unit2.GetSoldierRankName();
+			// End Issue #408
 			//LocTag.Flag = ;
 
 			if (Unit1.kAppearance.iGender == Unit2.kAppearance.iGender)

--- a/X2WOTCCommunityHighlander/Src/XComGame/Classes/XComGameState_StaffSlot.uc
+++ b/X2WOTCCommunityHighlander/Src/XComGame/Classes/XComGameState_StaffSlot.uc
@@ -1,0 +1,769 @@
+//---------------------------------------------------------------------------------------
+//  FILE:    XComGameState_StaffSlot.uc
+//  AUTHOR:  Mark Nauta
+//           
+//---------------------------------------------------------------------------------------
+//  Copyright (c) 2016 Firaxis Games, Inc. All rights reserved.
+//---------------------------------------------------------------------------------------
+class XComGameState_StaffSlot extends XComGameState_BaseObject;
+
+var() protected name                   m_TemplateName;
+var() protected X2StaffSlotTemplate    m_Template;
+
+var StateObjectReference			   Facility;
+var StateObjectReference			   Room; // Use for staff slots that don't have a facility (Build Slot)
+var StateObjectReference			   CovertAction;
+var StaffUnitInfo					   AssignedStaff;
+
+var int								   MaxAdjacentGhostStaff; // the maximum number of ghost staff units this slot can create
+var int								   AvailableGhostStaff; // the current number of possible ghost units which can be staffed in adjacent rooms
+
+var() bool							   bIsLocked; // If the staff slot is locked and cannot be staffed
+var() bool							   bRequireFamous; // If this staff slot requires a famous unit to be staffed there
+
+var() Name							   RequiredClass; // If this staff slot requires a specific soldier class
+var() int							   RequiredMinRank; // If this staff slot requires a soldier of at least a specific rank
+
+var StateObjectReference			   LinkedStaffSlot;
+
+//#############################################################################################
+//----------------   INITIALIZATION   ---------------------------------------------------------
+//#############################################################################################
+
+//---------------------------------------------------------------------------------------
+static function X2StrategyElementTemplateManager GetMyTemplateManager()
+{
+	return class'X2StrategyElementTemplateManager'.static.GetStrategyElementTemplateManager();
+}
+
+//---------------------------------------------------------------------------------------
+simulated function name GetMyTemplateName()
+{
+	return m_TemplateName;
+}
+
+//---------------------------------------------------------------------------------------
+simulated function X2StaffSlotTemplate GetMyTemplate()
+{
+	if(m_Template == none)
+	{
+		m_Template = X2StaffSlotTemplate(GetMyTemplateManager().FindStrategyElementTemplate(m_TemplateName));
+	}
+	return m_Template;
+}
+
+//---------------------------------------------------------------------------------------
+event OnCreation(optional X2DataTemplate Template)
+{
+	super.OnCreation( Template );
+
+	m_Template = X2StaffSlotTemplate(Template);
+	m_TemplateName = Template.DataName;
+}
+
+//#############################################################################################
+//----------------   ACCESS   -----------------------------------------------------------------
+//#############################################################################################
+
+//---------------------------------------------------------------------------------------
+function LockSlot()
+{
+	bIsLocked = true;
+}
+
+//---------------------------------------------------------------------------------------
+function UnlockSlot()
+{
+	bIsLocked = false;
+}
+
+//---------------------------------------------------------------------------------------
+function bool IsLocked()
+{
+	return bIsLocked;
+}
+
+//#############################################################################################
+//----------------   FILLING/EMPTYING   -------------------------------------------------------
+//#############################################################################################
+
+//---------------------------------------------------------------------------------------
+function bool IsUnitAvailableForThisSlot()
+{
+	local array<StaffUnitInfo> ValidUnits;
+		
+	if (IsSlotFilled())
+	{
+		return true;
+	}
+
+	ValidUnits = GetValidUnitsForSlot();
+	if (ValidUnits.Length > 0)
+	{
+		return true;
+	}
+
+	return false;
+}
+
+//---------------------------------------------------------------------------------------
+function array<StaffUnitInfo> GetValidUnitsForSlot()
+{
+	local array<StaffUnitInfo> ValidUnits;
+
+	if (GetMyTemplate().GetValidUnitsForSlotFn != None)
+	{
+		ValidUnits = GetMyTemplate().GetValidUnitsForSlotFn(self);
+	}
+
+	return ValidUnits;
+}
+
+//---------------------------------------------------------------------------------------
+function bool ValidUnitForSlot(StaffUnitInfo UnitInfo)
+{
+	if (GetMyTemplate().IsUnitValidForSlotFn != None)
+	{
+		return GetMyTemplate().IsUnitValidForSlotFn(self, UnitInfo);
+	}
+
+	// If there is no function to check if the unit is valid, assume all staff are allowed
+	return true;
+}
+
+//---------------------------------------------------------------------------------------
+function bool CanStaffBeMoved()
+{
+	// If slot is filled, check if the staffer can be moved without breaking anything
+	if (IsSlotFilled())
+	{
+		if (GetMyTemplate().CanStaffBeMovedFn != None)
+		{
+			return GetMyTemplate().CanStaffBeMovedFn(self.GetReference());
+		}
+	}
+	
+	// If the slot is empty or no slot check function, no issue
+	return true;
+}
+
+//---------------------------------------------------------------------------------------
+function bool IsStaffSlotBusy()
+{
+	// If slot is filled, check if the staffer is currently busy working on something
+	if (IsSlotFilled())
+	{
+		if (GetMyTemplate().IsStaffSlotBusyFn != None)
+		{
+			return GetMyTemplate().IsStaffSlotBusyFn(self);
+		}
+	}
+
+	// If the slot is empty or no function exists, it is not busy
+	return false;
+}
+
+//---------------------------------------------------------------------------------------
+function bool IsSlotFilled()
+{
+	local StateObjectReference EmptyRef;
+
+	return (AssignedStaff.UnitRef != EmptyRef);
+}
+
+//---------------------------------------------------------------------------------------
+function bool IsSlotFilledWithGhost(optional out XComGameState_StaffSlot GhostOwnerSlot)
+{
+	local array<XComGameState_StaffSlot> AdjacentGhostStaffSlots;
+	local XComGameState_StaffSlot AdjacentGhostStaffSlot;
+	local int iSlot;
+
+	if (IsSlotFilled())
+	{
+		// First get any adjacent slots which could produce ghosts
+		AdjacentGhostStaffSlots = GetAdjacentGhostCreatingStaffSlots();
+		for (iSlot = 0; iSlot < AdjacentGhostStaffSlots.Length; iSlot++)
+		{
+			AdjacentGhostStaffSlot = AdjacentGhostStaffSlots[iSlot];
+
+			// If the owner of the ghost-creating staff slot is also staffed here, this unit is duplicated and therefore a ghost
+			if (AdjacentGhostStaffSlot.GetAssignedStaffRef().ObjectID == GetAssignedStaffRef().ObjectID)
+			{
+				GhostOwnerSlot = AdjacentGhostStaffSlot;
+				return true;
+			}
+		}
+	}
+
+	return false;
+}
+
+//---------------------------------------------------------------------------------------
+function array<XComGameState_StaffSlot> GetAdjacentStaffSlots()
+{
+	local array<XComGameState_StaffSlot> AdjacentStaffSlots;
+	local XComGameState_HeadquartersRoom RoomState;
+	local XComGameState_FacilityXCom FacilityState;
+
+	RoomState = GetRoom();
+	FacilityState = GetFacility();
+
+	if (FacilityState == none && RoomState != none)
+		AdjacentStaffSlots = RoomState.GetAdjacentStaffSlots();
+	else if (FacilityState != none)
+		AdjacentStaffSlots = FacilityState.GetRoom().GetAdjacentStaffSlots();
+
+	return AdjacentStaffSlots;
+}
+
+//---------------------------------------------------------------------------------------
+function array<XComGameState_StaffSlot> GetAdjacentGhostCreatingStaffSlots()
+{
+	local array<XComGameState_StaffSlot> AdjacentStaffSlots;
+	local XComGameState_HeadquartersRoom RoomState;
+	local XComGameState_FacilityXCom FacilityState;
+
+	RoomState = GetRoom();
+	FacilityState = GetFacility();
+
+	if (FacilityState == none && RoomState != none)
+		AdjacentStaffSlots = RoomState.GetAdjacentGhostCreatingStaffSlots();
+	else if (FacilityState != none)
+		AdjacentStaffSlots = FacilityState.GetRoom().GetAdjacentGhostCreatingStaffSlots();
+		
+	return AdjacentStaffSlots;
+}
+
+//---------------------------------------------------------------------------------------
+function bool HasOpenAdjacentStaffSlots(StaffUnitInfo UnitInfo)
+{
+	local XComGameState_HeadquartersRoom RoomState;
+	local XComGameState_FacilityXCom FacilityState;
+
+	RoomState = GetRoom();
+	FacilityState = GetFacility();
+
+	if (FacilityState == none && RoomState != none)
+		return RoomState.HasOpenAdjacentStaffSlots(UnitInfo);
+	else if (FacilityState != none)
+		return FacilityState.GetRoom().HasOpenAdjacentStaffSlots(UnitInfo);
+
+	return false;
+}
+
+//---------------------------------------------------------------------------------------
+function bool HasAvailableAdjacentGhosts()
+{
+	local XComGameState_HeadquartersRoom RoomState;
+	local XComGameState_FacilityXCom FacilityState;
+
+	RoomState = GetRoom();
+	FacilityState = GetFacility();
+
+	if (FacilityState == none && RoomState != none)
+		return RoomState.HasAvailableAdjacentGhosts();
+	else if (FacilityState != none)
+		return FacilityState.GetRoom().HasAvailableAdjacentGhosts();
+
+	return false;
+}
+
+//---------------------------------------------------------------------------------------
+// Get any adjacent staff slots which are filled with ghosts created by this staff slot
+function array<XComGameState_StaffSlot> GetAdjacentGhostFilledStaffSlots()
+{
+	local array<XComGameState_StaffSlot> GhostFilledStaffSlots;
+	local XComGameState_HeadquartersRoom RoomState;
+	local XComGameState_FacilityXCom FacilityState;
+
+	RoomState = GetRoom();
+	FacilityState = GetFacility();
+	
+	// Check that this slot creates ghosts and is filled
+	if (GetMyTemplate().CreatesGhosts && IsSlotFilled())
+	{
+		if (FacilityState == none && RoomState != none)
+			GhostFilledStaffSlots = RoomState.GetAdjacentGhostFilledStaffSlots(GetAssignedStaffRef());
+		else if (FacilityState != none)
+			GhostFilledStaffSlots = FacilityState.GetRoom().GetAdjacentGhostFilledStaffSlots(GetAssignedStaffRef());
+	}
+
+	return GhostFilledStaffSlots;
+}
+
+//---------------------------------------------------------------------------------------
+function bool IsSlotEmpty()
+{
+	return (!IsSlotFilled());
+}
+
+//---------------------------------------------------------------------------------------
+function XComGameState_Unit GetAssignedStaff()
+{
+	if (IsSlotFilled())
+	{
+		return XComGameState_Unit(`XCOMHISTORY.GetGameStateForObjectID(AssignedStaff.UnitRef.ObjectID));
+	}
+	else
+		return None;
+}
+
+//---------------------------------------------------------------------------------------
+function XComGameState_Unit GetPairedStaff()
+{
+	if (IsSlotFilled() && AssignedStaff.PairUnitRef.ObjectID != 0)
+	{
+		return XComGameState_Unit(`XCOMHISTORY.GetGameStateForObjectID(AssignedStaff.PairUnitRef.ObjectID));
+	}
+	else
+		return None;
+}
+
+//---------------------------------------------------------------------------------------
+function StateObjectReference GetAssignedStaffRef()
+{
+	return AssignedStaff.UnitRef;
+}
+
+//---------------------------------------------------------------------------------------
+function StateObjectReference GetPairedStaffRef()
+{
+	return AssignedStaff.PairUnitRef;
+}
+
+//---------------------------------------------------------------------------------------
+function bool CanBeEmptied()
+{
+	if (IsSlotFilled())
+	{
+		if (!CanStaffBeMoved()) // If the unit is providing a critical function at their current slot, they can't be moved
+		{
+			return false;
+		}
+	}
+	
+	return true;
+}
+
+//---------------------------------------------------------------------------------------
+private function bool RemoveUnitFromOldSlot(StaffUnitInfo UnitInfo)
+{
+	local XComGameStateHistory History;
+	local XComGameState_Unit Unit;
+	local XComGameState_StaffSlot OldStaffSlot;
+	
+	History = `XCOMHISTORY;
+	Unit = XComGameState_Unit(History.GetGameStateForObjectID(UnitInfo.UnitRef.ObjectID)); // the new unit attempting to fill this staff slot
+
+	// Check the new unit or ghost's current staffing slot and try to empty it
+	if (UnitInfo.bGhostUnit)
+	{
+		OldStaffSlot = XComGameState_StaffSlot(History.GetGameStateForObjectID(UnitInfo.GhostLocation.ObjectID));
+	}
+	else if (Unit.StaffingSlot.ObjectID != 0)
+	{
+		OldStaffSlot = XComGameState_StaffSlot(History.GetGameStateForObjectID(Unit.StaffingSlot.ObjectID));
+	}
+
+	if (OldStaffSlot != none)
+	{
+		// if users are trying to assign a unit to the same slot they were previously on, bail out (do nothing).
+		if (ObjectID == OldStaffSlot.ObjectID)
+		{
+			return false; // If old slot is the same as this slot
+		}
+		else if (!OldStaffSlot.CanBeEmptied())
+		{
+			return false; // If old slot cannot be emptied
+		}
+
+		OldStaffSlot.EmptySlot();
+	}
+
+	return true;
+}
+
+//---------------------------------------------------------------------------------------
+// Attempts to auto-fill this slot with an available Unit
+function AutoFillSlot()
+{
+	local XComGameStateHistory History;
+	local XComGameState_HeadquartersXCom XComHQ;
+	local XComGameState_StaffSlot UnitSlotState;
+	local array<XComGameState_StaffSlot> AdjacentGhostCreatingSlots;
+	local XComGameState_Unit UnitState;
+	local StateObjectReference StaffRef;
+	local StaffUnitInfo UnitInfo;
+
+	History = `XCOMHISTORY;
+	XComHQ = XComGameState_HeadquartersXCom(History.GetSingleGameStateObjectForClass(class'XComGameState_HeadquartersXCom'));
+	AdjacentGhostCreatingSlots = GetAdjacentGhostCreatingStaffSlots();
+
+	// Cycle through all crew members looking for the unstaffed engineer or scientist to fill the slot, and place them there
+	foreach XComHQ.Crew(StaffRef)
+	{
+		UnitState = XComGameState_Unit(History.GetGameStateForObjectID(StaffRef.ObjectID));
+		UnitSlotState = UnitState.GetStaffSlot();
+		UnitInfo.UnitRef = StaffRef;
+
+		// Only assign a ghost unit if there are adjacent slots with available ghosts next to this slot location
+		if (AdjacentGhostCreatingSlots.Length > 0)
+		{
+			if (AdjacentGhostCreatingSlots.Find(UnitSlotState) != INDEX_NONE && UnitSlotState.AvailableGhostStaff > 0)
+			{
+				UnitInfo.bGhostUnit = true;
+			}
+		}
+
+		// Only allow staffing if this unit is creating available ghost units, or if they are available themselves, and are valid for the slot
+		if ((UnitSlotState == none || UnitInfo.bGhostUnit) && ValidUnitForSlot(UnitInfo))
+		{
+			AssignStaffToSlot(UnitInfo);
+			break;
+		}
+	}
+}
+
+//---------------------------------------------------------------------------------------
+// Attempts to remove the unit from their current staff slot, and then assign them to this slot
+function bool AssignStaffToSlot(StaffUnitInfo UnitInfo)
+{
+	local XComGameState NewGameState;
+	local XComGameState_StaffSlot StaffSlotState;
+
+	// First, if this slot provides ghosts make sure that it can be emptied (and replaced by the new unit)
+	// Because all ghost units must be manually unstaffed before the unit creating them can be replaced
+	if (MaxAdjacentGhostStaff > 0 && !CanBeEmptied())
+	{
+		return false;
+	}
+
+	// If the unit cannot be removed from its old slot, return false. Otherwise, empty the old staff slot.
+	if (!RemoveUnitFromOldSlot(UnitInfo))
+	{
+		return false;
+	}
+		
+	// Need to update game state for self in case we were emptied earlier (replacing unit in the same slot)
+	StaffSlotState = XComGameState_StaffSlot(`XCOMHISTORY.GetGameStateForObjectID(ObjectID));
+	StaffSlotState.FillSlot(UnitInfo); // Fill this slot with the unit
+	
+	NewGameState = class'XComGameStateContext_ChangeContainer'.static.CreateChangeState("Trigger Event On Staff Select");
+	`XEVENTMGR.TriggerEvent('OnStaffSelected', , , NewGameState);
+	`XCOMGAME.GameRuleset.SubmitGameState(NewGameState);
+	
+	return true;
+}
+
+//---------------------------------------------------------------------------------------
+// This function assumes that all validation on whether the unit can actually be placed
+// into this staff slot (ValidUnitForSlot) has already been completed!
+function FillSlot(StaffUnitInfo UnitInfo, optional XComGameState NewGameState)
+{
+	local bool bSubmitNewGameState;
+
+	if (NewGameState == none)
+	{
+		NewGameState = class'XComGameStateContext_ChangeContainer'.static.CreateChangeState("Fill Staff Slot");
+		bSubmitNewGameState = true;
+	}
+
+	EmptySlot(NewGameState);
+
+	if(GetMyTemplate() != none && GetMyTemplate().FillFn != none)
+	{
+		GetMyTemplate().FillFn(NewGameState, self.GetReference(), UnitInfo);
+
+		`XEVENTMGR.TriggerEvent('StaffUpdated', self, self, NewGameState);
+	}
+	else
+	{
+		`RedScreen("StaffSlot Template," @ string(GetMyTemplateName()) $ ", has no FillFn.");
+	}
+
+	if (bSubmitNewGameState)
+	{
+		`XCOMGAME.GameRuleset.SubmitGameState(NewGameState);
+		
+		// Alerts and XComHQ updates rely on the history, so only trigger them if the new game state was submitted
+		DisplaySlotFilledPopup(UnitInfo);
+		UpdateXComHQ();
+	}
+}
+
+//---------------------------------------------------------------------------------------
+function EmptySlot(optional XComGameState NewGameState)
+{
+	local bool bSubmitNewGameState;
+
+	if(IsSlotFilled())
+	{
+		if (NewGameState == none)
+		{
+			NewGameState = class'XComGameStateContext_ChangeContainer'.static.CreateChangeState("Empty Staff Slot");
+			bSubmitNewGameState = true;
+		}
+
+		if(GetMyTemplate().EmptyFn != none)
+		{
+			GetMyTemplate().EmptyFn(NewGameState, self.GetReference());
+
+			`XEVENTMGR.TriggerEvent('StaffUpdated', self, self, NewGameState);
+		}
+		else
+		{
+			`RedScreen("StaffSlot Template," @ string(GetMyTemplateName()) $ ", has no EmptyFn.");
+		}
+		
+		if (bSubmitNewGameState)
+		{
+			`XCOMGAME.GameRuleset.SubmitGameState(NewGameState);
+			UpdateXComHQ(); // XComHQ updates rely on the history, so only update if the new game state was submitted
+		}
+	}
+}
+
+//---------------------------------------------------------------------------------------
+function EmptySlotStopProject()
+{
+	local XComGameState NewGameState;
+
+	if (IsSlotFilled())
+	{
+		if (GetMyTemplate().EmptyStopProjectFn != none)
+		{
+			GetMyTemplate().EmptyStopProjectFn(self.GetReference());
+
+			NewGameState = class'XComGameStateContext_ChangeContainer'.static.CreateChangeState("Update Staff");
+			`XEVENTMGR.TriggerEvent('StaffUpdated', self, self, NewGameState);
+			`XCOMGAME.GameRuleset.SubmitGameState(NewGameState);
+		}
+		else
+		{
+			`RedScreen("StaffSlot Template," @ string(GetMyTemplateName()) $ ", has no EmptyStopProjectFn.");
+		}
+
+		UpdateXComHQ(); // XComHQ updates rely on the history, so only update if the new game state was submitted
+	}
+}
+
+//---------------------------------------------------------------------------------------
+function UpdateXComHQ()
+{
+	local XComGameState_HeadquartersXCom XComHQ;
+
+	class'X2StrategyGameRulesetDataStructures'.static.CheckForPowerStateChange();
+	XComHQ = class'UIUtilities_Strategy'.static.GetXComHQ();
+	XComHQ.HandlePowerOrStaffingChange();
+
+	`HQPRES.m_kAvengerHUD.UpdateResources();
+}
+
+//#############################################################################################
+//----------------   DISPLAY   ----------------------------------------------------------------
+//#############################################################################################
+
+//---------------------------------------------------------------------------------------
+private function DisplaySlotFilledPopup(StaffUnitInfo UnitInfo)
+{
+	local XComGameState_HeadquartersRoom RoomState;
+
+	// Trigger the appropriate popup to tell the player about the benefit they have received by filling this staff slot
+	if (!GetMyTemplate().bPreventFilledPopup)
+	{
+		// If the unit just added is a ghost, update its location to its new staff slot before passing to the Alerts
+		if (UnitInfo.bGhostUnit)
+		{
+			UnitInfo.GhostLocation = GetReference();
+		}
+
+		RoomState = GetRoom();
+		if (RoomState != none)
+		{
+			if (RoomState.ClearingRoom)
+			{
+				`HQPRES.UIClearRoomSlotFilled(RoomState.GetReference(), UnitInfo);
+			}
+			else if (RoomState.UnderConstruction)
+			{
+				`HQPRES.UIConstructionSlotFilled(RoomState.GetReference(), UnitInfo);
+			}
+		}
+		else
+		{
+			`HQPRES.UIStaffSlotFilled(GetFacility().GetReference(), GetMyTemplate(), UnitInfo);
+		}
+	}
+}
+
+//---------------------------------------------------------------------------------------
+function bool ShouldDisplayToDoWarning()
+{
+	if (GetMyTemplate().ShouldDisplayToDoWarningFn != none)
+	{
+		return GetMyTemplate().ShouldDisplayToDoWarningFn(self.GetReference());
+	}
+
+	return true;
+}
+
+//---------------------------------------------------------------------------------------
+function string GetNameDisplayString()
+{
+	if(GetMyTemplate().GetNameDisplayStringFn != none)
+	{
+		return GetMyTemplate().GetNameDisplayStringFn(self);
+	}
+
+	return "MISSING DISPLAY INFO";
+}
+
+//---------------------------------------------------------------------------------------
+function string GetSkillDisplayString()
+{
+	if (GetMyTemplate().GetSkillDisplayStringFn != none)
+	{
+		return GetMyTemplate().GetSkillDisplayStringFn(self);
+	}
+
+	return "MISSING DISPLAY INFO";
+}
+
+//---------------------------------------------------------------------------------------
+function string GetBonusDisplayString(optional bool bPreview)
+{
+	if (GetMyTemplate().GetBonusDisplayStringFn != none)
+	{
+		return GetMyTemplate().GetBonusDisplayStringFn(self, bPreview);
+	}
+
+	return "MISSING BONUS DISPLAY INFO";
+}
+
+//---------------------------------------------------------------------------------------
+function string GetLocationDisplayString()
+{
+	if (GetMyTemplate().GetLocationDisplayStringFn != None)
+	{
+		return GetMyTemplate().GetLocationDisplayStringFn(self);
+	}
+
+	return "MISSING DISPLAY INFO";
+}
+
+//---------------------------------------------------------------------------------------
+function string GetUnitTypeImage()
+{
+	local XComGameState_Unit Unit;
+
+	Unit = GetAssignedStaff();
+
+	if (Unit != none)
+	{
+		if (Unit.IsEngineer())
+		{
+			return class'UIUtilities_Image'.const.EventQueue_Engineer;
+		}
+		else if (Unit.IsScientist())
+		{
+			return class'UIUtilities_Image'.const.EventQueue_Science;
+		}
+		else if (Unit.IsSoldier())
+		{
+			// Start Issue #408
+			return Unit.GetSoldierRankIcon();
+			// End Issue #408
+		}
+	}
+
+	return "";
+}
+
+//#############################################################################################
+//----------------   TYPE   ----------------------------------------------------------------
+//#############################################################################################
+
+//---------------------------------------------------------------------------------------
+function bool IsHidden()
+{
+	return GetMyTemplate().bHideStaffSlot;
+}
+
+//---------------------------------------------------------------------------------------
+function bool IsEngineerSlot()
+{
+	return GetMyTemplate().bEngineerSlot;
+}
+
+//---------------------------------------------------------------------------------------
+function bool IsScientistSlot()
+{
+	return GetMyTemplate().bScientistSlot;
+}
+
+//---------------------------------------------------------------------------------------
+function bool IsSoldierSlot()
+{
+	return GetMyTemplate().bSoldierSlot;
+}
+
+//#############################################################################################
+//----------------   HELPERS   ----------------------------------------------------------------
+//#############################################################################################
+
+//---------------------------------------------------------------------------------------
+function XComGameState_FacilityXCom GetFacility()
+{
+	local StateObjectReference EmptyRef;
+
+	if (Facility != EmptyRef)
+	{
+		return XComGameState_FacilityXCom(`XCOMHISTORY.GetGameStateForObjectID(Facility.ObjectID));
+	}
+	else
+		return None;
+}
+
+//---------------------------------------------------------------------------------------
+function XComGameState_HeadquartersRoom GetRoom()
+{
+	local StateObjectReference EmptyRef;
+
+	if (Room != EmptyRef)
+	{
+		return XComGameState_HeadquartersRoom(`XCOMHISTORY.GetGameStateForObjectID(Room.ObjectID));
+	}
+	else
+		return None;
+}
+
+//---------------------------------------------------------------------------------------
+function XComGameState_CovertAction GetCovertAction()
+{
+	local StateObjectReference EmptyRef;
+
+	if (CovertAction != EmptyRef)
+	{
+		return XComGameState_CovertAction(`XCOMHISTORY.GetGameStateForObjectID(CovertAction.ObjectID));
+	}
+	else
+		return None;
+}
+
+//---------------------------------------------------------------------------------------
+function XComGameState_StaffSlot GetLinkedStaffSlot()
+{
+	local StateObjectReference EmptyRef;
+
+	if(LinkedStaffSlot != EmptyRef)
+	{
+		return XComGameState_StaffSlot(`XCOMHISTORY.GetGameStateForObjectID(LinkedStaffSlot.ObjectID));
+	}
+	else
+		return None;
+}
+
+//---------------------------------------------------------------------------------------
+DefaultProperties
+{
+}

--- a/X2WOTCCommunityHighlander/X2WOTCCommunityHighlander.x2proj
+++ b/X2WOTCCommunityHighlander/X2WOTCCommunityHighlander.x2proj
@@ -110,6 +110,9 @@
     <Content Include="Src\XComGame\Classes\UIAlert.uc">
       <SubType>Content</SubType>
     </Content>
+    <Content Include="Src\XComGame\Classes\UIArmory_ImplantSlot.uc">
+      <SubType>Content</SubType>
+    </Content>
     <Content Include="Src\XComGame\Classes\UIArmory_Loadout.uc">
       <SubType>Content</SubType>
     </Content>
@@ -143,6 +146,9 @@
     <Content Include="Src\XComGame\Classes\UIButton.uc">
       <SubType>Content</SubType>
     </Content>
+    <Content Include="Src\XComGame\Classes\UIChosenMissionSummary.uc">
+      <SubType>Content</SubType>
+    </Content>
     <Content Include="Src\XComGame\Classes\UICovertActionStaffSlot.uc">
       <SubType>Content</SubType>
     </Content>
@@ -174,6 +180,9 @@
       <SubType>Content</SubType>
     </Content>
     <Content Include="Src\XComGame\Classes\UIAvengerHud_SoldierStatusIndicatorContainer.uc">
+      <SubType>Content</SubType>
+    </Content>
+    <Content Include="Src\XComGame\Classes\UIPersonnel_DropDownListItem.uc">
       <SubType>Content</SubType>
     </Content>
     <Content Include="Src\XComGame\Classes\UIPersonnel_SoldierListItem.uc">
@@ -357,6 +366,9 @@
       <SubType>Content</SubType>
     </Content>
     <Content Include="Src\XComGame\Classes\XComGameState_ResistanceFaction.uc">
+      <SubType>Content</SubType>
+    </Content>
+    <Content Include="Src\XComGame\Classes\XComGameState_StaffSlot.uc">
       <SubType>Content</SubType>
     </Content>
     <Content Include="Src\XComGame\Classes\XComGameState_WorldRegion.uc">


### PR DESCRIPTION
(**Note** This pull request also adds some implementation for #106 in places that seem to have been overlooked, such as in `UIChosenMissionSummary`)

Resolves issue #408. This pull request introduces the following methods to
`XComGameState_Unit` that trigger events that listeners can use to
override rank names and icons:

 - GetSoldierRankName()
 - GetSoldierShortRankName()
 - GetSoldierRankIcon()

The commit also updates all the bits of code (outside of TLE and
multiplayer) that display soldier ranks and their icons so that they use
the above methods.

Here are the events that are fired:

 - `{ID: SoldierRankName, Data: [in int Rank, out bool override, out
 string RankName]}`
 - `{ID: SoldierShortRankName, Data: [in int Rank, out bool override,
 out string RankName]}`
 - `{ID: SoldierRankIcon, Data: [in int Rank, out bool override, out
 string IconPath]}`

Note that the rank sent in the event may be -1, in which case the unit's
current rank is being requested.

The overall implementation is very similar to that of #106.