### PR TITLE
Allow mods to control number of objective spawns (#463)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -86,7 +86,9 @@ All notable changes to Vanilla 'War Of The Chosen' Behaviour will be documented 
 - `OverrideVictoriousPlayer` to allow override whether a mission was successful or not (#266)
 - `OverrideItemSoundRange` to allow overriding an item's sound range (#363)
 - `OverrideHackingScreenType` and `HackIn2D` to allow hacking using a 2D movie and using
-  the Skulljack / ADVENT screen arbitrarily (#330)
+- Allow mods to override the number of objectives spawned for a mission via the new event
+  `OverrideObjectiveSpawnCount`, which is triggered as the objective spawns are being
+  selected by `XComTacticalMissionManager`. (#463)
 
 ### Configuration
 - Added ability to modify default spawn size (#18)

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -86,6 +86,7 @@ All notable changes to Vanilla 'War Of The Chosen' Behaviour will be documented 
 - `OverrideVictoriousPlayer` to allow override whether a mission was successful or not (#266)
 - `OverrideItemSoundRange` to allow overriding an item's sound range (#363)
 - `OverrideHackingScreenType` and `HackIn2D` to allow hacking using a 2D movie and using
+  the Skulljack / ADVENT screen arbitrarily (#330)
 - Allow mods to override the number of objectives spawned for a mission via the new event
   `OverrideObjectiveSpawnCount`, which is triggered as the objective spawns are being
   selected by `XComTacticalMissionManager`. (#463)

--- a/X2WOTCCommunityHighlander/Src/XComGame/Classes/XComTacticalMissionManager.uc
+++ b/X2WOTCCommunityHighlander/Src/XComGame/Classes/XComTacticalMissionManager.uc
@@ -1090,8 +1090,42 @@ private function array<ObjectiveSpawnPossibility> SelectObjectiveSpawns(Objectiv
 	local int NumToSelect;
 	local int AttemptCount;
 
-	NumToSelect = SpawnInfo.iMinObjectives + `SYNC_RAND_TYPED(SpawnInfo.iMaxObjectives - SpawnInfo.iMinObjectives);
+	// Start Issue #463
+	//	
+	// Vars
+	local XComGameState_BattleData BattleData;
+	local XComLWTuple OverrideTuple;
+	
+    BattleData = XComGameState_BattleData(`XCOMHISTORY.GetSingleGameStateObjectForClass(class'XComGameState_BattleData'));
 
+	// Fix the random range to correct an off-by-one error so that the max objective count is possible to spawn.
+	NumToSelect = SpawnInfo.iMinObjectives + `SYNC_RAND_TYPED(SpawnInfo.iMaxObjectives - SpawnInfo.iMinObjectives + 1);
+
+    // If we have battle info with a mission ID, see if any mods want
+	// to specify the number of objectives to use by passing this
+	// BattleData to them via an event.
+	//
+	// The event takes the form:
+	//   {
+	//       ID: OverrideObjectiveSpawnCount,
+	//       Data: [ in BattleData BattleData, out int SpawnCount ]
+	//   }
+    if (BattleData != none && BattleData.m_iMissionID > 0)
+    {
+		OverrideTuple = new class'XComLWTuple';
+		OverrideTuple.Id = 'OverrideObjectiveSpawnCount';
+		OverrideTuple.Data.Add(2);
+		OverrideTuple.Data[0].kind = XComLWTVObject;
+		OverrideTuple.Data[0].o = BattleData;
+		OverrideTuple.Data[1].kind = XComLWTVInt;
+		OverrideTuple.Data[1].i = NumToSelect;
+		
+		`XEVENTMGR.TriggerEvent('OverrideObjectiveSpawnCount', OverrideTuple, self);
+		
+		NumToSelect = OverrideTuple.Data[1].i;
+    }
+	// End Issue #463
+	
 	if(SpawnInfo.iMinTilesBetweenObjectives <= 0)
 	{
 		// simple case where we don't care about distance, so just select at random


### PR DESCRIPTION
This change adds an event trigger to `XComTacticalMissionManager` that allows
listeners to override the number of objective spawns for a mission. This is
important if a mod needs to sync the number of objective spawns with some
other data, such as the rewards for the mission.

The event takes the form of:

```
{
  ID: OverrideObjectiveSpawnCount,
  Data: [ in BattleData BattleData, out int SpawnCount]
}
```