### PR TITLE
Fix for Issue #245

### DIFF
--- a/X2WOTCCommunityHighlander/Src/XComGame/Classes/XGWeapon.uc
+++ b/X2WOTCCommunityHighlander/Src/XComGame/Classes/XGWeapon.uc
@@ -30,10 +30,6 @@ simulated event PostBeginPlay()
 simulated function Init(optional XComGameState_Item ItemState=none)
 {
 	CreateEntity(ItemState);
-
-	// Start Issue #245
-	DLCInfoInit(ItemState);
-	// End Issue #245
 }
 
 // Start Issue #245
@@ -199,6 +195,10 @@ simulated function Actor CreateEntity(optional XComGameState_Item ItemState=none
 
 			SetAppearance(WeaponAppearance);
 		}
+
+		// Start Issue #245
+		DLCInfoInit(InternalWeaponState);
+		// End Issue #245
 
 		InternalWeaponState = None;
 	}


### PR DESCRIPTION
Moves the dlc info calls from `XGWeapon.Init` to `XGWeapon.CreateEntity`.

Fixes an issue where weapons where in a unpatched state on tactical begin in Covert Infiltration missions that create cosmetic attachements for the misssion loading screen.

Some code paths involving creating cosmetic attachments apparently directly call `XGWeapon.CreateEntity` or `XGWeapon.CreateEntityFromWeaponState` bypassing `XGWeapon.Init` and the dlc info calls.
