### PR TITLE
Allow mods to override the time it takes to respec a soldier

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -90,6 +90,8 @@ RunPriorityGroup=RUN_STANDARD
   other ways than just the tooltip and image (#537)
 - Triggers the event `MissionIconSetScanSite` to allow mods to customize a scan site's icon in other
   ways than just the tooltip and image (#537)
+- Triggers the event `OverrideRespecSoldierProjectPoints` to allow mods to customize how long it should
+  take to respec a given soldier (#624)
 
 
 ### Modding Exposures

--- a/X2WOTCCommunityHighlander/Src/XComGame/Classes/XComGameState_HeadquartersProjectRespecSoldier.uc
+++ b/X2WOTCCommunityHighlander/Src/XComGame/Classes/XComGameState_HeadquartersProjectRespecSoldier.uc
@@ -1,0 +1,88 @@
+//---------------------------------------------------------------------------------------
+//  FILE:    XComGameState_HeadquartersProjectRespecSoldier.uc
+//  AUTHOR:  Joe Weinhoffer  --  06/05/2015
+//  PURPOSE: This object represents the instance data for an XCom HQ respec soldier project
+//           Will eventually be a component
+//           
+//---------------------------------------------------------------------------------------
+//  Copyright (c) 2016 Firaxis Games, Inc. All rights reserved.
+//---------------------------------------------------------------------------------------
+class XComGameState_HeadquartersProjectRespecSoldier extends XComGameState_HeadquartersProject native(Core);
+
+//---------------------------------------------------------------------------------------
+// Call when you start a new project, NewGameState should be none if not coming from tactical
+function SetProjectFocus(StateObjectReference FocusRef, optional XComGameState NewGameState, optional StateObjectReference AuxRef)
+{
+	local XComGameStateHistory History;
+	local XComGameState_GameTime TimeState;
+	local XComGameState_Unit UnitState;
+
+	History = `XCOMHISTORY;
+	ProjectFocus = FocusRef; // Unit
+	AuxilaryReference = AuxRef; // Facility
+	
+	UnitState = XComGameState_Unit(NewGameState.GetGameStateForObjectID(ProjectFocus.ObjectID));
+	//UnitState.PsiTrainingRankReset();
+	UnitState.SetStatus(eStatus_Training);
+	
+	ProjectPointsRemaining = CalculatePointsToRespec();
+	InitialProjectPoints = ProjectPointsRemaining;
+
+	UpdateWorkPerHour(NewGameState);
+	TimeState = XComGameState_GameTime(History.GetSingleGameStateObjectForClass(class'XComGameState_GameTime'));
+	StartDateTime = TimeState.CurrentTime;
+
+	if (`STRATEGYRULES != none)
+	{
+		if (class'X2StrategyGameRulesetDataStructures'.static.LessThan(TimeState.CurrentTime, `STRATEGYRULES.GameTime))
+		{
+			StartDateTime = `STRATEGYRULES.GameTime;
+		}
+	}
+
+	if (MakingProgress())
+	{
+		SetProjectedCompletionDateTime(StartDateTime);
+	}
+	else
+	{
+		// Set completion time to unreachable future
+		CompletionDateTime.m_iYear = 9999;
+	}
+}
+
+//---------------------------------------------------------------------------------------
+function int CalculatePointsToRespec()
+{
+	local XComGameStateHistory History;
+	local XComGameState_HeadquartersXCom XComHQ;
+
+	History = `XCOMHISTORY;
+	XComHQ = XComGameState_HeadquartersXCom(History.GetSingleGameStateObjectForClass(class'XComGameState_HeadquartersXCom'));
+	return XComHQ.GetRespecSoldierDays() * 24;
+}
+
+//---------------------------------------------------------------------------------------
+function int CalculateWorkPerHour(optional XComGameState StartState = none, optional bool bAssumeActive = false)
+{
+	return 1;
+}
+
+//---------------------------------------------------------------------------------------
+// Remove the project
+function OnProjectCompleted()
+{
+	local HeadquartersOrderInputContext OrderInput;
+	
+	OrderInput.OrderType = eHeadquartersOrderType_RespecSoldierCompleted;
+	OrderInput.AcquireObjectReference = self.GetReference();
+
+	class'XComGameStateContext_HeadquartersOrder'.static.IssueHeadquartersOrder(OrderInput);
+
+	`HQPRES.UITrainingComplete(ProjectFocus);
+}
+
+//---------------------------------------------------------------------------------------
+DefaultProperties
+{
+}

--- a/X2WOTCCommunityHighlander/X2WOTCCommunityHighlander.x2proj
+++ b/X2WOTCCommunityHighlander/X2WOTCCommunityHighlander.x2proj
@@ -473,6 +473,9 @@
     <Content Include="Src\XComGame\Classes\XComGameState_HeadquartersProjectPsiTraining.uc">
       <SubType>Content</SubType>
     </Content>
+    <Content Include="Src\XComGame\Classes\XComGameState_HeadquartersProjectRespecSoldier.uc">
+      <SubType>Content</SubType>
+    </Content>
     <Content Include="Src\XComGame\Classes\XComGameState_HeadquartersResistance.uc">
       <SubType>Content</SubType>
     </Content>


### PR DESCRIPTION
See second commit for more details, but this basically adds an event to `XComGameState_HeadquartersProjectRespecSoldier.SetProjectFocus()` that allows listeners to override the initial project points required to complete the retraining project.