### PR TITLE
Block `eStatus_CovertAction` units from missions (#665)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -133,6 +133,8 @@ RunPriorityGroup=RUN_STANDARD
 - Fix all Covert Actions from being removed when generating covert actions (#435)
 - Fix a pathing issue in base game with "flying" pod leaders where non-flat tiles on their
   paths prevent them from patrolling (#503)
+- Make units with a status of `eStatus_CovertAction` unavailable for missions
+  in `XComGameState_Unit.CanGoOnMission()` (#665)
 
 ## Tactical
 

--- a/X2WOTCCommunityHighlander/Src/XComGame/Classes/XComGameState_Unit.uc
+++ b/X2WOTCCommunityHighlander/Src/XComGame/Classes/XComGameState_Unit.uc
@@ -5473,7 +5473,7 @@ simulated function bool CanGoOnMission(optional bool bAllowWoundedSoldiers = fal
 	{
 		return true;
 	}
-	else
+	else if (GetStatus() != eStatus_CovertAction)  // Issue #665: Units on covert actions can't go on missions
 	{
 		bShaken = (GetMentalState() == eMentalState_Shaken);
 		bHasInjuries = (IsInjured() || bShaken);
@@ -5488,6 +5488,12 @@ simulated function bool CanGoOnMission(optional bool bAllowWoundedSoldiers = fal
 
 		return (bHasInjuries && bIgnoreInjuries);
 	}
+
+	// Start Issue #665
+	//
+	// Unit is on covert action, so can't go on mission.
+	return false;
+	// End Issue #665
 }
 
 function name GetCountry()


### PR DESCRIPTION
Fixes `XCGS_Unit.CanGoOnMission()` to honour units with a status of `eStatus_CovertAction`, returning `false` for those. This fixes a bug where wounded SPARKs that are on a covert action (or some other activity that sets that status) could be added to squads for missions via Squad Select's autofill feature.

Fixes #665.