### PR TITLE
Allow mods to control which techs can be inspired (#633)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -90,7 +90,8 @@ RunPriorityGroup=RUN_STANDARD
   other ways than just the tooltip and image (#537)
 - Triggers the event `MissionIconSetScanSite` to allow mods to customize a scan site's icon in other
   ways than just the tooltip and image (#537)
-
+- Triggers the event `CanTechBeInspired` to allow mods to block techs from being inspired, even if they
+  meet the vanilla game's conditions for it (#633)
 
 ### Modding Exposures
 - Allows mods to add custom items to the Avenger Shortcuts (#163)

--- a/X2WOTCCommunityHighlander/Src/XComGame/Classes/XComGameState_HeadquartersXCom.uc
+++ b/X2WOTCCommunityHighlander/Src/XComGame/Classes/XComGameState_HeadquartersXCom.uc
@@ -6882,7 +6882,7 @@ function CheckForInspiredTechs(XComGameState NewGameState)
 				// Start Issue #633
 				//
 				// Check with mods to determine whether this tech can be inspired or not.
-				if (!TriggerCanTechBeInspired(AvailableTechState))
+				if (!TriggerCanTechBeInspired(AvailableTechState, NewGameState))
 				{
 					continue;
 				}
@@ -6921,25 +6921,23 @@ function CheckForInspiredTechs(XComGameState NewGameState)
 //
 //   {
 //      ID: CanTechBeInspired,
-//      Data: [in XCGS_Tech Tech, inout bool CanBeInspired],
-//      Source: self (XCGS_HeadquartersXCom)
+//      Data: [inout bool CanBeInspired],
+//      Source: TechState (XCGS_Tech)
 //   }
 //
-function bool TriggerCanTechBeInspired(XComGameState_Tech TechState)
+private function bool TriggerCanTechBeInspired(XComGameState_Tech TechState, XComGameState NewGameState)
 {
 	local XComLWTuple Tuple;
 
 	Tuple = new class'XComLWTuple';
 	Tuple.Id = 'CanTechBeInspired';
-	Tuple.Data.Add(2);
-	Tuple.Data[0].Kind = XComLWTVObject;
-	Tuple.Data[0].o = TechState;
-	Tuple.Data[1].Kind = XComLWTVBool;
-	Tuple.Data[1].b = true;
+	Tuple.Data.Add(1);
+	Tuple.Data[0].Kind = XComLWTVBool;
+	Tuple.Data[0].b = true;
 
-	`XEVENTMGR.TriggerEvent('CanTechBeInspired', Tuple, self);
+	`XEVENTMGR.TriggerEvent('CanTechBeInspired', Tuple, TechState, NewGameState);
 
-	return Tuple.Data[1].b;
+	return Tuple.Data[0].b;
 }
 // End Issue #633
 

--- a/X2WOTCCommunityHighlander/Src/XComGame/Classes/XComGameState_HeadquartersXCom.uc
+++ b/X2WOTCCommunityHighlander/Src/XComGame/Classes/XComGameState_HeadquartersXCom.uc
@@ -6877,17 +6877,9 @@ function CheckForInspiredTechs(XComGameState NewGameState)
 			// Prevent any techs which could be made instant (autopsies), or which have already been reduced by purchasing tech reductions from the black market
 			// and only inspire techs which the player can afford
 			if (!TechTemplate.bCheckForceInstant && AvailableTechState.TimeReductionScalar < 0.001f && !HasPausedProject(AvailableTechRefs[TechIndex]) &&
-				MeetsRequirmentsAndCanAffordCost(TechTemplate.Requirements, TechTemplate.Cost, default.ResearchCostScalars, , TechTemplate.AlternateRequirements))
+				MeetsRequirmentsAndCanAffordCost(TechTemplate.Requirements, TechTemplate.Cost, default.ResearchCostScalars, , TechTemplate.AlternateRequirements) &&
+				/* Issue #633 */ TriggerCanTechBeInspired(AvailableTechState, NewGameState))
 			{
-				// Start Issue #633
-				//
-				// Check with mods to determine whether this tech can be inspired or not.
-				if (!TriggerCanTechBeInspired(AvailableTechState, NewGameState))
-				{
-					continue;
-				}
-				// End Issue #633
-
 				AvailableTechState = XComGameState_Tech(NewGameState.ModifyStateObject(class'XComGameState_Tech', AvailableTechState.ObjectID));
 				AvailableTechState.bInspired = true;
 				AvailableTechState.TimeReductionScalar = ((default.MinInspiredTechTimeReduction + `SYNC_RAND(default.MaxInspiredTechTimeReduction - default.MinInspiredTechTimeReduction + 1)) / 100.0f);


### PR DESCRIPTION
This adds a 'CanTechBeInspired' event fired from `XCGS_HeadquartersXCom.CheckForInspiredTechs()` that allows mods to block techs from being inspired. Mods simply need to implement a
listener that returns `false` in the tuple's bool field for those techs that it doesn't want to be inspired.

The event takes the form:

```
  {
    ID: CanTechBeInspired,
    Data: [in XCGS_Tech Tech, inout bool CanTechBeInspired],
    Source: XCGS_HeadquartersXCom,
 }
```