### PR TITLE
Fix teleporting enemy units basegame bug (#644)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -246,7 +246,8 @@ RunPriorityGroup=RUN_STANDARD
   a pod tries to patrol to any of them (#508)
 - Make disorient reapply to disoriented units so that things like flashbangs can
   still remove overwatch from disoriented units (#475)
-
+- Prevent patrolling enemy units from teleporting behind XCOM and revealing the
+  squad (#644)
 
 ## Miscellaneous
 

--- a/X2WOTCCommunityHighlander/Src/XComGame/Classes/X2Ability_DefaultAbilitySet.uc
+++ b/X2WOTCCommunityHighlander/Src/XComGame/Classes/X2Ability_DefaultAbilitySet.uc
@@ -412,6 +412,23 @@ simulated static function XComGameState MoveAbility_BuildInterruptGameState( XCo
 				{
 					class'Helpers'.static.RemoveTileSubset(ValidTileList, ValidTileList, OccupiedTiles);
 				}
+
+				// Start Issue #644
+				//
+				// Borrowed this implementation from the original LW2, which fixed the bug with patrolling
+				// units teleporting behind XCOM here. See this Reddit comment for some more info:
+				//
+				//  https://www.reddit.com/r/Xcom/comments/5qnob0/lw2_particularly_deadly_teleport_bug_on_supply/dd0uhjk/
+				//
+				// Old LWS comment: handle use case where ValidTileList has been reduced to 0 elements.
+				// Allow units to occupy same tile in this case reset the ValidTilesList back to the default,
+				// so that a tile will be selected instead of allowing a (0,0,0) tiles to be entered by default
+				if (ValidTileList.Length == 0)
+				{
+					ValidTileList = AbilityContext.InputContext.MovementPaths[MovingUnitIndex].MovementTiles;
+				}
+				// End Issue #644
+
 				NumMovementTiles = ValidTileList.Length;
 				UseInterruptStep = Min(InterruptStep, NumMovementTiles - 1);
 


### PR DESCRIPTION
Units in large pods could sometimes find themselves without any valid tiles to walk through/to, which would cause them to teleport to another part of the map.

See [this Reddit post](https://www.reddit.com/r/Xcom/comments/5qnob0/lw2_particularly_deadly_teleport_bug_on_supply/) for an explanation of the problem and some extra background.

This fix replicates what LW2 did to fix the same issue, by forcing some valid tiles for the unit to move to. Thanks to Amineri (of Pavonis Interactive) for the original code.

Fixes #644.