### PR TITLE
WIP Make civilians run from XCOM (#548)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -152,6 +152,7 @@ All notable changes to Vanilla 'War Of The Chosen' Behaviour will be documented 
 - Gremlins (and other Cosmetic Units) are now correctly tinted and patterned (#376)
 - Register tactical event listeners in TQL (#406)
 - Allow mods to decide which team(s) are granted an ability via X2SitRepEffect_GrantAbilities and better document that class (#445)
+- Make civilians run from XCOM on missions where XCOM doesn't start concealed (#548)
 
 ### Fixes
 - Ensure Gremlins use the walk/run animation based on the alert status of their

--- a/X2WOTCCommunityHighlander/Src/XComGame/Classes/X2TacticalGameRuleset.uc
+++ b/X2WOTCCommunityHighlander/Src/XComGame/Classes/X2TacticalGameRuleset.uc
@@ -1267,6 +1267,20 @@ function ApplyStartOfMatchConditions()
 	}
 	else
 	{
+		// Start Issue #548
+		//
+		// Fire the "concealment broken" event immediately upon mission start if
+		// XCOM aren't starting concealed.
+		foreach History.IterateByClassType(class'XComGameState_Player', PlayerState)
+		{
+			if (PlayerState.GetTeam() == eTeam_XCom)
+			{
+				`XEVENTMGR.TriggerEvent('SquadConcealmentBroken', PlayerState, PlayerState, none);
+				break;
+			}
+		}
+		// End Issue
+
 		if(!BattleDataState.DirectTransferInfo.IsDirectMissionTransfer) // only apply phantom at the start of the first leg of a multi-part mission
 		{
 			foreach History.IterateByClassType(class'XComGameState_Unit', UnitState)


### PR DESCRIPTION
If XCOM doesn't start concealed, then hostile civilians won't run from the
soldiers. They'll walk instead. This change fires a 'SquadConcealmentBroken'
event at the start of unconcealed missions, which ensures that civilians
are panicked by XCOM's presence and hence run from them.