### PR TITLE
Ensure effects tick correctly after mind control (#643)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -187,6 +187,8 @@ RunPriorityGroup=RUN_STANDARD
 - `OverrideAbilityIconColor` provides a tuple with the same ID as the
   event and data of the form `[bool IsObjective, string Color]` that allows
   mods to override the color of soldier abilities in the tactical HUD (#400)
+- `MindControlLost` fires whenever a unit stops being mind controlled or hacked. The event
+  passes the affected unit state as both event data and event source (#643)
 
 ### Configuration
 - Added ability to modify default spawn size (#18)
@@ -246,7 +248,6 @@ RunPriorityGroup=RUN_STANDARD
   a pod tries to patrol to any of them (#508)
 - Make disorient reapply to disoriented units so that things like flashbangs can
   still remove overwatch from disoriented units (#475)
-
 
 ## Miscellaneous
 

--- a/X2WOTCCommunityHighlander/Src/XComGame/Classes/X2Effect_MindControl.uc
+++ b/X2WOTCCommunityHighlander/Src/XComGame/Classes/X2Effect_MindControl.uc
@@ -126,6 +126,10 @@ simulated function OnEffectRemoved(const out EffectAppliedData ApplyEffectParame
 		}
 	}
 	UpdateAIData(NewGameState, UnitState, false);
+
+	// Start Issue #643
+	`XEVENTMGR.TriggerEvent('MindControlLost', UnitState, UnitState, NewGameState);
+	// End Issue #643
 }
 
 simulated function AddX2ActionsForVisualization(XComGameState VisualizeGameState, out VisualizationActionMetadata ActionMetadata, name EffectApplyResult)


### PR DESCRIPTION
Mind control is a nightmare. The issue here is that many effects use `XCGS_Effect.OnPlayerTurnTicked()` and `OnGroupTurnTicked()` to manage effect behaviour. However, those listeners are typically registered for specific players or unit groups. Mind control changes those, so the registered listeners stop working.

This change swaps those registered listeners for ones that use the correct player/unit group filter when the mind control is lost. In addition, it ensures the effect's `PlayerStateObjectRef` is updated to
the new player, because otherwise the listeners will skip the tick behaviour.

As this is a bit of a brute force technique, it only applies to effects that are listed in `CHHelpers.TickOnMindControlRemovalEffects`.

Fixes #643.