### PR TITLE
Allow mods to override the science score (#626)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -90,7 +90,8 @@ RunPriorityGroup=RUN_STANDARD
   other ways than just the tooltip and image (#537)
 - Triggers the event `MissionIconSetScanSite` to allow mods to customize a scan site's icon in other
   ways than just the tooltip and image (#537)
-
+- Triggers the event `OverrideScienceScore` to allow mods to override the XCOM HQ science score, for
+  example to add their own bonuses or to remove scientists that are engaged in other activities.
 
 ### Modding Exposures
 - Allows mods to add custom items to the Avenger Shortcuts (#163)

--- a/X2WOTCCommunityHighlander/Src/XComGame/Classes/XComGameState_HeadquartersXCom.uc
+++ b/X2WOTCCommunityHighlander/Src/XComGame/Classes/XComGameState_HeadquartersXCom.uc
@@ -2645,8 +2645,48 @@ function int GetScienceScore(optional bool bAddLabBonus = false)
 		}
 	}
 
-	return Score;
+	// Start Issue #626
+	return TriggerOverrideScienceScore(Score, bAddLabBonus);
+	// End Issue #626
 }
+
+// Start Issue #626
+//
+// Fires an 'OverrideScienceScore' event that allows listeners to override
+// the current science score, for example to apply bonuses or to remove scientists
+// that are on other jobs. If the `AddLabBonus` is true, then the game is
+// calculating the actual science score contributing to tech research progress.
+// If it's false, then the game is just checking whether a tech's or item's
+// science score requirement has been met.
+//
+// The event takes the form:
+//
+//  {
+//     ID: OverrideScienceScore,
+//     Data: [inout int ScienceScore, in bool AddLabBonus],
+//     Source: self (XCGS_HeadquartersXCom)
+//  }
+//
+// This function returns the new science score (or the original one if no listeners
+// modified it).
+//
+function int TriggerOverrideScienceScore(int BaseScienceScore, bool AddLabBonus)
+{
+	local XComLWTuple OverrideTuple;
+
+	OverrideTuple = new class'XComLWTuple';
+	OverrideTuple.Id = 'OverrideScienceScore';
+	OverrideTuple.Data.Add(2);
+	OverrideTuple.Data[0].Kind = XComLWTVInt;
+	OverrideTuple.Data[0].i = BaseScienceScore;
+	OverrideTuple.Data[1].Kind = XComLWTVBool;
+	OverrideTuple.Data[1].b = AddLabBonus;
+
+	`XEVENTMGR.TriggerEvent('OverrideScienceScore', OverrideTuple, self);
+
+	return OverrideTuple.Data[0].i;
+}
+// End Issue #626
 
 //---------------------------------------------------------------------------------------
 native function bool IsUnitInSquad(StateObjectReference UnitRef);


### PR DESCRIPTION
I have added an 'OverrideScienceScore' event that's fired from `XCGS_HeadquartersXCom.GetScienceScore()`. This event allows mods to override the game's science score, for example to add their own bonuses or to discount scientists that are doing other jobs.

The event takes the form:
```
 {
    ID: OverrideScienceScore,
    Data: [inout int ScienceScore, in bool AddLabBonus],
    Source: XCGS_HeadquartersXCom,
 }
```

Note that `AddLabBonus` indicates whether the game is requesting the science score that is contributing to research progress (`true`) or is checking whether there are enough scientists to meet a tech's or item's science score requirement (`false`).

Resolves #626.