### PR TITLE
Fix 1-day will recoveries from Shaken/Tired (#637)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -392,3 +392,6 @@ RunPriorityGroup=RUN_STANDARD
   UIScreen (#341)
 - Appearances now update correctly when a part change differs only by material override (#354)
 - All relevant body parts are now correctly validated when the torso is changed. (#350)
+- The will recovery project and soldier mental state are now consistent with each other
+  on borderline will values, whereas a rounding error previously could cause will recovery
+  to take a day for Shaken or Tired (#637)

--- a/X2WOTCCommunityHighlander/Src/XComGame/Classes/XComGameState_Unit.uc
+++ b/X2WOTCCommunityHighlander/Src/XComGame/Classes/XComGameState_Unit.uc
@@ -13499,17 +13499,24 @@ function EMentalState GetMentalState(optional bool bIgnoreBoost = false)
 function UpdateMentalState()
 {
 	local int WillPercent, idx;
+	local int MentalStateMaxWill; // Issue #637
 
-	WillPercent = int((GetCurrentStat(eStat_Will) / GetMaxStat(eStat_Will)) * 100.0f);
-
+	// Start Issue #637
+	//
+	// Rather than calculating the current will as a percentage of the unit's
+	// max, the will is now directly compared to the max will for each mental
+	// state. This ensures consistency with the will recovery project, which
+	// also uses the GetMaxWillForMentalState() function.
 	for(idx = 0; idx < eMentalState_Max; idx++)
 	{
-		if(WillPercent <= class'X2StrategyGameRulesetDataStructures'.default.MentalStatePercents[idx])
+		MentalStateMaxWill = GetMaxWillForMentalState(EMentalState(idx));
+		if(GetCurrentStat(eStat_Will) <= MentalStateMaxWill)
 		{
 			MentalState = EMentalState(idx);
 			return;
 		}
 	}
+	// End Issue #637
 }
 
 function int GetMaxWillForMentalState(EMentalState eState)


### PR DESCRIPTION
An inconsistency in handling the rounding of fractions meant that will recovery could sometimes take just 1 day from Shaken or Tired.

I have changed the implementation of `XCGS_Unit.UpdateMentalState()` so that it uses the same rounding behavior as the will recovery project.

Fixes #637.