### PR TITLE
Add OnLoadedSavedGameToTactical() to X2DownloadableContentInfo (#647)

### DIFF
--- a/X2WOTCCommunityHighlander/Src/XComGame/Classes/X2DownloadableContentInfo.uc
+++ b/X2WOTCCommunityHighlander/Src/XComGame/Classes/X2DownloadableContentInfo.uc
@@ -55,6 +55,18 @@ static event OnLoadedSavedGameToStrategy()
 
 }
 
+
+
+//Start issue #647
+/// <summary>
+/// This method is run when the player loads a saved game directly into Tactical while this DLC is installed
+/// </summary>
+static event OnLoadedSavedGameToTactical()
+{
+
+}
+//#end issue #647
+
 /// <summary>
 /// Called when the player starts a new campaign while this DLC / Mod is installed. When a new campaign is started the initial state of the world
 /// is contained in a strategy start state. Never add additional history frames inside of InstallNewCampaign, add new state objects to the start state

--- a/X2WOTCCommunityHighlander/Src/XComGame/Classes/X2TacticalGameRuleset.uc
+++ b/X2WOTCCommunityHighlander/Src/XComGame/Classes/X2TacticalGameRuleset.uc
@@ -3506,6 +3506,10 @@ Begin:
 		Pres.UINarrative(TutorialIntro);		
 	}
 
+	//Start Issue #647
+	UpdateDLCLoadingTacticalGame();
+	//End Issue #647
+
 	//Movie handline - for both the tutorial and normal loading
 	while(class'XComEngine'.static.IsAnyMoviePlaying() && !class'XComEngine'.static.IsLoadingMoviePlaying())
 	{
@@ -5530,6 +5534,24 @@ simulated function name GetNextTurnPhase(name CurrentState, optional name Defaul
 	`assert(false);
 	return DefaultPhaseName;
 }
+
+
+//Start issue #647
+function UpdateDLCLoadingTacticalGame()
+{
+	local XComOnlineEventMgr EventManager;
+	local array<X2DownloadableContentInfo> DLCInfos;
+	local int i;
+
+	EventManager = `ONLINEEVENTMGR;
+	DLCInfos = EventManager.GetDLCInfos(false);
+	for (i = 0; i < DLCInfos.Length; ++i)
+	{
+		DLCInfos[i].OnLoadedSavedGameToTactical();
+	}
+}
+//End issue #647
+
 
 function StateObjectReference GetCachedUnitActionPlayerRef()
 {


### PR DESCRIPTION
This allows mods to call OnLoadedSavedGameToTactical() upon loading a saved game into a mission. 

Fixes Issue #647 