### PR TITLE
Allow cosmetic body parts to contain more than just skeletal meshes (#641)

### DIFF
--- a/X2WOTCCommunityHighlander/Src/XComGame/Classes/XComBodyPartContentAdvanced.uc
+++ b/X2WOTCCommunityHighlander/Src/XComGame/Classes/XComBodyPartContentAdvanced.uc
@@ -1,0 +1,10 @@
+//-----------------------------------------------------------
+//	Class:	XComBodyPartContentAdvanced
+//	Author: xyman
+//	
+//-----------------------------------------------------------
+
+
+class XComBodyPartContentAdvanced extends XComBodyPartContent;
+
+var() array<Actor> Archetypes;

--- a/X2WOTCCommunityHighlander/Src/XComGame/Classes/XComBodyPartContentAdvanced.uc
+++ b/X2WOTCCommunityHighlander/Src/XComGame/Classes/XComBodyPartContentAdvanced.uc
@@ -1,9 +1,12 @@
-//-----------------------------------------------------------
-//	Class:	XComBodyPartContentAdvanced
-//	Author: xyman
-//	
-//-----------------------------------------------------------
-
+//---------------------------------------------------------------------------------------
+//  FILE:    XComBodyPartContentAdvanced
+//  AUTHOR:  Xymanek
+//           
+//  Allows cosmetic mods to attach arbitrary actors (eg. EmitterSpawnable) to a body part
+//
+//---------------------------------------------------------------------------------------
+// File added to the CHL (this is a non-base game class). Issue #641
+//---------------------------------------------------------------------------------------
 
 class XComBodyPartContentAdvanced extends XComBodyPartContent;
 

--- a/X2WOTCCommunityHighlander/X2WOTCCommunityHighlander.x2proj
+++ b/X2WOTCCommunityHighlander/X2WOTCCommunityHighlander.x2proj
@@ -434,6 +434,9 @@
     <Content Include="Src\XComGame\Classes\XComAutosaveMgr.uc">
       <SubType>Content</SubType>
     </Content>
+    <Content Include="Src\XComGame\Classes\XComBodyPartContentAdvanced.uc">
+      <SubType>Content</SubType>
+    </Content>
     <Content Include="Src\XComGame\Classes\XComEngine.uc">
       <SubType>Content</SubType>
     </Content>


### PR DESCRIPTION
Closes #641

Currently the implementation has a small problem - the effects aren't being removed after existing from cinematic. This can be encountered in 2 places;

* Armory (eg. class intro movie)
* Mission intro

![image](https://user-images.githubusercontent.com/2865341/65909048-5f1dc500-e3d0-11e9-9a45-90987fef893c.png)

Will provide video if needed

cc @robojumper 

P.S. Here is the use of this PR: https://github.com/WOTCStrategyOverhaul/CovertInfiltration/pull/259