### PR TITLE
Issue #524 Allow mods to define required and incompatible mod dependencies

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,9 +4,9 @@ All notable changes to Vanilla 'War Of The Chosen' Behaviour will be documented 
 ## General
 
 ### Mod/DLC Hooks
-- `GetIncompatibleDLCIdentifiers` allows mods to specify an array of incompatible mods. This will be used to show an warning popup if they are present.
-- `GetRequiredDLCIdentifiers` allows mods to specify an array of required mods. This will be used to show an warning popup if they are not present.
-- `GetDisplayName` allows mods to specify a display name which will be used in the warning popups for incompatible/required mod.
+- `GetIncompatibleDLCIdentifiers` allows mods to specify an array of incompatible mods. This will be used to show an warning popup if they are present. (#524)
+- `GetRequiredDLCIdentifiers` allows mods to specify an array of required mods. This will be used to show an warning popup if they are not present. (#524)
+- `GetDisplayName` allows mods to specify a display name which will be used in the warning popups for incompatible/required mod. (#524)
 
 ## Strategy
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,7 +1,12 @@
 # Change Log
 All notable changes to Vanilla 'War Of The Chosen' Behaviour will be documented in this file.
 
+## General
 
+### Mod/DLC Hooks
+- `GetIncompatibleDLCIdentifiers` allows mods to specify an array of incompatible mods. This will be used to show an warning popup if they are present.
+- `GetRequiredDLCIdentifiers` allows mods to specify an array of required mods. This will be used to show an warning popup if they are not present.
+- `GetDisplayName` allows mods to specify a display name which will be used in the warning popups for incompatible/required mod.
 
 ## Strategy
 

--- a/X2WOTCCommunityHighlander/Localization/X2WOTCCommunityHighlander.int
+++ b/X2WOTCCommunityHighlander/Localization/X2WOTCCommunityHighlander.int
@@ -8,3 +8,7 @@ NotExpectedNotFound="Optional"
 VersionMismatches="- Version Mismatches"
 WarningsLabel="- Warnings"
 ErrorsLabel="- ERRORS - CHECK LOG"
+
+[X2WOTCCH_ModDependencies]
+ModRequired="following required dependend mod(s) not found:"
+ModIncompatible="following loaded mod(s) are marked incompatible:"

--- a/X2WOTCCommunityHighlander/Localization/X2WOTCCommunityHighlander.int
+++ b/X2WOTCCommunityHighlander/Localization/X2WOTCCommunityHighlander.int
@@ -10,5 +10,8 @@ WarningsLabel="- Warnings"
 ErrorsLabel="- ERRORS - CHECK LOG"
 
 [X2WOTCCH_ModDependencies]
-ModRequired="following required dependend mod(s) not found:"
-ModIncompatible="following loaded mod(s) are marked incompatible:"
+ModRequiredPopupTitle="missing REQUIRED mods"
+ModRequired="Please ACTIVATE the following mods and restart or %s will not work properly:"
+ModIncompatiblePopupTitle="detected INCOMPATIBLE mods"
+ModIncompatible="Please DEACTIVATE the following mods and restart or %s will not work properly:"
+DisablePopup="DO NOT SHOW ME THIS AGAIN"

--- a/X2WOTCCommunityHighlander/Src/X2WOTCCommunityHighlander/Classes/X2WOTCCH_DialogCallbackData.uc
+++ b/X2WOTCCommunityHighlander/Src/X2WOTCCommunityHighlander/Classes/X2WOTCCH_DialogCallbackData.uc
@@ -1,0 +1,7 @@
+/**
+ * Issue #524
+ * Check mods required and incompatible mods against the actually loaded mod and display a popup for each mod
+ **/
+class X2WOTCCH_DialogCallbackData extends UICallbackData dependson (X2WOTCCH_ModDependencies);
+
+var ModDependency DependencyData;

--- a/X2WOTCCommunityHighlander/Src/X2WOTCCommunityHighlander/Classes/X2WOTCCH_ModDependencies.uc
+++ b/X2WOTCCommunityHighlander/Src/X2WOTCCommunityHighlander/Classes/X2WOTCCH_ModDependencies.uc
@@ -1,0 +1,121 @@
+/**
+ * Issue #524
+ * Check mods required and incompatible mods against the actually loaded mod and display a popup
+ **/
+class X2WOTCCH_ModDependencies extends Object;
+
+struct ModDependency
+{
+	var string ModName;
+	var array<String> Children;
+};
+
+var localized string ModRequired;
+var localized string ModIncompatible;
+
+static function GetModDependencies(out array<ModDependency> IncompatibleMods, out array<ModDependency> RequiredMods)
+{
+	local array<X2DownloadableContentInfo> DLCInfos;
+	local X2DownloadableContentInfo DLCInfo;
+	local array<string> DependendDLCIdentifiers;
+	local ModDependency ModDependencyToAdd, EmptyModDependencyToAdd;
+
+	DLCInfos = `ONLINEEVENTMGR.GetDLCInfos(false);
+
+	foreach DLCInfos(DLCInfo)
+	{
+		DependendDLCIdentifiers = DLCInfo.GetIncompatibleDLCIdentifiers();
+
+		ModDependencyToAdd = EmptyModDependencyToAdd;
+		if (GetModDependency(DLCInfos, DLCInfo, DependendDLCIdentifiers, false, ModDependencyToAdd))
+		{
+			if (ModDependencyToAdd.Children.Length > 0)
+			{
+				IncompatibleMods.AddItem(ModDependencyToAdd);
+			}
+		}
+
+		DependendDLCIdentifiers = DLCInfo.GetRequiredDLCIdentifiers();
+
+		ModDependencyToAdd = EmptyModDependencyToAdd;
+		if (GetModDependency(DLCInfos, DLCInfo, DependendDLCIdentifiers, true, ModDependencyToAdd))
+		{
+			if (ModDependencyToAdd.Children.Length > 0)
+			{
+				RequiredMods.AddItem(ModDependencyToAdd);
+			}
+		}
+	}
+}
+
+function static string Join(array<string> StringArray, optional string Delimiter = ",", optional bool bIgnoreBlanks = true)
+{
+	local string Result;
+
+	JoinArray(StringArray, Result, Delimiter, bIgnoreBlanks);
+
+	return Result;
+}
+
+private static function bool GetModDependency(
+	array<X2DownloadableContentInfo> DLCInfos,
+	X2DownloadableContentInfo DLCInfo,
+	array<string> DependendDLCIdentifiers,
+	bool bIsRequired,
+	out ModDependency ModDependencyToAdd
+	)
+{
+	local string DependendDLCIdentifier;
+	local X2DownloadableContentInfo Dependency;
+
+	if (DependendDLCIdentifiers.Length > 0)
+	{
+		ModDependencyToAdd.ModName = GetModDisplayName(DLCInfo);
+		foreach DependendDLCIdentifiers(DependendDLCIdentifier)
+		{
+			Dependency = FindDLCInfo(DLCInfos, DependendDLCIdentifier);
+			if (bIsRequired && Dependency == none)
+			{
+				ModDependencyToAdd.Children.AddItem(DependendDLCIdentifier);
+				`LOG(GetFuncName() @ GetModDisplayName(DLCInfo) @ "Add incompatible" @ DependendDLCIdentifier,, 'X2WOTCCommunityHighlander');
+			}
+			else if(!bIsRequired && Dependency != none)
+			{
+				ModDependencyToAdd.Children.AddItem(GetModDisplayName(Dependency));
+				`LOG(GetFuncName() @ GetModDisplayName(DLCInfo) @ "Add incompatible" @ GetModDisplayName(Dependency),, 'X2WOTCCommunityHighlander');
+			}
+		}
+		return true;
+	}
+	return false;
+}
+
+private static function X2DownloadableContentInfo FindDLCInfo(array<X2DownloadableContentInfo> Haystack, string Needle)
+{
+	local X2DownloadableContentInfo DLCInfo;
+
+	foreach Haystack(DLCInfo)
+	{
+		if (DLCInfo.DLCIdentifier == Needle)
+		{
+			return DLCInfo;
+		}
+	}
+	return None;
+}
+
+private static function string GetModDisplayName(X2DownloadableContentInfo DLCInfo)
+{
+	if (DLCInfo.GetDisplayName() != "")
+	{
+		return DLCInfo.GetDisplayName();
+	}
+
+	if (DLCInfo.PartContentLabel != "")
+	{
+		return DLCInfo.PartContentLabel;
+	}
+
+	return DLCInfo.DLCIdentifier;
+}
+

--- a/X2WOTCCommunityHighlander/Src/X2WOTCCommunityHighlander/Classes/X2WOTCCH_UIScreenListener_ShellPopup.uc
+++ b/X2WOTCCommunityHighlander/Src/X2WOTCCommunityHighlander/Classes/X2WOTCCH_UIScreenListener_ShellPopup.uc
@@ -1,70 +1,159 @@
 /**
  * Issue #524
- * Check mods required and incompatible mods against the actually loaded mod and display a popup
+ * Check mods required and incompatible mods against the actually loaded mod and display a popup for each mod
  **/
-class X2WOTCCH_UIScreenListener_ShellPopup extends UIScreenListener dependson (X2WOTCCH_ModDependencies);
+class X2WOTCCH_UIScreenListener_ShellPopup
+	extends UIScreenListener
+	dependson (X2WOTCCH_ModDependencies)
+	config (X2WOTCCommunityHighlander_NullConfig);
+
+
+var config array<name> HideIncompatibleModWarnings;
+var config array<name> HideRequiredModWarnings;
 
 event OnInit(UIScreen Screen)
 {
-	if(UIShell(Screen) != none)
+	// if UIShell(Screen).DebugMenuContainer is set do NOT show since were not on the final shell
+	if(UIShell(Screen) != none && UIShell(Screen).DebugMenuContainer == none)
 	{
-		Screen.SetTimer(1.5f, false, nameof(MakePopup), self);
+		Screen.SetTimer(2.5f, false, nameof(IncompatibleModsPopups), self);
+		Screen.SetTimer(2.6f, false, nameof(RequiredModsPopups), self);
 	}
 }
 
-simulated function MakePopup()
+simulated function IncompatibleModsPopups()
 {
 	local TDialogueBoxData kDialogData;
-
-	kDialogData.eType = eDialog_Warning;
-	kDialogData.strText = GetText();
-	kDialogData.fnCallback = OKClickedCB;
-
-	kDialogData.strAccept = class'UIUtilities_Text'.default.m_strGenericAccept;
-
-	`LOG(kDialogData.strText,, 'X2WOTCCommunityHighlander');
-
-	if (kDialogData.strText != "")
-	{
-		`PRESBASE.UIRaiseDialog(kDialogData);
-	}
-}
-
-simulated function OKClickedCB(Name eAction)
-{
-	`PRESBASE.PlayUISound(eSUISound_MenuSelect);
-}
-
-simulated function string GetText()
-{
-	local array<ModDependency> IncompatibleMods, RequiredMods;
+	local array<ModDependency> IncompatibleMods;
 	local ModDependency Dep;
-	local string Buffer;
+	local X2WOTCCH_DialogCallbackData CallbackData;
+	local int Index;
 
-	class'X2WOTCCH_ModDependencies'.static.GetModDependencies(IncompatibleMods, RequiredMods);
+	IncompatibleMods = class'X2WOTCCH_ModDependencies'.static.GetIncompatbleMods();
 
 	foreach IncompatibleMods(Dep)
 	{
-		Buffer $= class'UIUtilities_Text'.static.GetColoredText("["  $ Dep.ModName $ "]", eUIState_Good) @ 
-			class'UIUtilities_Text'.static.GetColoredText(class'X2WOTCCH_ModDependencies'.default.ModIncompatible, eUIState_Disabled) @ 
-			class'UIUtilities_Text'.static.GetColoredText(Join(Dep.Children, ", "), eUIState_Bad) $ "<br />";
+		Index = HideIncompatibleModWarnings.Find(Dep.DLCIdentifier);
+
+		if (Index == INDEX_NONE && Dep.ModName != "" && Dep.Children.Length > 0)
+		{
+			CallbackData = new class'X2WOTCCH_DialogCallbackData';
+			CallbackData.DependencyData = Dep;
+
+			kDialogData.strTitle = Dep.ModName @ class'X2WOTCCH_ModDependencies'.default.ModIncompatiblePopupTitle;
+			kDialogData.eType = eDialog_Warning;
+			kDialogData.strText = GetIncompatibleModsText(Dep);
+			kDialogData.fnCallbackEx = IncompatibleModsCB;
+			kDialogData.strAccept = class'X2WOTCCH_ModDependencies'.default.DisablePopup;
+			kDialogData.strCancel = class'UIUtilities_Text'.default.m_strGenericAccept;
+			kDialogData.xUserData = CallbackData;
+
+			`LOG(kDialogData.strText,, 'X2WOTCCommunityHighlander');
+
+			`PRESBASE.UIRaiseDialog(kDialogData);
+		}
 	}
+}
+
+simulated function RequiredModsPopups()
+{
+	local TDialogueBoxData kDialogData;
+	local array<ModDependency> RequiredMods;
+	local ModDependency Dep;
+	local X2WOTCCH_DialogCallbackData CallbackData;
+	local int Index;
+
+	RequiredMods = class'X2WOTCCH_ModDependencies'.static.GetRequiredMods();
 
 	foreach RequiredMods(Dep)
 	{
-		Buffer $= class'UIUtilities_Text'.static.GetColoredText("["  $ Dep.ModName $ "]", eUIState_Good) @ 
-			class'UIUtilities_Text'.static.GetColoredText(class'X2WOTCCH_ModDependencies'.default.ModRequired, eUIState_Disabled) @ 
-			class'UIUtilities_Text'.static.GetColoredText(Join(Dep.Children, ", "), eUIState_Warning) $ "<br />";
-	}
+		Index = HideRequiredModWarnings.Find(Dep.DLCIdentifier);
+		if (Index == INDEX_NONE && Dep.ModName != "" && Dep.Children.Length > 0)
+		{
+			CallbackData = new class'X2WOTCCH_DialogCallbackData';
+			CallbackData.DependencyData = Dep;
 
-	return Buffer;
+			kDialogData.strTitle = Dep.ModName @ class'X2WOTCCH_ModDependencies'.default.ModRequiredPopupTitle;
+			kDialogData.eType = eDialog_Warning;
+			kDialogData.strText = GetRequiredModsText(Dep);
+			kDialogData.fnCallbackEx = RequiredModsCB;
+			kDialogData.strAccept = class'X2WOTCCH_ModDependencies'.default.DisablePopup;
+			kDialogData.strCancel = class'UIUtilities_Text'.default.m_strGenericAccept;
+			kDialogData.xUserData = CallbackData;
+
+			`LOG(kDialogData.strText,, 'X2WOTCCommunityHighlander');
+
+			`PRESBASE.UIRaiseDialog(kDialogData);
+		}
+	}
 }
 
-function string Join(array<string> StringArray, string Delimiter, optional bool bIgnoreBlanks = true)
+simulated function IncompatibleModsCB(Name eAction, UICallbackData xUserData)
 {
-	local string Result;
+	local X2WOTCCH_DialogCallbackData CallbackData;
 
-	JoinArray(StringArray, Result, Delimiter, bIgnoreBlanks);
+	if (eAction == 'eUIAction_Accept')
+	{
+		CallbackData = X2WOTCCH_DialogCallbackData(xUserData);
+		HideIncompatibleModWarnings.AddItem(CallbackData.DependencyData.DLCIdentifier);
 
-	return Result;
+		`PRESBASE.PlayUISound(eSUISound_MenuSelect);
+		
+		self.SaveConfig();
+	}
+	else
+	{
+		`PRESBASE.PlayUISound(eSUISound_MenuSelect);
+	}
+}
+
+simulated function RequiredModsCB(Name eAction, UICallbackData xUserData)
+{
+	local X2WOTCCH_DialogCallbackData CallbackData;
+
+	if (eAction == 'eUIAction_Accept')
+	{
+		CallbackData = X2WOTCCH_DialogCallbackData(xUserData);
+		HideRequiredModWarnings.AddItem(CallbackData.DependencyData.DLCIdentifier);
+
+		`PRESBASE.PlayUISound(eSUISound_MenuSelect);
+		
+		self.SaveConfig();
+	}
+	else
+	{
+		`PRESBASE.PlayUISound(eSUISound_MenuSelect);
+	}
+}
+
+simulated function string GetIncompatibleModsText(ModDependency Dep)
+{
+	return class'UIUtilities_Text'.static.GetColoredText(Repl(class'X2WOTCCH_ModDependencies'.default.ModIncompatible, "%s", Dep.ModName, true), eUIState_Header) $ "\n\n" $
+			class'UIUtilities_Text'.static.GetColoredText(MakeBulletList(Dep.Children), eUIState_Bad) $ "\n";
+}
+
+simulated function string GetRequiredModsText(ModDependency Dep)
+{
+	return class'UIUtilities_Text'.static.GetColoredText(Repl(class'X2WOTCCH_ModDependencies'.default.ModRequired, "%s", Dep.ModName, true), eUIState_Header) $ "\n\n" $
+			class'UIUtilities_Text'.static.GetColoredText(MakeBulletList(Dep.Children), eUIState_Bad) $ "\n";
+}
+
+function static string MakeBulletList(array<string> List)
+{
+	local string Buffer;
+	local int Index;
+
+	if (List.Length == 0)
+	{
+		return "";
+	}
+
+	Buffer = "<ul>";
+	for(Index=0; Index < List.Length; Index++)
+	{
+		Buffer $= "<li>" $ List[Index] $ "</li>";
+	}
+	Buffer $= "</ul>";
+	
+	return Buffer;
 }

--- a/X2WOTCCommunityHighlander/Src/X2WOTCCommunityHighlander/Classes/X2WOTCCH_UIScreenListener_ShellPopup.uc
+++ b/X2WOTCCommunityHighlander/Src/X2WOTCCommunityHighlander/Classes/X2WOTCCH_UIScreenListener_ShellPopup.uc
@@ -1,0 +1,70 @@
+/**
+ * Issue #524
+ * Check mods required and incompatible mods against the actually loaded mod and display a popup
+ **/
+class X2WOTCCH_UIScreenListener_ShellPopup extends UIScreenListener dependson (X2WOTCCH_ModDependencies);
+
+event OnInit(UIScreen Screen)
+{
+	if(UIShell(Screen) != none)
+	{
+		Screen.SetTimer(1.5f, false, nameof(MakePopup), self);
+	}
+}
+
+simulated function MakePopup()
+{
+	local TDialogueBoxData kDialogData;
+
+	kDialogData.eType = eDialog_Warning;
+	kDialogData.strText = GetText();
+	kDialogData.fnCallback = OKClickedCB;
+
+	kDialogData.strAccept = class'UIUtilities_Text'.default.m_strGenericAccept;
+
+	`LOG(kDialogData.strText,, 'X2WOTCCommunityHighlander');
+
+	if (kDialogData.strText != "")
+	{
+		`PRESBASE.UIRaiseDialog(kDialogData);
+	}
+}
+
+simulated function OKClickedCB(Name eAction)
+{
+	`PRESBASE.PlayUISound(eSUISound_MenuSelect);
+}
+
+simulated function string GetText()
+{
+	local array<ModDependency> IncompatibleMods, RequiredMods;
+	local ModDependency Dep;
+	local string Buffer;
+
+	class'X2WOTCCH_ModDependencies'.static.GetModDependencies(IncompatibleMods, RequiredMods);
+
+	foreach IncompatibleMods(Dep)
+	{
+		Buffer $= class'UIUtilities_Text'.static.GetColoredText("["  $ Dep.ModName $ "]", eUIState_Good) @ 
+			class'UIUtilities_Text'.static.GetColoredText(class'X2WOTCCH_ModDependencies'.default.ModIncompatible, eUIState_Disabled) @ 
+			class'UIUtilities_Text'.static.GetColoredText(Join(Dep.Children, ", "), eUIState_Bad) $ "<br />";
+	}
+
+	foreach RequiredMods(Dep)
+	{
+		Buffer $= class'UIUtilities_Text'.static.GetColoredText("["  $ Dep.ModName $ "]", eUIState_Good) @ 
+			class'UIUtilities_Text'.static.GetColoredText(class'X2WOTCCH_ModDependencies'.default.ModRequired, eUIState_Disabled) @ 
+			class'UIUtilities_Text'.static.GetColoredText(Join(Dep.Children, ", "), eUIState_Warning) $ "<br />";
+	}
+
+	return Buffer;
+}
+
+function string Join(array<string> StringArray, string Delimiter, optional bool bIgnoreBlanks = true)
+{
+	local string Result;
+
+	JoinArray(StringArray, Result, Delimiter, bIgnoreBlanks);
+
+	return Result;
+}

--- a/X2WOTCCommunityHighlander/Src/XComGame/Classes/CHModDependency.uc
+++ b/X2WOTCCommunityHighlander/Src/XComGame/Classes/CHModDependency.uc
@@ -1,0 +1,9 @@
+class CHModDependency extends Object perobjectconfig Config(Game);
+
+var config array<string> IncompatibleMods;
+var config array<string> IgnoreIncompatibleMods;
+var config array<string> RequiredMods;
+var config array<string> IgnoreRequiredMods;
+var string DisplayName;
+
+

--- a/X2WOTCCommunityHighlander/Src/XComGame/Classes/X2DownloadableContentInfo.uc
+++ b/X2WOTCCommunityHighlander/Src/XComGame/Classes/X2DownloadableContentInfo.uc
@@ -554,3 +554,12 @@ static function UnitPawnPostInitAnimTree(XComGameState_Unit UnitState, XComUnitP
 	return;
 }
 /// End Issue #455
+
+/// Start Issue #524
+/// <summary>
+/// Allow mods to specify array of incompatible and required mod.
+/// </summary>
+function array<string> GetIncompatibleDLCIdentifiers();
+function array<string> GetRequiredDLCIdentifiers();
+function string GetDisplayName();
+/// End Issue #524

--- a/X2WOTCCommunityHighlander/Src/XComGame/Classes/X2DownloadableContentInfo.uc
+++ b/X2WOTCCommunityHighlander/Src/XComGame/Classes/X2DownloadableContentInfo.uc
@@ -558,8 +558,68 @@ static function UnitPawnPostInitAnimTree(XComGameState_Unit UnitState, XComUnitP
 /// Start Issue #524
 /// <summary>
 /// Allow mods to specify array of incompatible and required mod.
+/// Should be specified in the mods XComGame.ini like
+/// [ModSafeName CHModDependency]
+/// +IncompatibleMods=...
+/// +IgnoreIncompatibleMods=...
+/// +RequiredMods=...
+/// +IgnoreRequiredMods=...
+/// DisplayName="..."
 /// </summary>
-function array<string> GetIncompatibleDLCIdentifiers();
-function array<string> GetRequiredDLCIdentifiers();
-function string GetDisplayName();
+final function array<string> GetIncompatibleDLCIdentifiers()
+{
+	local CHModDependency ModDependency;
+
+	ModDependency = new(none, DLCIdentifier)class'CHModDependency';
+	if (ModDependency != none && ModDependency.IncompatibleMods.Length > 0)
+	{
+		return ModDependency.IncompatibleMods;
+	}
+}
+
+final function array<string> GetIgnoreIncompatibleDLCIdentifiers()
+{
+	local CHModDependency ModDependency;
+
+	ModDependency = new(none, DLCIdentifier)class'CHModDependency';
+	if (ModDependency != none && ModDependency.IgnoreIncompatibleMods.Length > 0)
+	{
+		return ModDependency.IgnoreIncompatibleMods;
+	}
+}
+
+final function array<string> GetRequiredDLCIdentifiers()
+{
+	local CHModDependency ModDependency;
+
+	ModDependency = new(none, DLCIdentifier)class'CHModDependency';
+	if (ModDependency != none && ModDependency.RequiredMods.Length > 0)
+	{
+		return ModDependency.RequiredMods;
+	}
+}
+
+final function array<string> GetIgnoreRequiredDLCIdentifiers()
+{
+	local CHModDependency ModDependency;
+
+	ModDependency = new(none, DLCIdentifier)class'CHModDependency';
+	if (ModDependency != none && ModDependency.IgnoreRequiredMods.Length > 0)
+	{
+		return ModDependency.IgnoreRequiredMods;
+	}
+}
+
+final function string GetDisplayName()
+{
+	local CHModDependency ModDependency;
+
+	ModDependency = new(none, DLCIdentifier)class'CHModDependency';
+	if (ModDependency != none && ModDependency.DisplayName != "")
+	{
+		return ModDependency.DisplayName;
+	}
+
+	return "";
+}
 /// End Issue #524

--- a/X2WOTCCommunityHighlander/X2WOTCCommunityHighlander.x2proj
+++ b/X2WOTCCommunityHighlander/X2WOTCCommunityHighlander.x2proj
@@ -64,6 +64,9 @@
     <Content Include="Src\X2WOTCCommunityHighlander\Classes\X2WOTCCH_Components.uc">
       <SubType>Content</SubType>
     </Content>
+    <Content Include="Src\X2WOTCCommunityHighlander\Classes\X2WOTCCH_DialogCallbackData.uc">
+      <SubType>Content</SubType>
+    </Content>
     <Content Include="Src\X2WOTCCommunityHighlander\Classes\X2WOTCCH_ModDependencies.uc">
       <SubType>Content</SubType>
     </Content>

--- a/X2WOTCCommunityHighlander/X2WOTCCommunityHighlander.x2proj
+++ b/X2WOTCCommunityHighlander/X2WOTCCommunityHighlander.x2proj
@@ -92,6 +92,9 @@
     <Content Include="Src\XComGame\Classes\CHItemSlotStore.uc">
       <SubType>Content</SubType>
     </Content>
+    <Content Include="Src\XComGame\Classes\CHModDependency.uc">
+      <SubType>Content</SubType>
+    </Content>
     <Content Include="Src\XComGame\Classes\CHUIItemSlotEnumerator.uc">
       <SubType>Content</SubType>
     </Content>

--- a/X2WOTCCommunityHighlander/X2WOTCCommunityHighlander.x2proj
+++ b/X2WOTCCommunityHighlander/X2WOTCCommunityHighlander.x2proj
@@ -64,6 +64,12 @@
     <Content Include="Src\X2WOTCCommunityHighlander\Classes\X2WOTCCH_Components.uc">
       <SubType>Content</SubType>
     </Content>
+    <Content Include="Src\X2WOTCCommunityHighlander\Classes\X2WOTCCH_ModDependencies.uc">
+      <SubType>Content</SubType>
+    </Content>
+    <Content Include="Src\X2WOTCCommunityHighlander\Classes\X2WOTCCH_UIScreenListener_ShellPopup.uc">
+      <SubType>Content</SubType>
+    </Content>
     <Content Include="Src\X2WOTCCommunityHighlander\Classes\X2WOTCCH_UIScreenListener_ShellSplash.uc">
       <SubType>Content</SubType>
     </Content>
@@ -285,7 +291,7 @@
       <SubType>Content</SubType>
     </Content>
     <Content Include="Src\XComGame\Classes\X2DataSet.uc">
-          <SubType>Content</SubType>
+      <SubType>Content</SubType>
     </Content>
     <Content Include="Src\XComGame\Classes\X2Action_Death.uc">
       <SubType>Content</SubType>
@@ -297,7 +303,7 @@
       <SubType>Content</SubType>
     </Content>
     <Content Include="Src\XComGame\Classes\X2FiraxisLiveClient.uc">
-          <SubType>Content</SubType>
+      <SubType>Content</SubType>
     </Content>
     <Content Include="Src\XComGame\Classes\X2GameRuleset.uc">
       <SubType>Content</SubType>
@@ -306,7 +312,7 @@
       <SubType>Content</SubType>
     </Content>
     <Content Include="Src\XComGame\Classes\X2SitRepEffect_GrantAbilities.uc">
-          <SubType>Content</SubType>
+      <SubType>Content</SubType>
     </Content>
     <Content Include="Src\XComGame\Classes\X2SitRepEffect_ModifyTacticalStartState.uc">
       <SubType>Content</SubType>


### PR DESCRIPTION
and detect missing dependencies and mod conflicts.

There will be a shell screen popup for each mod that requirements are not met. Incompatible and required warnings are displayed in separate popups.

Popups can be (semi) permanently removed by the user. The info is persisted in the users local config directory (`XComX2WOTCCommunityHighlander_NullConfig.ini` ).