### PR TITLE
Copy `bRemovedFromPlay` flag from proxy VIP units (#465)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -217,6 +217,9 @@ All notable changes to Vanilla 'War Of The Chosen' Behaviour will be documented 
   no broken duo poses for units that can't play them (#309)
 - Additional Photobooth particle system enums for mods (#359)
 - Tweaks to "Resistance Archives" random Legacy Operations UI. Restarts show the correct locked difficulty, and a crash condition on backing out of a restart fixed. (#307)
+- Allow mods to check whether VIP units left a mission successfully via the `bRemovedFromPlay`
+  flag on `XComGameState_Unit`. This behavior is gated behind the new `CHHelpers.PreserveProxyUnitData`
+  config variable. (#465)
 
 
 ### Fixes

--- a/X2WOTCCommunityHighlander/Config/XComGame.ini
+++ b/X2WOTCCommunityHighlander/Config/XComGame.ini
@@ -24,3 +24,5 @@ bEnableVersionDisplay=true
 
 ;bDontUnequipWhenWounded=true ; Set to true to make soldier keep their gear when wounded
 ;bDontUnequipCovertOps=true ; Uncomment to make soldiers on covert ops keep their gear even if ambush risk is 0
+
+;PreserveProxyUnitData=true ; Set to true to make sure important info on proxy VIP units is copied to the original units

--- a/X2WOTCCommunityHighlander/Src/XComGame/Classes/CHHelpers.uc
+++ b/X2WOTCCommunityHighlander/Src/XComGame/Classes/CHHelpers.uc
@@ -110,6 +110,10 @@ var config(Content) array<name> EyeMaterial;
 var config(Content) array<name> FlagMaterial;
 // End Issue #356
 
+// Start Issue #465
+var config bool PreserveProxyUnitData;
+// End Issue #465
+
 // Start Issue #123
 simulated static function RebuildPerkContentCache() {
 	local XComContentManager		Content;

--- a/X2WOTCCommunityHighlander/Src/XComGame/Classes/XComGameStateContext_StrategyGameRule.uc
+++ b/X2WOTCCommunityHighlander/Src/XComGame/Classes/XComGameStateContext_StrategyGameRule.uc
@@ -1293,6 +1293,13 @@ static function CleanupProxyVips()
 			OriginalUnit.SetCurrentStat(eStat_HP, ProxyUnit.GetCurrentStat(eStat_HP));
 		}
 
+		// Start Issue #465
+		if (class'CHHelpers'.default.PreserveProxyUnitData && ProxyUnit.bRemovedFromPlay)
+		{
+			OriginalUnit.RemoveStateFromPlay();
+		}
+		// End Issue #465
+		
 		// remove the proxy from the game. We don't need it anymore
 		NewGameState.RemoveStateObject(ProxyUnit.ObjectID);
 	}


### PR DESCRIPTION
Mods were unable to check whether VIP units left a mission or not because the
`bRemovedFromPlay` flag was not being copied across to the original reward
unit. This change fixes that behaviour if the `CHHelpers.PreserveProxyUnitData`
config variable is set to `true`.