### PR TITLE
Fix pathing issue for flying units (#503)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -77,6 +77,8 @@ All notable changes to Vanilla 'War Of The Chosen' Behaviour will be documented 
 - Fix Loadout utility items when unit has an item equipped in the Ammo Pocket (#99)
 - Fix units unequipping items they shouldn't, resulting in duplicate Paired Weapons (#189)
 - Fix all Covert Actions from being removed when generating covert actions (#435)
+- Fix a pathing issue in base game with "flying" pod leaders where non-flat tiles on their
+  paths prevent them from patrolling (#503)
 
 ## Tactical
 

--- a/X2WOTCCommunityHighlander/Src/XComGame/Classes/XGAIBehavior.uc
+++ b/X2WOTCCommunityHighlander/Src/XComGame/Classes/XGAIBehavior.uc
@@ -9638,6 +9638,16 @@ function bool GetTileWithinOneActionPointMove( TTile kTileIn, out TTile kTileOut
 			{
 				continue;
 			}
+
+			// Start Issue #503
+			//
+			// Bugfix for flying units - the path will often have above-ground tiles on
+			// each point along the path except the start and end, so we need to reset
+			// each potential stopping point to the floor level before testing if it's
+			// in movement range, otherwise it will always return "-1" for an invalid end
+			// point tile that's above ground.
+			kCurrTile.Z = XWorld.GetFloorTileZ(kCurrTile, true);
+			// End Issue #503
 			if( IsWithinMovementRange(kCurrTile, bAllowDashMovement) )
 			{
 				kTileOut = kCurrTile;


### PR DESCRIPTION
Pods that have a "flying" unit (like an Archon or drone) were not
patrolling properly because the logic for calculating the tile paths was
treating any non-flat tile as impassable.

This fix comes straight from the original LW2 and has been tested with
ADVENT and drone patrols.