### PR TITLE
Fix handling of Esc for hacks that have started (#648)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -246,7 +246,8 @@ RunPriorityGroup=RUN_STANDARD
   a pod tries to patrol to any of them (#508)
 - Make disorient reapply to disoriented units so that things like flashbangs can
   still remove overwatch from disoriented units (#475)
-
+- Fix issue where trying to break out of a hack that has already been started using the
+  Esc key or the right mouse button bypasses Haywire's cooldown (#648)
 
 ## Miscellaneous
 


### PR DESCRIPTION
This adds some checks to `UIHackingScreen`'s `OnCancel` handler to ensure that the hack isn't "cancelled" after it has been started, thus refunding charges or taking Haywire back off cooldown.

Note that the fix comes from the vanilla highlander.

Fixes #648.