### PR TITLE
#561 SitReps additional checks event

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -128,6 +128,7 @@ RunPriorityGroup=RUN_STANDARD
 - Triggers the event `CovertAction_AllowResActivityRecord` to allow mods to enable/disable "covert action completed"
   record for the monthly resistance report (#696)
 - Triggers the event `OverrideDarkEventCount` to allow mods to change the number of dark events in the monthly report (#711)
+- Triggers the event `SitRepCheckAdditionalRequirements` to allow mods to perform additional checks for sitrep eligibility for a mission (#561)
 
 ### Modding Exposures
 - Allows mods to add custom items to the Avenger Shortcuts (#163)

--- a/X2WOTCCommunityHighlander/Src/XComGame/Classes/X2SitRepTemplate.uc
+++ b/X2WOTCCommunityHighlander/Src/XComGame/Classes/X2SitRepTemplate.uc
@@ -107,8 +107,34 @@ function bool MeetsRequirements(XComGameState_MissionSite MissionState)
 		return false;
 	}
 
+	// Start issue #561
+	if (!TriggerAdditionalChecks(MissionState))
+	{
+		return false;
+	}
+	// End issue #561
+
 	return true;
 }
+
+// Start issue #561
+function bool TriggerAdditionalChecks(XComGameState_MissionSite MissionState)
+{
+	local XComLWTuple Tuple;
+
+	Tuple = new class'XComLWTuple';
+	Tuple.Id = 'SitRepCheckAdditionalRequirements';
+	Tuple.Data.Add(2);
+	Tuple.Data[0].kind = XComLWTVBool;
+	Tuple.Data[0].b = true;
+	Tuple.Data[1].kind = XComLWTVObject;
+	Tuple.Data[1].o = MissionState;
+
+	`XEVENTMGR.TriggerEvent('SitRepCheckAdditionalRequirements', Tuple, self);
+
+	return Tuple.Data[0].b;
+}
+// End issue #561
 
 static function bool CanLaunchMission(XComGameState_MissionSite Mission, out string FailReason)
 {


### PR DESCRIPTION
Closes #561 

Note that this PR includes commit 8b9e4d8 from #567 - this is the best I could do to prevent them from conflicting as they both augment `X2SitRepTemplate` which is currently not included in CHL's master