### PR TITLE
Unbreak the Ranks, bump to 1.18.2

### DIFF
--- a/Components/DLC2CommunityHighlander/DLC2CommunityHighlander/Src/DLC_2/Classes/X2DLC2CH_CHXComGameVersion.uc
+++ b/Components/DLC2CommunityHighlander/DLC2CommunityHighlander/Src/DLC_2/Classes/X2DLC2CH_CHXComGameVersion.uc
@@ -29,6 +29,6 @@ defaultproperties
 {
     MajorVersion = 1;
     MinorVersion = 18;
-    PatchVersion = 1;
+    PatchVersion = 2;
     Commit = "";
 }

--- a/VERSION.ps1
+++ b/VERSION.ps1
@@ -6,7 +6,7 @@ defaultproperties
 {
     MajorVersion = 1;
     MinorVersion = 18;
-    PatchVersion = 1;
+    PatchVersion = 2;
     Commit = "";
 }
 '@

--- a/X2WOTCCommunityHighlander/Src/Engine/Classes/CHEngineVersion.uc
+++ b/X2WOTCCommunityHighlander/Src/Engine/Classes/CHEngineVersion.uc
@@ -11,6 +11,6 @@ defaultproperties
 {
     MajorVersion = 1;
     MinorVersion = 18;
-    PatchVersion = 1;
+    PatchVersion = 2;
     Commit = "";
 }

--- a/X2WOTCCommunityHighlander/Src/X2WOTCCommunityHighlander/Classes/X2WOTCCH_CHXComGameVersion.uc
+++ b/X2WOTCCommunityHighlander/Src/X2WOTCCommunityHighlander/Classes/X2WOTCCH_CHXComGameVersion.uc
@@ -29,6 +29,6 @@ defaultproperties
 {
     MajorVersion = 1;
     MinorVersion = 18;
-    PatchVersion = 1;
+    PatchVersion = 2;
     Commit = "";
 }

--- a/X2WOTCCommunityHighlander/Src/XComGame/Classes/CHXComGameVersionTemplate.uc
+++ b/X2WOTCCommunityHighlander/Src/XComGame/Classes/CHXComGameVersionTemplate.uc
@@ -61,7 +61,7 @@ defaultproperties
 {
     MajorVersion = 1;
     MinorVersion = 18;
-    PatchVersion = 1;
+    PatchVersion = 2;
     Commit = "";
 }
 

--- a/X2WOTCCommunityHighlander/Src/XComGame/Classes/XComGameState_Unit.uc
+++ b/X2WOTCCommunityHighlander/Src/XComGame/Classes/XComGameState_Unit.uc
@@ -14072,7 +14072,7 @@ function string GetSoldierRankName(optional int Rank = -1)
 	OverrideTuple = TriggerSoldierRankEvent(
 		Rank,
 		'SoldierRankName',
-		class'X2ExperienceConfig'.static.GetRankName(GetRank(), GetSoldierClassTemplateName()));
+		class'X2ExperienceConfig'.static.GetRankName((Rank == -1) ? GetRank() : Rank, GetSoldierClassTemplateName()));
 
 	return OverrideTuple.Data[1].s;
 }
@@ -14097,7 +14097,7 @@ function string GetSoldierShortRankName(optional int Rank = -1)
 	OverrideTuple = TriggerSoldierRankEvent(
 		Rank,
 		'SoldierShortRankName',
-		class'X2ExperienceConfig'.static.GetShortRankName(GetRank(), GetSoldierClassTemplateName()));
+		class'X2ExperienceConfig'.static.GetShortRankName((Rank == -1) ? GetRank() : Rank, GetSoldierClassTemplateName()));
 
 	return OverrideTuple.Data[1].s;
 }
@@ -14122,7 +14122,7 @@ function string GetSoldierRankIcon(optional int Rank = -1)
 	OverrideTuple = TriggerSoldierRankEvent(
 		Rank,
 		'SoldierRankIcon',
-		class'UIUtilities_Image'.static.GetRankIcon(GetRank(), GetSoldierClassTemplateName()));
+		class'UIUtilities_Image'.static.GetRankIcon((Rank == -1) ? GetRank() : Rank, GetSoldierClassTemplateName()));
 
 	return OverrideTuple.Data[1].s;
 }


### PR DESCRIPTION
Fixes #526.

Continuing our tradition of breaking everything, this time we broke the hero promotion screen and tactical rank-up messages -- both would always use the unit's current rank (for purposes of rank icons and text). This isn't game-breaking, but it's something that I believe warrants a hotfix. Therefore, this will bump the version to 1.18.2, which I will release later today.