### PR TITLE
Allow Traits to be Modified by External Sources in XComGameState_Unit

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -97,6 +97,7 @@ RunPriorityGroup=RUN_STANDARD
 - UIScanButton now calls OnMouseEventDelegate (#483). Note: DO NOT call ProcessMouseEvents, just set the delegate directly
 - Remove `private` from `X2AIBTBehaviorTree.Behaviors` so that mods can change the behavior trees without
   overwriting all the necessary entries (#410)
+- Removed `protectedwrite` from `AcquiredTraits`, `PendingTraits`, and `CuredTraits` in `XComGameState_Unit`, allowing Traits to be modified by external sources (#681)
 
 ### Configuration
 - Allow disabling of Factions being initialized on startup by

--- a/X2WOTCCommunityHighlander/Src/XComGame/Classes/XComGameState_Unit.uc
+++ b/X2WOTCCommunityHighlander/Src/XComGame/Classes/XComGameState_Unit.uc
@@ -156,9 +156,11 @@ var() int StunnedActionPoints, StunnedThisTurn;                     //Number of 
 var() int Ruptured;                                                 //Ruptured amount is permanent extra damage this unit suffers from each attack.
 var() int Shredded;                                                 //Shredded amount is always subtracted from any armor mitigation amount.
 var() int Untouchable;                                              //Number of times this unit can freely dodge attacks.
+//start issue #681: Allows Traits to be Modified by External Sources
 var() array<name> AcquiredTraits;                    								//X2TraitTemplates that this unit currently possesses
 var() array<name> PendingTraits;                     								//X2TraitTemplates whose criteria have been met, and will be applied at the end of the mission
 var() array<name> CuredTraits;											 								//X2TraitTemplates who were previously acquired and are thus unavailable to be re-acquired
+//end issue #681
 var() array<name> WorldMessageTraits;								//Cleared after seeing world message on the Avenger
 var() array<name> AlertTraits;										//Cleared after seeing the trait alert (floating icon displays until cleared)
 var() XComGameStateContext_Ability ReflectedAbilityContext;			//Original context of last reflected ability

--- a/X2WOTCCommunityHighlander/Src/XComGame/Classes/XComGameState_Unit.uc
+++ b/X2WOTCCommunityHighlander/Src/XComGame/Classes/XComGameState_Unit.uc
@@ -156,9 +156,9 @@ var() int StunnedActionPoints, StunnedThisTurn;                     //Number of 
 var() int Ruptured;                                                 //Ruptured amount is permanent extra damage this unit suffers from each attack.
 var() int Shredded;                                                 //Shredded amount is always subtracted from any armor mitigation amount.
 var() int Untouchable;                                              //Number of times this unit can freely dodge attacks.
-var() protectedwrite array<name> AcquiredTraits;                    //X2TraitTemplates that this unit currently possesses
-var() protectedwrite array<name> PendingTraits;                     //X2TraitTemplates whose criteria have been met, and will be applied at the end of the mission
-var() protectedwrite array<name> CuredTraits;						//X2TraitTemplates who were previously acquired and are thus unavailable to be re-acquired
+var() array<name> AcquiredTraits;                    								//X2TraitTemplates that this unit currently possesses
+var() array<name> PendingTraits;                     								//X2TraitTemplates whose criteria have been met, and will be applied at the end of the mission
+var() array<name> CuredTraits;											 								//X2TraitTemplates who were previously acquired and are thus unavailable to be re-acquired
 var() array<name> WorldMessageTraits;								//Cleared after seeing world message on the Avenger
 var() array<name> AlertTraits;										//Cleared after seeing the trait alert (floating icon displays until cleared)
 var() XComGameStateContext_Ability ReflectedAbilityContext;			//Original context of last reflected ability


### PR DESCRIPTION
Removed protectedwrite from AcquiredTraits, PendingTraits, and CuredTraits.

Currently it's not possible to remove a specific Trait from an unit.
These changes allows anyone to modify the unit's current traits.