### PR TITLE
Add Psi training complete event

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -44,6 +44,7 @@ All notable changes to Vanilla 'War Of The Chosen' Behaviour will be documented 
 - Triggers the event `ShouldCleanupCovertAction` to allow mod control over Covert Action deletion. (#435)
 - Triggers the event `BlackMarketGoodsReset` when the Black Market goods are reset (#473)
 - Triggers the event `OverrideImageForItemAvaliable` to allow mods to override the image shown in eAlert_ItemAvailable (#491)
+- Triggers the event `PsiProjectCompleted` to notify mods when a soldier has finished training in the psi labs (#534)
 
 ### Modding Exposures
 - Allows mods to add custom items to the Avenger Shortcuts (#163)

--- a/X2WOTCCommunityHighlander/Src/XComGame/Classes/XComGameState_HeadquartersProjectPsiTraining.uc
+++ b/X2WOTCCommunityHighlander/Src/XComGame/Classes/XComGameState_HeadquartersProjectPsiTraining.uc
@@ -130,9 +130,39 @@ function OnProjectCompleted()
 
 	`HQPRES.UIPsiTrainingComplete(ProjectFocus, AbilityTemplate);
 	
-	// Start Issue 
-	`XEVENTMGR.TriggerEvent('PsiProjectCompleted', self, self);
+	// Start Issue #534
+	TriggerPsiProjectCompleted(Unit, AbilityName);
+	// End Issue #534
 }
+
+// Start Issue #534
+//
+// Triggers a 'PsiProjectCompleted' event that notifies listeners 
+// that a psi operative has finished training.
+//
+// The event itself takes the form:
+//
+//   {
+//      ID: PsiProjectCompleted,
+//      Data: [in XCGS_Unit Unit, in string AbilityName],
+//      Source: self (XCGS_HQProjectPsiTraining)
+//   }
+//
+function TriggerPsiProjectCompleted(XComGameState_Unit Unit, name AbilityName)
+{
+	local XComLWTuple Tuple;
+
+	Tuple = new class'XComLWTuple';
+	Tuple.Id = 'PsiProjectCompleted';
+	Tuple.Data.Add(2);
+	Tuple.Data[0].kind = XComLWTVObject;
+	Tuple.Data[0].o = Unit;
+	Tuple.Data[1].kind = XComLWTVObject;
+	Tuple.Data[1].s = string(AbilityName);
+
+	`XEVENTMGR.TriggerEvent('PsiProjectCompleted', Tuple, self);
+}
+// End Issue #534
 
 //---------------------------------------------------------------------------------------
 DefaultProperties

--- a/X2WOTCCommunityHighlander/Src/XComGame/Classes/XComGameState_HeadquartersProjectPsiTraining.uc
+++ b/X2WOTCCommunityHighlander/Src/XComGame/Classes/XComGameState_HeadquartersProjectPsiTraining.uc
@@ -1,0 +1,140 @@
+//---------------------------------------------------------------------------------------
+//  FILE:    XComGameState_HeadquartersProjectPsiTraining.uc
+//  AUTHOR:  Mark Nauta  --  11/11/2014
+//  PURPOSE: This object represents the instance data for an XCom HQ psi training project
+//           Will eventually be a component
+//           
+//---------------------------------------------------------------------------------------
+//  Copyright (c) 2016 Firaxis Games, Inc. All rights reserved.
+//---------------------------------------------------------------------------------------
+class XComGameState_HeadquartersProjectPsiTraining extends XComGameState_HeadquartersProject native(Core);
+
+var int iAbilityRank;	// the rank of the ability the psi operative will learn upon completing the project
+var int iAbilityBranch; // the branch of the ability the psi operative will learn upon completing the project
+
+var bool bForcePaused;
+
+//---------------------------------------------------------------------------------------
+function SetProjectFocus(StateObjectReference FocusRef, optional XComGameState NewGameState, optional StateObjectReference AuxRef)
+{
+	local XComGameStateHistory History;
+	local XComGameState_Unit UnitState;
+	local XComGameState_GameTime TimeState;
+
+	History = `XCOMHISTORY;
+	ProjectFocus = FocusRef; // Unit
+	AuxilaryReference = AuxRef; // Facility
+
+	UnitState = XComGameState_Unit(NewGameState.GetGameStateForObjectID(ProjectFocus.ObjectID));
+	if (UnitState == none)
+	{
+		UnitState = XComGameState_Unit(History.GetGameStateForObjectID(ProjectFocus.ObjectID));
+	}
+
+	// If the soldier is not already a Psi Operative (if they are, the ability will be assigned from the player's choice)
+	if (UnitState.GetSoldierClassTemplateName() != 'PsiOperative')
+	{
+		// Randomly choose a branch and ability from the starting two tiers of the Psi Op tree
+		iAbilityRank = `SYNC_RAND(2);
+		iAbilityBranch = `SYNC_RAND(2);
+		ProjectPointsRemaining = CalculatePointsToTrain(true);
+	}
+	else
+	{
+		ProjectPointsRemaining = CalculatePointsToTrain();
+	}
+
+	InitialProjectPoints = ProjectPointsRemaining;
+
+	UpdateWorkPerHour(NewGameState); 
+	TimeState = XComGameState_GameTime(History.GetSingleGameStateObjectForClass(class'XComGameState_GameTime'));
+	StartDateTime = TimeState.CurrentTime;
+
+	if (`STRATEGYRULES != none)
+	{
+		if (class'X2StrategyGameRulesetDataStructures'.static.LessThan(TimeState.CurrentTime, `STRATEGYRULES.GameTime))
+		{
+			StartDateTime = `STRATEGYRULES.GameTime;
+		}
+	}
+
+	if(MakingProgress())
+	{
+		SetProjectedCompletionDateTime(StartDateTime);
+	}
+	else
+	{
+		// Set completion time to unreachable future
+		CompletionDateTime.m_iYear = 9999;
+	}
+}
+
+//---------------------------------------------------------------------------------------
+function int CalculatePointsToTrain(optional bool bClassTraining = false)
+{
+	local XComGameStateHistory History;
+	local XComGameState_HeadquartersXCom XComHQ;
+	local XComGameState_Unit Unit;
+	local int RankDifference;
+
+	History = `XCOMHISTORY;
+	XComHQ = XComGameState_HeadquartersXCom(History.GetSingleGameStateObjectForClass(class'XComGameState_HeadquartersXCom'));
+	if (bClassTraining)
+	{
+		return XComHQ.GetPsiTrainingDays() * XComHQ.XComHeadquarters_DefaultPsiTrainingWorkPerHour * 24;
+	}
+	else
+	{
+		Unit = XComGameState_Unit(History.GetGameStateForObjectID(ProjectFocus.ObjectID));
+		RankDifference = Max(iAbilityRank - Unit.GetRank(), 0);
+		return (XComHQ.GetPsiTrainingDays() + Round(XComHQ.GetPsiTrainingScalar() * float(RankDifference))) * XComHQ.XComHeadquarters_DefaultPsiTrainingWorkPerHour * 24;
+	}
+}
+
+//---------------------------------------------------------------------------------------
+function int CalculateWorkPerHour(optional XComGameState StartState = none, optional bool bAssumeActive = false)
+{
+	local XComGameStateHistory History;
+	local XComGameState_HeadquartersXCom XComHQ;
+	local int iTotalWork;
+
+	History = `XCOMHISTORY;
+	XComHQ = XComGameState_HeadquartersXCom(History.GetSingleGameStateObjectForClass(class'XComGameState_HeadquartersXCom'));
+	iTotalWork = XComHQ.PsiTrainingRate;
+
+	// Can't make progress when paused
+	if (bForcePaused && !bAssumeActive)
+	{
+		return 0;
+	}
+
+	return iTotalWork;
+}
+
+//---------------------------------------------------------------------------------------
+function OnProjectCompleted()
+{
+	local HeadquartersOrderInputContext OrderInput;
+	local XComGameState_Unit Unit;
+	local X2AbilityTemplate AbilityTemplate;
+	local name AbilityName;
+
+	OrderInput.OrderType = eHeadquartersOrderType_PsiTrainingCompleted;
+	OrderInput.AcquireObjectReference = self.GetReference();
+
+	class'XComGameStateContext_HeadquartersOrder'.static.IssueHeadquartersOrder(OrderInput);
+
+	Unit = XComGameState_Unit(`XCOMHISTORY.GetGameStateForObjectID(ProjectFocus.ObjectID));
+	AbilityName = Unit.GetAbilityName(iAbilityRank, iAbilityBranch);
+	AbilityTemplate = class'X2AbilityTemplateManager'.static.GetAbilityTemplateManager().FindAbilityTemplate(AbilityName);
+
+	`HQPRES.UIPsiTrainingComplete(ProjectFocus, AbilityTemplate);
+	
+	// Start Issue 
+	`XEVENTMGR.TriggerEvent('PsiProjectCompleted', self, self);
+}
+
+//---------------------------------------------------------------------------------------
+DefaultProperties
+{
+}

--- a/X2WOTCCommunityHighlander/X2WOTCCommunityHighlander.x2proj
+++ b/X2WOTCCommunityHighlander/X2WOTCCommunityHighlander.x2proj
@@ -386,6 +386,9 @@
     <Content Include="Src\XComGame\Classes\XComGameState_HeadquartersAlien.uc">
       <SubType>Content</SubType>
     </Content>
+    <Content Include="Src\XComGame\Classes\XComGameState_HeadquartersProjectPsiTraining.uc">
+      <SubType>Content</SubType>
+    </Content>
     <Content Include="Src\XComGame\Classes\XComGameState_HeadquartersResistance.uc">
       <SubType>Content</SubType>
     </Content>


### PR DESCRIPTION
I have added a 'PsiProjectCompleted' event that's fired from
`XComGameState_HeadquartersProjectPsiTraining` once a psi operative has
finished their training.

The event takes the form:
```
  {
      ID: PsiProjectCompleted,
      Data: [in XCGS_Unit Unit, in string AbilityName],
      Source: self (XCGS_HQProjectPsiTraining)
  }
```