### PR TITLE
Add config option to disable minimum damage through armor

### DIFF
--- a/X2WOTCCommunityHighlander/Config/XComGameCore.ini
+++ b/X2WOTCCommunityHighlander/Config/XComGameCore.ini
@@ -18,7 +18,7 @@
 ;+CritUpgradesThatDontUseEffects="MyFancyTemplateName" ;For modders to use to specify upgrades in their mods that use Issue #237 functionality
 
 ; Issue 321
-; Set to false (vanilla behaviour) if you want to still damage the target by 1 even if armor is more than incoming damage
-; Set to true if you want damage that is less than target armor to be completely neutralized
+; Set to false/commented out (vanilla behaviour) if you want to still damage the target by 1 even if armor is more than incoming damage
+; Set to true/uncomment it if you want damage that is less than target armor to be completely neutralized
 [XComGame.X2Effect_ApplyWeaponDamage]
-+NO_MINIMUM_DAMAGE=false
+;+NO_MINIMUM_DAMAGE=true

--- a/X2WOTCCommunityHighlander/Config/XComGameCore.ini
+++ b/X2WOTCCommunityHighlander/Config/XComGameCore.ini
@@ -16,3 +16,9 @@
 
 [XComGame.X2AbilityToHitCalc_StandardAim]
 ;+CritUpgradesThatDontUseEffects="MyFancyTemplateName" ;For modders to use to specify upgrades in their mods that use Issue #237 functionality
+
+; Issue 321
+; Set to true (vanilla behaviour) if you want to still damage the target by 1 even if armor is more than incoming damage
+; Set to false if you want damage that is less than target armor to be completely neutralized
+[XComGame.X2Effect_ApplyWeaponDamage]
++ALWAYS_APPLY_MINIMUM_DAMAGE=true

--- a/X2WOTCCommunityHighlander/Config/XComGameCore.ini
+++ b/X2WOTCCommunityHighlander/Config/XComGameCore.ini
@@ -18,7 +18,7 @@
 ;+CritUpgradesThatDontUseEffects="MyFancyTemplateName" ;For modders to use to specify upgrades in their mods that use Issue #237 functionality
 
 ; Issue 321
-; Set to true (vanilla behaviour) if you want to still damage the target by 1 even if armor is more than incoming damage
-; Set to false if you want damage that is less than target armor to be completely neutralized
+; Set to false (vanilla behaviour) if you want to still damage the target by 1 even if armor is more than incoming damage
+; Set to true if you want damage that is less than target armor to be completely neutralized
 [XComGame.X2Effect_ApplyWeaponDamage]
-+ALWAYS_APPLY_MINIMUM_DAMAGE=true
++NO_MINIMUM_DAMAGE=false

--- a/X2WOTCCommunityHighlander/Src/XComGame/Classes/X2Effect_ApplyWeaponDamage.uc
+++ b/X2WOTCCommunityHighlander/Src/XComGame/Classes/X2Effect_ApplyWeaponDamage.uc
@@ -19,6 +19,9 @@ var bool    bIgnoreArmor;
 var bool	bBypassSustainEffects;
 var array<name> HideVisualizationOfResultsAdditional;
 
+// Issue #321
+var config bool ALWAYS_APPLY_MINIMUM_DAMAGE;
+
 // These values are extra amount an ability may add or apply directly
 var WeaponDamageValue EffectDamageValue;
 var int EnvironmentalDamageAmount;
@@ -1036,7 +1039,8 @@ simulated function int CalculateDamageAmount(const out EffectAppliedData ApplyEf
 				ArmorMitigation -= ArmorPiercing;				
 				if (ArmorMitigation < 0)
 					ArmorMitigation = 0;
-				if (ArmorMitigation >= WeaponDamage)
+				// Issue #321
+				if (ArmorMitigation >= WeaponDamage && default.ALWAYS_APPLY_MINIMUM_DAMAGE)
 					ArmorMitigation = WeaponDamage - 1;
 				if (ArmorMitigation < 0)    //  WeaponDamage could have been 0
 					ArmorMitigation = 0;    

--- a/X2WOTCCommunityHighlander/Src/XComGame/Classes/X2Effect_ApplyWeaponDamage.uc
+++ b/X2WOTCCommunityHighlander/Src/XComGame/Classes/X2Effect_ApplyWeaponDamage.uc
@@ -20,7 +20,7 @@ var bool	bBypassSustainEffects;
 var array<name> HideVisualizationOfResultsAdditional;
 
 // Issue #321
-var config bool ALWAYS_APPLY_MINIMUM_DAMAGE;
+var config bool NO_MINIMUM_DAMAGE;
 
 // These values are extra amount an ability may add or apply directly
 var WeaponDamageValue EffectDamageValue;
@@ -1040,7 +1040,7 @@ simulated function int CalculateDamageAmount(const out EffectAppliedData ApplyEf
 				if (ArmorMitigation < 0)
 					ArmorMitigation = 0;
 				// Issue #321
-				if (ArmorMitigation >= WeaponDamage && default.ALWAYS_APPLY_MINIMUM_DAMAGE)
+				if (ArmorMitigation >= WeaponDamage && !default.NO_MINIMUM_DAMAGE)
 					ArmorMitigation = WeaponDamage - 1;
 				if (ArmorMitigation < 0)    //  WeaponDamage could have been 0
 					ArmorMitigation = 0;    


### PR DESCRIPTION
Adds the config option ALWAYS_APPLY_MINIMUM_DAMAGE and a single change to an if-statement inside X2Effect_ApplyWeaponDamage. Tested in skirmish and works with guns, grenades, and shredding.
Closes issue #321 