### PR TITLE
Fix missions with rescue rings (#551)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -246,7 +246,8 @@ RunPriorityGroup=RUN_STANDARD
   a pod tries to patrol to any of them (#508)
 - Make disorient reapply to disoriented units so that things like flashbangs can
   still remove overwatch from disoriented units (#475)
-
+- Make sure that rescue rings do not disappear on other rescuable units after a
+  neutral unit swaps to team XCom (#551)
 
 ## Miscellaneous
 

--- a/X2WOTCCommunityHighlander/Src/XComGame/Classes/X2Action_SwapTeams.uc
+++ b/X2WOTCCommunityHighlander/Src/XComGame/Classes/X2Action_SwapTeams.uc
@@ -1,0 +1,66 @@
+//-----------------------------------------------------------
+// Used by the visualizer system to control a Visualization Actor
+//-----------------------------------------------------------
+class X2Action_SwapTeams extends X2Action;
+
+// a reference to the unit that swapped teams
+var private XComGameState_Unit GameStateUnit;
+
+function Init()
+{
+	super.Init();
+	
+	GameStateUnit = XComGameState_Unit(Metadata.StateObject_NewState);
+}
+
+//------------------------------------------------------------------------------------------------
+simulated state Executing
+{
+	function UpdateUnitForSwap()
+	{
+		local XComGameStateHistory History;
+		local XGUnit VisUnit;
+		local XGPlayer VisPlayer;
+		local XComWorldData WorldData;
+		local XComGameState_Player PlayerState; //The player in control of this unit
+		local ETeam	ControlledUnitTeam; // The team of the player in control
+
+		if( GameStateUnit == none )
+		{
+			`Redscreen("X2Action_SwapTeams: No unit provided to swap! Talk to David B., or fix this if you broke it!");
+			return;
+		}
+
+		History = `XCOMHISTORY;
+
+		VisUnit = XGUnit(History.GetVisualizer(GameStateUnit.ObjectID));
+		VisPlayer = XGPlayer(History.GetVisualizer(GameStateUnit.ControllingPlayer.ObjectID));
+		
+		// remove any previously attached range indicators from the unit. These are usually put on
+		// non-xcom civilians and should be removed before they switch teams
+		VisUnit.GetPawn().DetachRangeIndicator();
+		
+		VisUnit.m_kPlayer = VisPlayer;
+		VisUnit.m_kPlayerNativeBase = VisPlayer;
+		VisUnit.SetTeamType(Unit.GetTeam());
+		VisUnit.InitBehavior();
+
+		VisUnit.IdleStateMachine.CheckForStanceUpdate();
+
+		// Mark the FOW texture map as dirty to force an update
+		WorldData = `XWORLD.GetWorldData();
+		WorldData.bFOWTextureBufferIsDirty = true;
+
+		// Changing the glow material on cover depending on who's in control of this unit.
+		PlayerState = XComGameState_Player(History.GetGameStateForObjectID(GameStateUnit.ControllingPlayer.ObjectID));
+		ControlledUnitTeam = PlayerState.GetTeam();
+		UnitPawn.ChangeAuxMaterialOnTeamChange(ControlledUnitTeam);
+	}
+
+Begin:
+	
+	UpdateUnitForSwap();
+
+	CompleteAction();
+}
+

--- a/X2WOTCCommunityHighlander/Src/XComGame/Classes/X2Action_SwapTeams.uc
+++ b/X2WOTCCommunityHighlander/Src/XComGame/Classes/X2Action_SwapTeams.uc
@@ -39,6 +39,15 @@ simulated state Executing
 		// remove any previously attached range indicators from the unit. These are usually put on
 		// non-xcom civilians and should be removed before they switch teams
 		VisUnit.GetPawn().DetachRangeIndicator();
+
+		// Start Issue #551
+		//
+		// Make sure the pawn's team changes too (used by X2UnitRadiusManager) and
+		// the XGUnit's squad (used by XGUnit.RemoveRanges()). This fixes the issue
+		// with disappearing rescue rings on units that haven't been rescued.
+		VisUnit.GetPawn().SetTeamType(Unit.GetTeam());
+		VisUnit.SetSquad(VisPlayer.GetSquad());
+		// End Issue #551
 		
 		VisUnit.m_kPlayer = VisPlayer;
 		VisUnit.m_kPlayerNativeBase = VisPlayer;

--- a/X2WOTCCommunityHighlander/X2WOTCCommunityHighlander.x2proj
+++ b/X2WOTCCommunityHighlander/X2WOTCCommunityHighlander.x2proj
@@ -623,6 +623,9 @@
     <Content Include="Src\XComGame\Classes\X2Action_Hack.uc">
       <SubType>Content</SubType>
     </Content>
+    <Content Include="Src\XComGame\Classes\X2Action_SwapTeams.uc">
+      <SubType>Content</SubType>
+    </Content>
     <Content Include="Src\XComGame\Classes\XComPlayerController.uc">
       <SubType>Content</SubType>
     </Content>


### PR DESCRIPTION
In Gather Survivors and several LW2 missions, XCOM has to rescue units and
take them to evac. To enable player control of the rescued unit, its team
is swapped to XCom. But XGUnit then removes the range indicators from all
members of that unit's squad, which is not XCOM at that stage but team
Neutral.

This fix ensures that the swap team action changes the unit's squad (and
the pawn's team) in addition to the existing XGUnit team change.