### PR TITLE
Add new events to customise unit status strings (#322)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -44,6 +44,12 @@ All notable changes to Vanilla 'War Of The Chosen' Behaviour will be documented 
 - Triggers the event `ShouldCleanupCovertAction` to allow mod control over Covert Action deletion. (#435)
 - Triggers the event `BlackMarketGoodsReset` when the Black Market goods are reset (#473)
 - Triggers the event `OverrideImageForItemAvaliable` to allow mods to override the image shown in eAlert_ItemAvailable (#491)
+- Triggers the event `CustomizeStatusStringsSeparate` in XComGameState_Unit::GetStatusStringsSeparate (#322)
+- Triggers the event `OverridePersonnelStatus` in UIUtilities_Strategy::GetPersonnelStatusStringParts. This
+  allows listeners the opportunity to override the status, its time remaining and its colour. (#322)
+- Triggers the event `OverridePersonnelStatusTime` in a number of places to allow listeners to change the way
+  unit status times (like how long is left on a covert action) are displayed. For example, a listener could
+  display a time in hours rather than days, perhaps based on how many hours are left. (#322)
 
 ### Modding Exposures
 - Allows mods to add custom items to the Avenger Shortcuts (#163)

--- a/X2WOTCCommunityHighlander/Src/XComGame/Classes/CHHelpers.uc
+++ b/X2WOTCCommunityHighlander/Src/XComGame/Classes/CHHelpers.uc
@@ -122,6 +122,10 @@ var config array<name> RequiresTargetingActivation;
 var config array<name> AdditionalAmbushRiskTemplates;
 // End Issue #485
 
+// Start Issue #322
+var config bool UseNewPersonnelStatusBehavior;
+// End Issue #322
+
 // Start Issue #123
 simulated static function RebuildPerkContentCache() {
 	local XComContentManager		Content;

--- a/X2WOTCCommunityHighlander/Src/XComGame/Classes/UIUtilities_Strategy.uc
+++ b/X2WOTCCommunityHighlander/Src/XComGame/Classes/UIUtilities_Strategy.uc
@@ -817,6 +817,7 @@ static function GetPersonnelStatusStringParts(
 	local string sTimeValueString;
 	local bool bHideZeroDays, bIsMentalState;
 
+	bIsMentalState = false;
 	bHideZeroDays = true;
 	HideTime = 0;
 
@@ -871,6 +872,7 @@ static function GetPersonnelStatusStringParts(
 		{
 			Unit.GetMentalStateStringsSeparate(Status, TimeLabel, iTimeNum);
 			eState = Unit.GetMentalStateUIState();
+			bIsMentalState = true;
 		}
 		else if (Unit.IsPsiTraining() || Unit.IsPsiAbilityTraining())
 		{
@@ -892,6 +894,7 @@ static function GetPersonnelStatusStringParts(
 		{
 			Unit.GetMentalStateStringsSeparate(Status, TimeLabel, iTimeNum);
 			eState = Unit.GetMentalStateUIState();
+			bIsMentalState = true;
 		}
 		else
 		{

--- a/X2WOTCCommunityHighlander/Src/XComGame/Classes/UIUtilities_Strategy.uc
+++ b/X2WOTCCommunityHighlander/Src/XComGame/Classes/UIUtilities_Strategy.uc
@@ -650,10 +650,47 @@ static function string GetPersonnelLocation( XComGameState_Unit Unit, optional i
 		return class'UIUtilities_Text'.static.GetSizedText(default.m_strUnassignedPersonnelLocation, FontSize);
 }
 
-static function string GetPersonnelStatus( XComGameState_Unit Unit, optional int FontSize = -1 )
+// Start Issue #322
+//
+// This is a massive refactoring of GetPersonnelStatus() and GetPersonnelStatusSeparate()
+// to ensure consistency and also provide mods the ability to override a unit's status
+// strings.
+//
+// See TriggerOverridePersonnelStatus() and TriggerOverridePersonnelStatusTime() below for
+// details of the events that mods can listen to.
+static function string GetPersonnelStatus(XComGameState_Unit Unit, optional int FontSize = -1)
 {
 	local string ShakenStr;
+	local string Status, TimeLabel, TimeValue;
+	local EUIState eState;
+	local int HideTime;
 
+	// By setting this to -1 we can easily tell whether it's been overridden
+	// by listeners, since it's an invalid enum value.
+	eState = -1;
+
+	// This condition and guard variable added as part of issue #322
+	if (class'CHHelpers'.default.UseNewPersonnelStatusBehavior)
+	{
+		// Issue #322
+		//
+		// New code path that goes through GetPersonnelStatusStringParts() for consistency and so 
+		// that this works with mods that override the personnel status.
+		GetPersonnelStatusStringParts(Unit, Status, eState, TimeLabel, TimeValue, HideTime, true);
+		if (eState == -1)
+		{
+			return class'UIUtilities_Text'.static.GetSizedText(FormatStatusString(Status, TimeLabel, TimeValue, HideTime != 0), FontSize);
+		}
+		else
+		{
+			return class'UIUtilities_Text'.static.GetColoredText(
+				FormatStatusString(Status, TimeLabel, TimeValue, HideTime != 0),
+				eState,
+				FontSize);
+		}
+	}
+	
+	// This branch of the condition is the old code that basically ignores GetPersonnelStatusSeparate()
 	if (Unit.IsScientist() || Unit.IsEngineer())
 	{
 		if (Unit.IsInjured())
@@ -692,32 +729,129 @@ static function string GetPersonnelStatus( XComGameState_Unit Unit, optional int
 	return "MISSING DATA";
 }
 
+// Issue #322
+//
+// New method for creating a simple formatted string from a status and time remaining.
+static function string FormatStatusString(string Status, string TimeLabel, string TimeValue, optional bool HideTime = false)
+{
+	local string FormattedStatus;
+	
+	FormattedStatus = Status;
+
+	if (!HideTime)
+	{
+		FormattedStatus = FormattedStatus @ "(" $ TimeValue @ TimeLabel $ ")";
+	}
+	return FormattedStatus;
+}
+
+// Issue #322
+//
+// This function is intended to work as before, but most of its implementation
+// has been moved to GetPersonnelStatusStringParts() below.
 static function GetPersonnelStatusSeparate(XComGameState_Unit Unit, out string Status, out string TimeLabel, out string TimeValue, optional int FontSize = -1, optional bool bIncludeMentalState = false)
 {
-	local EUIState eState; 
-	local int TimeNum;
-	local bool bHideZeroDays;
+	local EUIState eState;
+	local int bHideTimePart;
+
+	// By setting this to -1 we can easily tell whether it's been overridden
+	// by listeners, since it's an invalid enum value.
+	eState = -1;
+
+	GetPersonnelStatusStringParts(Unit, Status, eState, TimeLabel, TimeValue, bHideTimePart, bIncludeMentalState);
+
+	if (eState == -1)
+	{
+		// State was not set, so don't use colored text.
+		Status = class'UIUtilities_Text'.static.GetSizedText(Status, FontSize);
+		TimeLabel = class'UIUtilities_Text'.static.GetSizedText(TimeLabel, FontSize);
+	}
+	else
+	{
+		Status = class'UIUtilities_Text'.static.GetColoredText(Status, eState, FontSize);
+		TimeLabel = class'UIUtilities_Text'.static.GetColoredText(TimeLabel, eState, FontSize);
+	}
+
+	if (bHideTimePart != 0)
+	{
+		TimeValue = "";
+	}
+	else
+	{
+		TimeValue = class'UIUtilities_Text'.static.GetColoredText(TimeValue, eState, FontSize);
+	}
+}
+
+// Provides the details about a unit's status as a set of out parameters. It allows mods to
+// override each part via an event described with TriggerOverridePersonnelStatus() below.
+// There is also another event - TriggerOverridePersonnelStatusTime() - that allows mods to
+// override how the time remaining (if a status has such) is displayed. This is particularly
+// useful for mods that want to change the cutoff point at which hours are displayed versus
+// days.
+//
+//   Unit		The unit whose status you want.
+//   Status		The status type as a string, such as "Wounded".
+//   eState		An enum that indicates whether this status is bad, good, or some other state.
+//   			This may not be set, in which case it will return whatever value you passed in.
+//   			You can pass in -1 and check for that value to determine whether the state has
+//   			been set or not.
+//   TimeLabel	The unit of time as a label, e.g. "Days", "Day", "Hours", etc.
+//   TimeValue	The number of units of time left for the status. What the value represents
+//   			depends on what the label is (typically "Days" or "Hours").
+//   HideTime   Indicates whether you should display the time value and label or not. 0 means
+//   			don't hide it, i.e. display it. Any other value means the opposite.
+//   IncludeMentalState		Indicates whether you want any mental statuses or not. If false,
+//   						then you won't get will-related statuses like Tired. Note that
+//   						you will always get Shaken (if applicable) even if this is false.
+//
+static function GetPersonnelStatusStringParts(
+		XComGameState_Unit Unit,
+		out string Status,
+		out EUIState eState,
+		out string TimeLabel,
+		out string TimeValue,
+		out int HideTime,
+		optional bool IncludeMentalState = false)
+{
+	local int iTimeNum, iDays, iDoTimeConversion;
+	local bool bHideZeroDays, bIsMentalState;
 
 	bHideZeroDays = true;
+	HideTime = 0;
 
-	if(Unit.IsMPCharacter())
+	if (Unit.IsMPCharacter())
 	{
 		Status = default.m_strAvailableStatus;
 		eState = eUIState_Good;
-		TimeNum = 0;
-		Status = class'UIUtilities_Text'.static.GetColoredText(Status, eState, FontSize);
+		HideTime = 1;
 		return;
 	}
 
 	// template names are set in X2Character_DefaultCharacters.uc
 	if (Unit.IsScientist() || Unit.IsEngineer())
 	{
-		Status = class'UIUtilities_Text'.static.GetSizedText(Unit.GetLocation(), FontSize);
+		// CHL: The old GetPersonnelStatusSeparate() implementation just returned the
+		// location, but I think that's because it was never called for any unit other
+		// than soldiers. This seems more correct.
+		if (Unit.IsInjured())
+		{
+			Unit.GetStatusStringsSeparate(Status, TimeLabel, iTimeNum);
+			eState = eUIState_Bad;
+		}
+		else if (Unit.IsOnCovertAction())
+		{
+			Unit.GetStatusStringsSeparate(Status, TimeLabel, iTimeNum);
+			eState = eUIState_Warning;
+		}
+		else 
+		{
+			Status = Unit.GetLocation();
+		}
 	}
 	else if (Unit.IsSoldier())
 	{
 		// soldiers get put into the hangar to indicate they are getting ready to go on a mission
-		if(`HQPRES != none &&  `HQPRES.ScreenStack.IsInStack(class'UISquadSelect') && GetXComHQ().IsUnitInSquad(Unit.GetReference()) )
+		if (`HQPRES != none &&  `HQPRES.ScreenStack.IsInStack(class'UISquadSelect') && GetXComHQ().IsUnitInSquad(Unit.GetReference()))
 		{
 			Status = default.m_strOnMissionStatus;
 			eState = eUIState_Highlight;
@@ -727,51 +861,77 @@ static function GetPersonnelStatusSeparate(XComGameState_Unit Unit, out string S
 			Status = default.m_strBoostedStatus;
 			eState = eUIState_Warning;
 		}
-		else if( Unit.IsInjured() || Unit.IsDead() )
+		else if (Unit.IsInjured() || Unit.IsDead())
 		{
-			Unit.GetStatusStringsSeparate(Status, TimeLabel, TimeNum);
+			Unit.GetStatusStringsSeparate(Status, TimeLabel, iTimeNum);
 			eState = eUIState_Bad;
 		}
-		else if(Unit.GetMentalState() == eMentalState_Shaken)
+		else if (Unit.GetMentalState() == eMentalState_Shaken)
 		{
-			Unit.GetMentalStateStringsSeparate(Status, TimeLabel, TimeNum);
+			Unit.GetMentalStateStringsSeparate(Status, TimeLabel, iTimeNum);
 			eState = Unit.GetMentalStateUIState();
 		}
-		else if( Unit.IsPsiTraining() || Unit.IsPsiAbilityTraining() )
+		else if (Unit.IsPsiTraining() || Unit.IsPsiAbilityTraining())
 		{
-			Unit.GetStatusStringsSeparate(Status, TimeLabel, TimeNum);
+			Unit.GetStatusStringsSeparate(Status, TimeLabel, iTimeNum);
 			eState = eUIState_Psyonic;
 		}
-		else if( Unit.IsTraining() )
+		else if (Unit.IsTraining())
 		{
-			Unit.GetStatusStringsSeparate(Status, TimeLabel, TimeNum);
+			Unit.GetStatusStringsSeparate(Status, TimeLabel, iTimeNum);
 			eState = eUIState_Warning;
 		}
-		else if(  Unit.IsOnCovertAction() )
+		else if (Unit.IsOnCovertAction())
 		{
-			Unit.GetStatusStringsSeparate(Status, TimeLabel, TimeNum);
+			Unit.GetStatusStringsSeparate(Status, TimeLabel, iTimeNum);
 			eState = eUIState_Warning;
 			bHideZeroDays = false;
 		}
-		else if(bIncludeMentalState && Unit.BelowReadyWillState())
+		else if (IncludeMentalState && Unit.BelowReadyWillState())
 		{
-			Unit.GetMentalStateStringsSeparate(Status, TimeLabel, TimeNum);
+			Unit.GetMentalStateStringsSeparate(Status, TimeLabel, iTimeNum);
 			eState = Unit.GetMentalStateUIState();
 		}
 		else
 		{
 			Status = default.m_strAvailableStatus;
 			eState = eUIState_Good;
-			TimeNum = 0;
+			iTimeNum = 0;
 		}
 	}
 
-	Status = class'UIUtilities_Text'.static.GetColoredText(Status, eState, FontSize);
-	TimeLabel = class'UIUtilities_Text'.static.GetColoredText(TimeLabel, eState, FontSize);
-	if( TimeNum == 0 && bHideZeroDays )
-		TimeValue = "";
+	// If this is one of the base game statuses, then the duration is already
+	// set to the appropriate unit (hours/days). We only have to do the conversion
+	// if a listener wants us to (because they have overridden the duration,
+	// iTimeNum, with a new number of hours, but want to delegate the conversion).
+	TriggerOverridePersonnelStatus(Unit, Status, eState, TimeLabel, iTimeNum, HideTime, iDoTimeConversion);
+
+	if (iDoTimeConversion != 0 && HideTime == 0)
+	{
+		iDays = FCeil(float(iTimeNum) / 24.0);
+
+		// Let listeners override label and time value. If label is still empty,
+		// assume that the values aren't overridden. This is on the basis that
+		// any time should have a label.
+		TimeLabel = "";
+		TriggerOverridePersonnelStatusTime(Unit, bIsMentalState, TimeLabel, iTimeNum);
+
+		if (TimeLabel == "")
+		{
+			TimeLabel = class'UIUtilities_Text'.static.GetDaysString(iDays);
+			iTimeNum = iDays;
+		}
+		TimeValue = string(iTimeNum);
+	}
 	else
-		TimeValue = class'UIUtilities_Text'.static.GetColoredText(string(TimeNum), eState, FontSize);
+	{
+		TimeValue = string(iTimeNum);
+	}
+	
+	if (bHideZeroDays && iTimeNum == 0)
+	{
+		HideTime = 1;
+	}
 
 	//Do this after the initial status coloring, since Shaken is colored separately.  
 	//if( Unit.bIsShaken )
@@ -779,6 +939,100 @@ static function GetPersonnelStatusSeparate(XComGameState_Unit Unit, out string S
 	//	Status = class'UIUtilities_Text'.static.GetColoredText(default.m_strShakenStatus, eUIState_Bad, FontSize) @ Status; 
 	//}
 }
+
+// Triggers an 'OverridePersonnelStatus' event that allows listeners to override the
+// status of a unit. See GetPersonnelStatusStringParts() for a description of the
+// parameters, although note that it provides the integer TimeNum in place of the
+// string TimeValue. This is so that the time can be used for calculations easily.
+//
+// Listeners can either provide the amount of time plus a label to go with it, like
+// 3 + "Days", or it can set the provide the amount of time in hours and set the
+// DoTimeConversion value to true. In this latter case, the CHL will generate the
+// appropriate time label (which it may delegate to listeners of
+// 'OverridePersonnelStatusTime').
+//
+// The event itself takes the form:
+//
+//   {
+//      ID: OverridePersonnelStatus,
+//      Data: [inout string Status, inout string TimeLabel, inout int TimeNum,
+//             inout int State, inout bool HideTime, inout bool DoTimeConversion],
+//      Source: Unit
+//   }
+//
+static function TriggerOverridePersonnelStatus(
+	XComGameState_Unit Unit,
+	out string Status,
+	out EUIState eState,
+	out string TimeLabel,
+	out int TimeNum,
+	out int HideTime,
+	out int DoTimeConversion)
+{
+	local XComLWTuple OverrideTuple;
+
+	OverrideTuple = new class'XComLWTuple';
+	OverrideTuple.Id = 'OverridePersonnelStatus';
+	OverrideTuple.Data.Add(6);
+	OverrideTuple.Data[0].kind = XComLWTVString;
+	OverrideTuple.Data[0].s = Status;
+	OverrideTuple.Data[1].kind = XComLWTVString;
+	OverrideTuple.Data[1].s = TimeLabel;
+	OverrideTuple.Data[2].kind = XComLWTVInt;
+	OverrideTuple.Data[2].i = TimeNum;
+	OverrideTuple.Data[3].kind = XComLWTVInt;
+	OverrideTuple.Data[3].i = int(eState);
+	OverrideTuple.Data[4].kind = XComLWTVBool;
+	OverrideTuple.Data[4].b = HideTime != 0;
+	OverrideTuple.Data[5].kind = XComLWTVBool;
+	OverrideTuple.Data[5].b = DoTimeConversion != 0;
+
+	`XEVENTMGR.TriggerEvent('OverridePersonnelStatus', OverrideTuple, Unit);
+
+	Status = OverrideTuple.Data[0].s;
+	TimeLabel = OverrideTuple.Data[1].s;
+	TimeNum = OverrideTuple.Data[2].i;
+	eState = EUIState(OverrideTuple.Data[3].i);
+	HideTime = OverrideTuple.Data[4].b ? 1 : 0;
+	DoTimeConversion = OverrideTuple.Data[5].b ? 1 : 0;
+}
+
+// Triggers an 'OverridePersonnelStatusTime' event that allows listeners to override
+// the time label and value for a unit status. For example, it can be used to change
+// from hours to days or vice versa.
+//
+// The event itself takes the form:
+//
+//   {
+//      ID: OverridePersonnelStatusTime,
+//      Data: [in bool IsMentalState, out string TimeLabel, out int TimeNum],
+//      Source: Unit
+//   }
+//	
+static function TriggerOverridePersonnelStatusTime(
+	XComGameState_Unit Unit,
+	bool IsMentalState,
+	out string TimeLabel,
+	out int TimeNum)
+{
+	local XComLWTuple OverrideTuple;
+
+	OverrideTuple = new class'XComLWTuple';
+	OverrideTuple.Id = 'OverridePersonnelStatusTime';
+	OverrideTuple.Data.Add(4);
+	OverrideTuple.Data[0].kind = XComLWTVBool;
+	OverrideTuple.Data[0].b = IsMentalState;
+	OverrideTuple.Data[1].kind = XComLWTVString;
+	OverrideTuple.Data[1].s = TimeLabel;
+	OverrideTuple.Data[2].kind = XComLWTVInt;
+	OverrideTuple.Data[2].i = TimeNum;
+
+	`XEVENTMGR.TriggerEvent('OverridePersonnelStatusTime', OverrideTuple, Unit);
+
+	TimeLabel = OverrideTuple.Data[1].s;
+	TimeNum = OverrideTuple.Data[2].i;
+}
+// End Issue #322
 
 simulated static function array<XComGameState_Item> GetEquippedUtilityItems(XComGameState_Unit Unit, optional XComGameState CheckGameState)
 {

--- a/X2WOTCCommunityHighlander/Src/XComGame/Classes/XComGameState_Unit.uc
+++ b/X2WOTCCommunityHighlander/Src/XComGame/Classes/XComGameState_Unit.uc
@@ -5158,7 +5158,8 @@ function GetStatusStringsSeparate(out string Status, out string TimeLabel, out i
 {
 	local bool bProjectExists;
 	local int iHours, iDays;
-	
+	local int iDoTimeConversion;  // Issue #322
+
 	if( IsInjured() )
 	{
 		Status = GetWoundStatus(iHours);
@@ -5186,7 +5187,16 @@ function GetStatusStringsSeparate(out string Status, out string TimeLabel, out i
 		Status = "";
 	}
 	
-	if (bProjectExists)
+	// Start Issue #322
+	//
+	// Allow mods to override the duration and label. If listeners want to
+	// delegate the hours/days handling to the highlander, i.e. iDoTimeConversion
+	// is true, then the TimeValue must be a value in hours.
+	iDoTimeConversion = bProjectExists ? 1 : 0;
+	TriggerCustomizeStatusStringsSeparate(Status, TimeLabel, TimeValue, iDoTimeConversion);
+	// End Issue #322
+	
+	if (iDoTimeConversion != 0)  // Issue #322: Add iDoTimeConversion check
 	{
 		iDays = iHours / 24;
 
@@ -5195,10 +5205,73 @@ function GetStatusStringsSeparate(out string Status, out string TimeLabel, out i
 			iDays += 1;
 		}
 
-		TimeValue = iDays;
-		TimeLabel = class'UIUtilities_Text'.static.GetDaysString(iDays);
+		// Issue #322
+		//
+		// Let listeners override label and time value. If label is still empty,
+		// assume that the values aren't overridden. This is on the basis that
+		// any time should have a label.
+		TimeLabel = "";
+		TimeValue = iHours;
+		class'UIUtilities_Strategy'.static.TriggerOverridePersonnelStatusTime(self, false, TimeLabel, TimeValue);
+
+		if (TimeLabel == "")
+		{
+			TimeValue = iDays;
+			TimeLabel = class'UIUtilities_Text'.static.GetDaysString(iDays);
+		}
+		// End Issue #322
 	}
 }
+
+// Start Issue #322
+//
+// Triggers a 'CustomizeStatusStringsSeparate' event that allows listeners to override
+// the status of a unit.
+//
+// Listeners can either provide the amount of time plus a label to go with it, like
+// 3 + "Days", in which case they should set DoTimeConversion to false. Otherwise,
+// they should set DoTimeConversion to true and provide the amount of time in hours.
+// In this latter case, the CHL will generate the appropriate time label (which it
+// may delegate to listeners of 'OverridePersonnelStatusTime').
+//
+// The event itself takes the form:
+//
+//   {
+//      ID: CustomizeStatusStringsSeparate,
+//      Data: [inout bool DoTimeConversion, inout string Status,
+//             inout string TimeLabel, inout int TimeValue],
+//      Source: self
+//   }
+//
+function TriggerCustomizeStatusStringsSeparate(
+	out string Status,
+	out string TimeLabel,
+	out int TimeValue,
+	out int DoTimeConversion)
+{
+	local XComLWTuple Tuple;
+
+	Tuple = new class'XComLWTuple';
+	Tuple.Id = 'CustomizeStatusStringsSeparate';
+	Tuple.Data.Add(4);
+	Tuple.Data[0].kind = XComLWTVBool;
+	Tuple.Data[0].b = DoTimeConversion != 0;
+	Tuple.Data[1].kind = XComLWTVString;
+	Tuple.Data[1].s = Status;
+	Tuple.Data[2].kind = XComLWTVString;
+	Tuple.Data[2].s = TimeLabel;
+	Tuple.Data[3].kind = XComLWTVInt;
+	Tuple.Data[3].i = TimeValue;
+
+	`XEVENTMGR.TriggerEvent('CustomizeStatusStringsSeparate', Tuple, self);
+
+	DoTimeConversion = Tuple.Data[0].b ? 1 : 0;
+	Status = Tuple.Data[1].s;
+	TimeLabel = Tuple.Data[2].s;
+	TimeValue = Tuple.Data[3].i;
+}
+// End Issue #322
+
 //-------------------------------------------------------------------------
 // Returns a UI state (color) that matches the soldier's status
 function int GetStatusUIState()
@@ -13275,6 +13348,7 @@ function GetMentalStateStringsSeparate(out string Status, out string TimeLabel, 
 	local XComGameStateHistory History;
 	local XComGameState_HeadquartersProjectRecoverWill WillProject;
 	local int iDays;
+	local int iHours;  // Issue #322
 
 	History = `XCOMHISTORY;
 	Status = GetMentalStateLabel();
@@ -13287,14 +13361,25 @@ function GetMentalStateStringsSeparate(out string Status, out string TimeLabel, 
 		{
 			if(WillProject.ProjectFocus.ObjectID == self.ObjectID)
 			{
-				iDays = WillProject.GetCurrentNumDaysRemaining();
-				TimeValue = iDays;
-				if (TimeValue == 0)
+				// Start Issue #322
+				//
+				// Get the project length in hours so that it can be easily overridden by mods
+				// that want to display the time in hours rather than days.
+				TimeValue = WillProject.GetCurrentNumHoursRemaining();
+				
+				class'UIUtilities_Strategy'.static.TriggerOverridePersonnelStatusTime(self, true, TimeLabel, TimeValue);
+				
+				// If no override has been provided, i.e. the time label is still an empty
+				// string, then default to the old behavior.
+				if (TimeLabel == "")
 				{
+					iDays = WillProject.GetCurrentNumDaysRemaining();
+
 					// Even if there isn't any time left, add a day to the string so it displays some time remaining in the UI
-					TimeValue = 1;
+					TimeLabel = class'UIUtilities_Text'.static.GetDaysString(iDays);
+					TimeValue = iDays > 0 ? iDays : 1;
 				}
-				TimeLabel = class'UIUtilities_Text'.static.GetDaysString(iDays);
+				// End Issue #322
 				break;
 			}
 		}

--- a/X2WOTCCommunityHighlander/Src/XComGame/Classes/XComGameState_Unit.uc
+++ b/X2WOTCCommunityHighlander/Src/XComGame/Classes/XComGameState_Unit.uc
@@ -13348,7 +13348,6 @@ function GetMentalStateStringsSeparate(out string Status, out string TimeLabel, 
 	local XComGameStateHistory History;
 	local XComGameState_HeadquartersProjectRecoverWill WillProject;
 	local int iDays;
-	local int iHours;  // Issue #322
 
 	History = `XCOMHISTORY;
 	Status = GetMentalStateLabel();


### PR DESCRIPTION
Further to an earlier pull request, this change adds two extra events that
allow mods to customise unit status strings.

The first is 'OverridePersonnelStatus', which can override the status strings
determined by `GetPersonnelStatusSeparate()`. The event takes the form:

   {
      ID: OverridePersonnelStatus,
      Data: [out string Status, out string TimeLabel, out int TimeNum,
             out int State, out bool HideTime],
      Source: Unit
   }

The second event is 'OverridePersonnelStatusTime', which can override the
time parts of the status, for example by converting days to hours or vice
versa. The event takes the form:

   {
      ID: OverridePersonnelStatusTime,
      Data: [out string TimeLabel, out int TimeNum],
      Source: Unit
   }

This commit also introduces a new config variable -
CHHelpers.UseNewPersonnelStatusBehavior - that, when set, makes
GetPersonnelStatus() go through GetPersonnelStatusSeparate(). This is
to help ensure consistency between the two methods.

Finally, GetStatusStringsSeparate() and GetMentalStateStringsSeparate()
in XComGameState_Unit now trigger the 'OverridePersonnelStatusTime' event
so that listeners can override how times are displayed in those cases.