### PR TITLE
Pull request for Issue #724.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -161,6 +161,7 @@ RunPriorityGroup=RUN_STANDARD
   matches as for other parts (in particular this means Anarchy's Children localizations which already exist in the files
   are picked up automatically). Otherwise, "_Torso"/"_Legs"/"_Arms" is appended to the template name
   to create the unique object name. (#328)
+- The list of Reserve Action Points that make the soldier display the Overwatch "Eye" icon under the Unit Flag is configurable in XComUI.ini. Now includes Pistol Overwatch by default.
 
 ### Fixes
 - Fix an issue in base game where strategy X2EventListenerTemplates only

--- a/X2WOTCCommunityHighlander/Config/XComUI.ini
+++ b/X2WOTCCommunityHighlander/Config/XComUI.ini
@@ -1,0 +1,5 @@
+[XComGame.UIUnitFlag]
+;	If the Unit has one of these Reserve Action Points, 
+;	an Overwatch "Eye" icon will be displayed under their Unit Flag.
++ValidReserveAPForUnitFlag = "overwatch"
++ValidReserveAPForUnitFlag = "pistoloverwatch"

--- a/X2WOTCCommunityHighlander/Src/XComGame/Classes/UIUnitFlag.uc
+++ b/X2WOTCCommunityHighlander/Src/XComGame/Classes/UIUnitFlag.uc
@@ -9,7 +9,7 @@
 //--------------------------------------------------------------------------------------- 
 
 class UIUnitFlag extends UIPanel
-	dependson(XComGameState_Unit);
+	dependson(XComGameState_Unit) config(UI);
 
 enum EUnitFlagTargetingState
 {
@@ -88,6 +88,9 @@ var localized string m_strReinforcementsTitle;
 var localized string m_strReinforcementsBody;
 
 var int VisualizedHistoryIndex;
+
+//	Variable for Issue #724
+var config(UI) array<name> ValidReserveAPForUnitFlag;
 
 // kUnit, the unit this flag is associated with.
 simulated function InitFlag(StateObjectReference ObjectRef)
@@ -1684,7 +1687,10 @@ simulated function Remove()
 
 //This function will be spammed, so please only send changes to flash.
 simulated function RealizeOverwatch(optional XComGameState_Unit NewUnitState = none)
-{
+{	
+	//	Variable for Issue #724
+	local name OverwatchActionPointName;
+
 	if( NewUnitState == none )
 	{
 		NewUnitState = XComGameState_Unit(History.GetGameStateForObjectID(StoredObjectID));
@@ -1692,8 +1698,17 @@ simulated function RealizeOverwatch(optional XComGameState_Unit NewUnitState = n
 
 	if( NewUnitState != none )
 	{
-
-		AS_SetOverwatchIcon(NewUnitState.ReserveActionPoints.Find('Overwatch') > -1);
+		//	Start Issue #724
+		foreach ValidReserveAPForUnitFlag(OverwatchActionPointName)
+		{	
+			if (NewUnitState.ReserveActionPoints.Find(OverwatchActionPointName) > -1)
+			{
+				AS_SetOverwatchIcon(true);
+				return;
+			}
+		}
+		AS_SetOverwatchIcon(false);
+		//	End Issue #724
 	}
 }
 


### PR DESCRIPTION
The list of Reserve Action Points that make the soldier display the Overwatch "Eye" icon under the Unit Flag is now configurable in XComUI.ini. Now includes Pistol Overwatch by default.

Closes #724