### PR TITLE
Allow the git commit versioning to be used when the CHL is a submodule

### DIFF
--- a/.scripts/update_version.ps1
+++ b/.scripts/update_version.ps1
@@ -37,8 +37,29 @@ $fileNames = Get-ChildItem -Path $srcDirectory -Recurse -Include "*Version*.uc"
 for ($i = 0; $i -lt $fileNames.Length; $i++) {
 	$target_file = $fileNames[$i]
 	$content = Get-Content $target_file | Out-String
+	
 	if ($content -match '// AUTO-CODEGEN: Version-Info\s*defaultproperties\s*{[^}]*}') {
-		Write-Host $target_file
-		((($content) -replace '// AUTO-CODEGEN: Version-Info\s*defaultproperties\s*{[^}]*}', $version_block) -replace "%COMMIT%", $version_commit) | Set-Content $target_file -NoNewline
+		$new_content = (($content) -replace '// AUTO-CODEGEN: Version-Info\s*defaultproperties\s*{[^}]*}', $version_block) -replace "%COMMIT%", $version_commit;
+		$cached_file_path = "$($target_file).cached";
+		$found_cached = $false;
+
+		if (Test-Path -Path $cached_file_path) {
+			$cached_content = Get-Content $cached_file_path | Out-String;
+
+			if ($cached_content -eq $new_content) {
+				Write-Host "$target_file replacing with cached version"
+				
+				Remove-Item $target_file
+				Copy-Item $cached_file_path -Destination $target_file
+				$found_cached = $true;
+			}
+		}
+
+		if (!$found_cached) {
+			Write-Host "$target_file no cached version, or it is not up-to-date - replacing (will trigger package recompile)"
+
+			$new_content | Set-Content $target_file -NoNewline;
+			$new_content | Set-Content $cached_file_path -NoNewline;
+		}
 	}
 }

--- a/VERSION.ps1
+++ b/VERSION.ps1
@@ -7,6 +7,6 @@ defaultproperties
     MajorVersion = 1;
     MinorVersion = 18;
     PatchVersion = 0;
-    Commit = "";
+    Commit = "%COMMIT%";
 }
 '@


### PR DESCRIPTION
Also fixes the commit field which [was broken in 1.18rc](https://github.com/X2CommunityCore/X2WOTCCommunityHighlander/commit/b9bd25d416760648b572c3f6e095531ac0ff48b6#diff-fbe217507dcd06b27b5bf1f239e1aca9L10)