### PR TITLE
Add event for overriding ShowPromoteIcon (#631)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -90,7 +90,8 @@ RunPriorityGroup=RUN_STANDARD
   other ways than just the tooltip and image (#537)
 - Triggers the event `MissionIconSetScanSite` to allow mods to customize a scan site's icon in other
   ways than just the tooltip and image (#537)
-
+- Triggers the event `OverrideShowPromoteIcon` to allow mods to override whether the promotion icon is
+  displayed for a given soldier or not (#631)
 
 ### Modding Exposures
 - Allows mods to add custom items to the Avenger Shortcuts (#163)

--- a/X2WOTCCommunityHighlander/Src/XComGame/Classes/XComGameState_Unit.uc
+++ b/X2WOTCCommunityHighlander/Src/XComGame/Classes/XComGameState_Unit.uc
@@ -12508,7 +12508,19 @@ function SCATProgression GetSCATProgressionForAbility(name AbilityName)
 // Show the promotion icon (in strategy)
 function bool ShowPromoteIcon()
 {
-	return (IsAlive() && !bCaptured && (CanRankUpSoldier() || HasAvailablePerksToAssign()));
+	// Start Issue #631
+	local XComLWTuple OverrideTuple;
+
+	OverrideTuple = new class'XComLWTuple';
+	OverrideTuple.Id = 'OverrideShowPromoteIcon';
+	OverrideTuple.Data.Add(1);
+	OverrideTuple.Data[0].kind = XComLWTVBool;
+	OverrideTuple.Data[0].b = (IsAlive() && !bCaptured && (CanRankUpSoldier() || HasAvailablePerksToAssign()));
+
+	`XEVENTMGR.TriggerEvent('OverrideShowPromoteIcon', OverrideTuple, self);
+
+	return OverrideTuple.Data[0].b;
+	// End Issue #631
 }
 
 function bool ShowBondAvailableIcon(out StateObjectReference BondmateRef, out SoldierBond BondData)


### PR DESCRIPTION
Mods can now override whether a promotion icon is displayed for units or not. They just need to pass true or false back from an 'OverrideShowPromoteIcon' event fired from `XCGS_Unit.ShowPromoteIcon()` that takes the form:

```
  {
    ID: OverrideShowPromoteIcon,
    Data: [inout bool ShouldShowPromoteIcon],
    Source: XComGameState_Unit,
 }
```