### PR TITLE
Fix carrying out soldier multiple times (#557)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -171,6 +171,7 @@ All notable changes to Vanilla 'War Of The Chosen' Behaviour will be documented 
   their damage with psi flyovers (Psi Bomb, mod abilities) (#326)
 - Fix `X2AbilityToHitCalc_StandardAim` discarding unfavorable (for XCOM) changes
   to hit results from effects (#426)
+- Allow soldiers to be carried out from multiple missions in a campaign (#557)
 
 
 ## Miscellaneous

--- a/X2WOTCCommunityHighlander/Src/XComGame/Classes/XComGameState_Unit.uc
+++ b/X2WOTCCommunityHighlander/Src/XComGame/Classes/XComGameState_Unit.uc
@@ -2292,6 +2292,14 @@ function OnBeginTacticalPlay(XComGameState NewGameState)
 	}
 
 	bRequiresVisibilityUpdate = true;
+
+	// Start Issue #557
+	//
+	// Reset the body recovered flag. A unit that was previously carried to evac while KO'd/bleeding
+	// out will have this flag set, and this flag prevents units from being carried. If this unit
+	// gets KO'd again, they won't be able to be picked up if this flag is still set.
+	bBodyRecovered = false;
+	// End Issue #557
 }
 
 function ApplyFirstTimeStatModifiers()


### PR DESCRIPTION
The problem was that the game was setting the `bBodyRecovered` flag to true and then never clearing it again. So you could carry a soldier out once, but never again on any future missions.

This fix simply clears the flag at the beginning of tactical play. Fixed #557.