### PR TITLE
Fix rocket targeting

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -246,6 +246,8 @@ RunPriorityGroup=RUN_STANDARD
   a pod tries to patrol to any of them (#508)
 - Make disorient reapply to disoriented units so that things like flashbangs can
   still remove overwatch from disoriented units (#475)
+- Fix rocket targeting so that it isn't always unobstructed when the shooter has
+  a valid step-out tile (#617)
 
 
 ## Miscellaneous

--- a/X2WOTCCommunityHighlander/Src/XComGame/Classes/X2TargetingMethod_RocketLauncher.uc
+++ b/X2WOTCCommunityHighlander/Src/XComGame/Classes/X2TargetingMethod_RocketLauncher.uc
@@ -1,0 +1,76 @@
+class X2TargetingMethod_RocketLauncher extends X2TargetingMethod_Grenade;
+
+var vector NewTargetLocation;
+
+static function bool UseGrenadePath() { return false; }
+
+function Update(float DeltaTime)
+{
+	local XComWorldData World;
+	local VoxelRaytraceCheckResult Raytrace;
+	local array<Actor> CurrentlyMarkedTargets;
+	local int Direction, CanSeeFromDefault;
+	local UnitPeekSide PeekSide;
+	local int OutRequiresLean;
+	local TTile BlockedTile, PeekTile, UnitTile;
+	local bool GoodView;
+	local CachedCoverAndPeekData PeekData;
+	local array<TTile> Tiles;
+	local GameRulesCache_VisibilityInfo OutVisibilityInfo;
+
+	NewTargetLocation = Cursor.GetCursorFeetLocation();
+
+	if( NewTargetLocation != CachedTargetLocation )
+	{
+		World = `XWORLD;
+		GoodView = false;
+		if( World.VoxelRaytrace_Locations(FiringUnit.Location, NewTargetLocation, Raytrace) )
+		{
+			BlockedTile = Raytrace.BlockedTile; 
+			//  check left and right peeks
+			FiringUnit.GetDirectionInfoForPosition(NewTargetLocation, OutVisibilityInfo, Direction, PeekSide, CanSeeFromDefault, OutRequiresLean, true);
+
+			if (PeekSide != eNoPeek)
+			{
+				UnitTile = World.GetTileCoordinatesFromPosition(FiringUnit.Location);
+				PeekData = World.GetCachedCoverAndPeekData(UnitTile);
+				if (PeekSide == ePeekLeft)
+					PeekTile = PeekData.CoverDirectionInfo[Direction].LeftPeek.PeekTile;
+				else
+					PeekTile = PeekData.CoverDirectionInfo[Direction].RightPeek.PeekTile;
+
+				if (!World.VoxelRaytrace_Tiles(UnitTile, PeekTile, Raytrace))
+					GoodView = true;
+				else
+					BlockedTile = Raytrace.BlockedTile;
+			}				
+		}		
+		else
+		{
+			GoodView = true;
+		}
+
+		if( !GoodView )
+		{
+			NewTargetLocation = World.GetPositionFromTileCoordinates(BlockedTile);
+		}
+		GetTargetedActors(NewTargetLocation, CurrentlyMarkedTargets, Tiles);
+		CheckForFriendlyUnit(CurrentlyMarkedTargets);	
+		MarkTargetedActors(CurrentlyMarkedTargets, (!AbilityIsOffensive) ? FiringUnit.GetTeam() : eTeam_None );
+		DrawSplashRadius();
+		DrawAOETiles(Tiles);
+	}
+
+	super.UpdateTargetLocation(DeltaTime);
+}
+
+simulated protected function Vector GetSplashRadiusCenter( bool SkipTileSnap = false )
+{
+	return NewTargetLocation;
+}
+
+function GetTargetLocations(out array<Vector> TargetLocations)
+{
+	TargetLocations.Length = 0;
+	TargetLocations.AddItem(NewTargetLocation);
+}

--- a/X2WOTCCommunityHighlander/Src/XComGame/Classes/X2TargetingMethod_RocketLauncher.uc
+++ b/X2WOTCCommunityHighlander/Src/XComGame/Classes/X2TargetingMethod_RocketLauncher.uc
@@ -13,6 +13,7 @@ function Update(float DeltaTime)
 	local UnitPeekSide PeekSide;
 	local int OutRequiresLean;
 	local TTile BlockedTile, PeekTile, UnitTile;
+	local TTile TargetTile;   // Issue #617
 	local bool GoodView;
 	local CachedCoverAndPeekData PeekData;
 	local array<TTile> Tiles;
@@ -39,10 +40,15 @@ function Update(float DeltaTime)
 				else
 					PeekTile = PeekData.CoverDirectionInfo[Direction].RightPeek.PeekTile;
 
-				if (!World.VoxelRaytrace_Tiles(UnitTile, PeekTile, Raytrace))
+				// Start Issue #617
+				//
+				// Ray trace from the peek tile to the target, not from the unit tile to the peek tile.
+				TargetTile = World.GetTileCoordinatesFromPosition(NewTargetLocation);
+				if (!World.VoxelRaytrace_Tiles(PeekTile, TargetTile, Raytrace))
 					GoodView = true;
 				else
 					BlockedTile = Raytrace.BlockedTile;
+				// End Issue #617
 			}				
 		}		
 		else

--- a/X2WOTCCommunityHighlander/X2WOTCCommunityHighlander.x2proj
+++ b/X2WOTCCommunityHighlander/X2WOTCCommunityHighlander.x2proj
@@ -416,6 +416,9 @@
     <Content Include="Src\XComGame\Classes\X2TacticalGameRulesetDataStructures.uc">
       <SubType>Content</SubType>
     </Content>
+    <Content Include="Src\XComGame\Classes\X2TargetingMethod_RocketLauncher.uc">
+      <SubType>Content</SubType>
+    </Content>
     <Content Include="Src\XComGame\Classes\X2UnifiedProjectile.uc">
       <SubType>Content</SubType>
     </Content>


### PR DESCRIPTION
`X2TargetingMethod_RocketLauncher` now checks the firing line between the step-out (peek) tile and the target, rather than between the unit tile and the peek tile. The latter meant that no matter what tile you targeted, it would be an unobstructed path.