### PR TITLE
Use different deploy action so that bot account is used

### DIFF
--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -21,8 +21,10 @@ jobs:
         cd mkdocs
         mkdocs build -d ../target
     - name: Deploy
-      uses: JamesIves/github-pages-deploy-action@releases/v3
+      uses: crazy-max/ghaction-github-pages@v1
       with:
-        ACCESS_TOKEN: ${{ secrets.ACCESS_TOKEN }}
-        BRANCH: gh-pages # The branch the action should deploy to.
-        FOLDER: target # The folder the action should deploy.
+        target_branch: gh-pages
+        build_dir: target # The folder the action should deploy.
+        committer_name: X2CommunityCore-Docs-Bot
+      env:
+        GITHUB_PAT: ${{ secrets.ACCESS_TOKEN }}


### PR DESCRIPTION
The other action uses whomever did the merge/push, and I dislike automated actions impersonating users.

The bot account is @X2CommunityCore-Docs-Bot and a member of this organization. That account is also the owner of the token.