### PR TITLE
Changes to item upgrade system

### DIFF
--- a/X2WOTCCommunityHighlander/Src/XComGame/Classes/CHHelpers.uc
+++ b/X2WOTCCommunityHighlander/Src/XComGame/Classes/CHHelpers.uc
@@ -1,13 +1,23 @@
 class CHHelpers extends Object config(Game);
 
-//issue #188 - creating a struct and usable array for modders
+//issue #188 - creating a struct for modders
 struct TeamRequest
 {
 	var ETeam Team; //eTeam_One and eTeam_Two should be the only ones here.
 };
-
-var config array<TeamRequest> ModAddedTeams;
 //end issue #188
+
+// Start Issue #93
+struct UpgradeSlotHelper
+{
+	var name TemplateName; // Name of the non-X2WeaponTemplate to be assigned slots (X2WeaponTemplates have NumUpgradeSlots on the template)
+	var int NumUpgradeSlots; // The number of slots to assign
+};
+// End Issue #93
+
+var config array<TeamRequest> ModAddedTeams; //issue #188 - creating a usable array for modders
+
+var config array<UpgradeSlotHelper> NonWeaponUpgradeSlots; // Issue #93 - configure upgrade slots for templates
 
 var config int SPAWN_EXTRA_TILE; // Issue #18 - Add extra ini config
 var config int MAX_TACTICAL_AUTOSAVES; // Issue #53 - make configurable, only use if over 0

--- a/X2WOTCCommunityHighlander/Src/XComGame/Classes/UIArmory_WeaponUpgrade.uc
+++ b/X2WOTCCommunityHighlander/Src/XComGame/Classes/UIArmory_WeaponUpgrade.uc
@@ -242,7 +242,10 @@ simulated function UpdateSlots()
 	// Get equipped upgrades
 	EquippedUpgrades = Weapon.GetMyWeaponUpgradeTemplates();
 	WeaponTemplate = X2WeaponTemplate(Weapon.GetMyTemplate());
-	NumUpgradeSlots = WeaponTemplate.NumUpgradeSlots;
+	// Start Issue #93
+	//NumUpgradeSlots = WeaponTemplate.NumUpgradeSlots;
+	NumUpgradeSlots = Weapon.GetNumUpgradeSlots();
+	// End Issue #93
 
 	if (XComHQ.bExtraWeaponUpgrade)
 		NumUpgradeSlots++;

--- a/X2WOTCCommunityHighlander/Src/XComGame/Classes/UILadderUpgradeScreen.uc
+++ b/X2WOTCCommunityHighlander/Src/XComGame/Classes/UILadderUpgradeScreen.uc
@@ -1,0 +1,348 @@
+//----------------------------------------------------------------------------
+//  *********   FIRAXIS SOURCE CODE   ******************
+//  FILE:    UILadderUpgradeScreen.uc
+//  AUTHOR:  Joe Cortese
+//----------------------------------------------------------------------------
+//  Copyright (c) 2018 Firaxis Games, Inc. All rights reserved.
+//----------------------------------------------------------------------------
+
+class UILadderUpgradeScreen extends UIScreen;
+
+var UIButton	 Upgrade0Button;
+var UIButton	 Upgrade1Button;
+
+var int SelectedColumn; 
+var XComGameState_HeadquartersXCom XComHQ;
+
+var localized string m_strChooseUpgrade;
+var localized string m_strEquipUpgrade;
+var localized string m_strUpgradeFormat;
+var localized string m_strReplaceFormat;
+
+simulated function InitScreen(XComPlayerController InitController, UIMovie InitMovie, optional name InitName)
+{
+	super.InitScreen(InitController, InitMovie, InitName);
+
+	Upgrade0Button = Spawn(class'UIButton', self);
+	Upgrade1Button = Spawn(class'UIButton', self);
+	
+	Upgrade0Button.InitButton('Upgrade00', m_strChooseUpgrade, ChooseUpgrade0);
+	Upgrade1Button.InitButton('Upgrade01', m_strChooseUpgrade, ChooseUpgrade1);
+
+	if( `ISCONTROLLERACTIVE )
+	{
+		SelectColumn(SelectedColumn);
+	}
+}
+
+simulated function OnInit()
+{
+	local XComGameState_LadderProgress LadderData;
+	local X2LadderUpgradeTemplateManager TemplateManager;
+	local X2LadderUpgradeTemplate Upgrade;
+	local X2SoldierClassTemplateManager ClassManager;
+	local X2ItemTemplateManager ItemManager;
+	local array<name> SquadProgressionNames;
+	local XComNarrativeMoment NarrativeMoment;
+	local name NextNarrativeSquadName;
+	
+	super.OnInit();
+
+	LadderData = XComGameState_LadderProgress(`XCOMHISTORY.GetSingleGameStateObjectForClass(class'XComGameState_LadderProgress'));
+	XComHQ = XComGameState_HeadquartersXCom(`XCOMHISTORY.GetSingleGameStateObjectForClass(class'XComGameState_HeadquartersXCom'));
+
+	if (LadderData.SquadProgressionName != "")
+		SquadProgressionNames = class'XComGameState_LadderProgress'.static.GetSquadProgressionMembers( LadderData.SquadProgressionName, LadderData.LadderRung + 1 );
+	if (LadderData.LadderSquadName != '')
+	{
+		NextNarrativeSquadName = class'XComGameState_LadderProgress'.static.GetNarrativeSquadName( LadderData.LadderIndex, LadderData.LadderRung + 1 );
+		class'UITacticalQuickLaunch_MapData'.static.GetSqaudMemberNames( NextNarrativeSquadName, SquadProgressionNames );
+	}
+
+	`assert( SquadProgressionNames.Length > 0 );
+
+	MC.BeginFunctionOp("SetScreenTitle");
+	MC.QueueString(class'UIMissionSummary'.default.m_strMissionComplete); // Title
+	if (LadderData.LadderIndex < 10)
+	{
+		MC.QueueString(LadderData.NarrativeLadderNames[LadderData.LadderIndex]);//Mission Name
+	}
+	else
+	{
+		MC.QueueString(LadderData.LadderName);//Mission Name
+	}
+	MC.QueueString(class'UILadderSoldierInfo'.default.m_MissionLabel);//Mission Label
+	MC.QueueString(String(LadderData.LadderRung) $ "/" $ String(LadderData.LadderSize));//Mission Count
+	MC.QueueString(m_strChooseUpgrade);//Upgrade sub title
+	MC.EndOp();
+
+	TemplateManager = class'X2LadderUpgradeTemplateManager'.static.GetLadderUpgradeTemplateManager();
+	ClassManager = class'X2SoldierClassTemplateManager'.static.GetSoldierClassTemplateManager();
+	ItemManager = class'X2ItemTemplateManager'.static.GetItemTemplateManager();
+
+	Upgrade = TemplateManager.FindUpgradeTemplate(LadderData.ProgressionChoices1[LadderData.LadderRung - 1]);
+	PopulateUpgradePanel( 0, Upgrade, SquadProgressionNames, ClassManager, ItemManager );
+
+	Upgrade = TemplateManager.FindUpgradeTemplate(LadderData.ProgressionChoices2[LadderData.LadderRung - 1]);
+	PopulateUpgradePanel( 1, Upgrade, SquadProgressionNames, ClassManager, ItemManager );
+
+	if (`XPROFILESETTINGS.Data.m_bLadderNarrativesOn)
+	{
+		if ((LadderData.LootSelectNarrative.Length >= LadderData.LadderRung) && (LadderData.LootSelectNarrative[ LadderData.LadderRung - 1 ] != ""))
+		{
+			NarrativeMoment = XComNarrativeMoment(DynamicLoadObject(LadderData.LootSelectNarrative[ LadderData.LadderRung - 1 ], class'XComNarrativeMoment'));
+			if (NarrativeMoment != none)
+			{
+				`PRESBASE.UINarrative( NarrativeMoment );
+			}
+		}
+	}
+}
+
+simulated function PopulateUpgradePanel( int Index, X2LadderUpgradeTemplate Upgrade, array<name> SquadMembers, X2SoldierClassTemplateManager ClassManager, X2ItemTemplateManager ItemManager )
+{
+	local int i, j, k, DescIdx;
+	local XGParamTag ParamTag;
+	local string ExpandedString;
+	local X2SoldierClassTemplate ClassTemplate;
+	local X2EquipmentTemplate ItemTemplate;
+	local X2WeaponUpgradeTemplate ItemUpgradeTemplate;
+	local array<X2WeaponUpgradeTemplate> equippedUpgrades;
+	local name FilterName;
+	local array<name> DisplayedClasses;
+	local XComGameState_Item primaryWeaponItem, replacementItem;
+	local array<XComGameState_Item> utilItems;
+	local bool bReplace, bAddLine, bAdded;
+	local XComGameState_Unit Soldier;
+	local X2WeaponTemplate WeaponTemplate;
+	
+	mc.BeginFunctionOp("SetUpgradePanel");
+	mc.QueueNumber(Index); // index
+	mc.QueueString(Upgrade.ImagePath); //upgrade image
+	mc.QueueString(Upgrade.ShortDescription); // upgrade title
+	mc.QueueString(Upgrade.FullDescription); // upgrade info
+	mc.QueueString(GetEquipButtonText(Index)); // choose this button text
+	mc.EndOp();
+
+	ParamTag = XGParamTag(`XEXPANDCONTEXT.FindTag("XGParam"));
+
+	mc.BeginFunctionOp("SetUpgradeDetailRow");
+	mc.QueueNumber(Index); // index
+
+	DescIdx = 0;
+
+	for (i = 0; (i < Upgrade.Upgrades.Length) && (DescIdx < 6); ++i)
+	{
+		bAddLine = true;
+		
+		FilterName = name(Upgrade.Upgrades[i].ClassGroup != "" ? Upgrade.Upgrades[i].ClassGroup : Upgrade.Upgrades[i].ClassFilter);
+
+		// determine if we already saw this class (because of a story character class probably)
+		if (DisplayedClasses.Find( FilterName ) != INDEX_NONE)
+			continue;
+		
+		bAdded = false;
+		for (j = 0; j < XComHQ.Squad.Length && !bAdded; j++)
+		{
+			Soldier = XComGameState_Unit(`XCOMHISTORY.GetGameStateForObjectID(XComHQ.Squad[j].ObjectID));
+			if (Soldier != none && Soldier.GetSoldierClassTemplateName() == name(Upgrade.Upgrades[i].ClassFilter))
+			{
+				bAdded = true;
+				ClassTemplate = ClassManager.FindSoldierClassTemplate(FilterName);
+				DisplayedClasses.AddItem(FilterName);
+
+				ItemTemplate = X2EquipmentTemplate(ItemManager.FindItemTemplate(Upgrade.Upgrades[i].EquipmentNames[0]));
+
+				bReplace = false;
+				if (ItemTemplate != none)
+				{
+					if (ItemTemplate.InventorySlot != eInvSlot_Utility)
+					{
+						if (ItemTemplate.InventorySlot == eInvSlot_HeavyWeapon)
+						{
+							bAddLine = Soldier.HasHeavyWeapon();
+						}
+						replacementItem = Soldier.GetItemInSlot(ItemTemplate.InventorySlot);
+
+						bReplace = replacementItem != none;
+						ParamTag.StrValue2 = replacementItem.GetMyTemplate().GetItemFriendlyNameNoStats();
+					}
+					else
+					{
+						utilItems = Soldier.GetAllItemsInSlot(eInvSlot_Utility);
+						for (k = 0; k < utilItems.Length; k++)
+						{
+							if ((utilItems[k].GetMyTemplate().ItemCat == 'grenade' && ItemTemplate.ItemCat == 'grenade') ||
+								(utilItems[k].GetMyTemplate().ItemCat == 'pcs'     && ItemTemplate.ItemCat == 'pcs'    ) ||
+								(utilItems[k].GetMyTemplate().ItemCat != 'grenade' && ItemTemplate.ItemCat != 'grenade' && utilItems[k].GetMyTemplateName() != 'XPad' && utilItems[k].GetMyTemplate().ItemCat != 'heal' ))
+							{
+								bReplace = true;
+								ParamTag.StrValue2 = utilItems[k].GetMyTemplate().GetItemFriendlyNameNoStats();
+							}
+						}
+					}
+
+					//
+					ParamTag.StrValue0 = ClassTemplate.DisplayName;
+					ParamTag.StrValue1 = ItemTemplate.GetItemFriendlyNameNoStats();
+				}
+				else
+				{
+					ItemUpgradeTemplate = X2WeaponUpgradeTemplate(ItemManager.FindItemTemplate(Upgrade.Upgrades[i].EquipmentNames[0]));
+
+					primaryWeaponItem = Soldier.GetItemInSlot(eInvSlot_PrimaryWeapon);
+					equippedUpgrades = primaryWeaponItem.GetMyWeaponUpgradeTemplates();
+					if (equippedUpgrades.Length > 0)
+					{
+						bReplace = true;
+						ParamTag.StrValue2 = equippedUpgrades[0].GetItemFriendlyNameNoStats();
+					}
+					WeaponTemplate = X2WeaponTemplate(primaryWeaponItem.GetMyTemplate());
+
+					bAddLine = WeaponTemplate != none && WeaponTemplate.NumUpgradeSlots > 0 && ItemUpgradeTemplate.CanApplyUpgradeToWeapon(primaryWeaponItem);
+
+					//
+					ParamTag.StrValue0 = ClassTemplate.DisplayName;
+					ParamTag.StrValue1 = ItemUpgradeTemplate.GetItemFriendlyNameNoStats();
+				}
+
+				if (bReplace)
+				{
+					ExpandedString = `XEXPAND.ExpandString(m_strReplaceFormat);
+					ExpandedString = class'UIUtilities_Text'.static.InjectImage("warning_icon", 26, 26, -4) $ " " $ ExpandedString;
+				}
+				else
+				{
+					ExpandedString = `XEXPAND.ExpandString(m_strUpgradeFormat);
+				}
+
+				if (bAddLine)
+				{
+					MC.QueueString(ExpandedString);
+
+					++DescIdx;
+				}
+			}
+		}
+	}
+
+	// Fill up any unused parameters
+	while (DescIdx < 6)
+	{
+		MC.QueueString("");
+		++DescIdx;
+	}
+	mc.EndOp();
+}
+
+simulated function ChooseUpgrade0(UIButton button)
+{
+	local XComGameState_LadderProgress LadderData;
+	local XComGameState_CampaignSettings CampaignSettings;
+
+	Movie.Pres.PlayUISound(eSUISound_MenuSelect);
+
+	LadderData = XComGameState_LadderProgress(`XCOMHISTORY.GetSingleGameStateObjectForClass(class'XComGameState_LadderProgress', true));
+	LadderData.OnComplete('eUIAction_Accept');
+
+	CampaignSettings = XComGameState_CampaignSettings(`XCOMHISTORY.GetSingleGameStateObjectForClass(class'XComGameState_CampaignSettings'));
+
+	`FXSLIVE.BizAnalyticsLadderUpgrade( CampaignSettings.BizAnalyticsCampaignID, 
+											string(LadderData.ProgressionChoices1[LadderData.LadderRung - 1]),
+											string(LadderData.ProgressionChoices2[LadderData.LadderRung - 1]),
+											1 );
+}
+simulated function ChooseUpgrade1(UIButton button)
+{
+	local XComGameState_LadderProgress LadderData;
+	local XComGameState_CampaignSettings CampaignSettings;
+
+	Movie.Pres.PlayUISound(eSUISound_MenuSelect);
+
+	LadderData = XComGameState_LadderProgress(`XCOMHISTORY.GetSingleGameStateObjectForClass(class'XComGameState_LadderProgress', true));
+	LadderData.OnComplete('eUIAction_Decline');
+
+	CampaignSettings = XComGameState_CampaignSettings(`XCOMHISTORY.GetSingleGameStateObjectForClass(class'XComGameState_CampaignSettings'));
+
+	`FXSLIVE.BizAnalyticsLadderUpgrade( CampaignSettings.BizAnalyticsCampaignID, 
+											string(LadderData.ProgressionChoices1[LadderData.LadderRung - 1]),
+											string(LadderData.ProgressionChoices2[LadderData.LadderRung - 1]),
+											2 );
+}
+
+simulated function bool OnUnrealCommand(int cmd, int arg)
+{
+	// Only pay attention to presses or repeats; ignoring other input types
+	// NOTE: Ensure repeats only occur with arrow keys
+	if( !CheckInputIsReleaseOrDirectionRepeat(cmd, arg) )
+		return false;
+
+	switch( cmd )
+	{
+	case class'UIUtilities_Input'.const.FXS_BUTTON_A :
+	case class'UIUtilities_Input'.const.FXS_KEY_ENTER :
+	case class'UIUtilities_Input'.const.FXS_KEY_SPACEBAR :
+		//TODO : confirm column selection 
+		if( SelectedColumn == 0 )
+			ChooseUpgrade0(none);
+		else if( SelectedColumn == 1 )
+			ChooseUpgrade1(none);
+		return true;
+
+	case class'UIUtilities_Input'.const.FXS_VIRTUAL_LSTICK_RIGHT :
+	case class'UIUtilities_Input'.const.FXS_ARROW_RIGHT :
+	case class'UIUtilities_Input'.const.FXS_DPAD_RIGHT :
+	case class'UIUtilities_Input'.const.FXS_KEY_D :
+		SelectColumn(1);
+		return true;
+
+	case class'UIUtilities_Input'.const.FXS_VIRTUAL_LSTICK_LEFT :
+	case class'UIUtilities_Input'.const.FXS_ARROW_LEFT :
+	case class'UIUtilities_Input'.const.FXS_DPAD_LEFT :
+	case class'UIUtilities_Input'.const.FXS_KEY_A :
+		SelectColumn(0);
+		return true;
+	}
+
+	return super.OnUnrealCommand(cmd, arg);
+}
+
+simulated function SelectColumn(int iCol)
+{
+	SelectedColumn = iCol; 
+	MC.FunctionNum("SelectColumn", SelectedColumn); 
+
+	RefreshContinueText(0);
+	RefreshContinueText(1);
+}
+
+simulated function RefreshContinueText(int iCol)
+{
+	mc.BeginFunctionOp("SetContinueText");
+	mc.QueueNumber(iCol); // index
+	mc.QueueString(GetEquipButtonText(iCol)); // choose this button text
+	mc.EndOp();
+}
+
+simulated function string GetEquipButtonText(int iCol)
+{
+	if( `ISCONTROLLERACTIVE && SelectedColumn == iCol )
+	{
+		return class'UIUtilities_Text'.static.InjectImage(class'UIUtilities_Input'.static.GetAdvanceButtonIcon(), 26, 26, -10) @ m_strEquipUpgrade;
+	}
+	else
+	{
+		return m_strEquipUpgrade;
+	}
+}
+
+defaultproperties
+{
+	Package = "/ package/gfxTLE_LadderLevelUp/TLE_LadderLevelUp";
+	LibID = "UpgradeScreen";
+	InputState = eInputState_Consume;
+
+	bHideOnLoseFocus = false;
+
+	SelectedColumn = 0; 
+}

--- a/X2WOTCCommunityHighlander/Src/XComGame/Classes/UILadderUpgradeScreen.uc
+++ b/X2WOTCCommunityHighlander/Src/XComGame/Classes/UILadderUpgradeScreen.uc
@@ -199,7 +199,8 @@ simulated function PopulateUpgradePanel( int Index, X2LadderUpgradeTemplate Upgr
 					}
 					WeaponTemplate = X2WeaponTemplate(primaryWeaponItem.GetMyTemplate());
 
-					bAddLine = WeaponTemplate != none && WeaponTemplate.NumUpgradeSlots > 0 && ItemUpgradeTemplate.CanApplyUpgradeToWeapon(primaryWeaponItem);
+					// Single line for Issue #93
+					bAddLine = WeaponTemplate != none && WeaponTemplate.GetNumUpgradeSlots() > 0 && ItemUpgradeTemplate.CanApplyUpgradeToWeapon(primaryWeaponItem);
 
 					//
 					ParamTag.StrValue0 = ClassTemplate.DisplayName;

--- a/X2WOTCCommunityHighlander/Src/XComGame/Classes/UIUtilities_Strategy.uc
+++ b/X2WOTCCommunityHighlander/Src/XComGame/Classes/UIUtilities_Strategy.uc
@@ -1607,7 +1607,10 @@ simulated static function GetWeaponUpgradeAvailability(XComGameState_Unit Unit, 
 	WeaponTemplate = X2WeaponTemplate(PrimaryWeapon.GetMyTemplate());
 	// Single line for Issue #306
 	EquippedUpgrades = PrimaryWeapon.GetMyWeaponUpgradeCount();
-	AvailableSlots = WeaponTemplate.NumUpgradeSlots;
+	// Start Issue #93
+	//AvailableSlots = WeaponTemplate.NumUpgradeSlots;
+	AvailableSlots = PrimaryWeapon.GetNumUpgradeSlots();
+	// End Issue #93
 
 	// Only add extra slots if the weapon had some to begin with
 	if (AvailableSlots > 0)

--- a/X2WOTCCommunityHighlander/Src/XComGame/Classes/X2AchievementTracker.uc
+++ b/X2WOTCCommunityHighlander/Src/XComGame/Classes/X2AchievementTracker.uc
@@ -943,7 +943,10 @@ static function EventListenerReturn OnWeaponUpgraded(Object EventData, Object Ev
 		{
 			UpgradeTemplates = WeaponState.GetMyWeaponUpgradeTemplates();
 
-			NumUpgradeSlots = WeaponTemplate.NumUpgradeSlots;
+			// Start Issue #93
+			//NumUpgradeSlots = WeaponTemplate.NumUpgradeSlots;
+			NumUpgradeSlots = WeaponState.GetNumUpgradeSlots();
+			// End Issue #93
 			if (XComHQ.bExtraWeaponUpgrade)
 				NumUpgradeSlots++;
 			if (XComHQ.ExtraUpgradeWeaponCats.Find(WeaponTemplate.WeaponCat) != INDEX_NONE)

--- a/X2WOTCCommunityHighlander/Src/XComGame/Classes/X2AchievementTracker.uc
+++ b/X2WOTCCommunityHighlander/Src/XComGame/Classes/X2AchievementTracker.uc
@@ -1,0 +1,1492 @@
+//---------------------------------------------------------------------------------------
+//  FILE:    X2AchievementTracker.uc
+//  AUTHOR:  Aaron Smith -- 7/29/2015
+//  PURPOSE: Tracks achievements
+//           
+//---------------------------------------------------------------------------------------
+//  Copyright (c) 2016 Firaxis Games, Inc. All rights reserved.
+//---------------------------------------------------------------------------------------
+class X2AchievementTracker extends Object
+	native(Core);
+
+var TDateTime	GameStartTime;
+var TDateTime	June1st;
+var TDateTime	July15th;
+var TDateTime	July31st;
+
+enum HeavyWeaponKill
+{
+	HWK_RocketLauncher,
+	HWK_ShredderGun,
+	HWK_Flamethrower,
+	HWK_HellfireProjector,
+	HWK_BlasterLauncher,
+	HWK_PlasmaBlaster,
+	HWK_ShredstormCannon,
+};
+
+var array<Name> arrSkulljackedUnitGroups;
+
+var const int SKIRMISHER_MULTI_ACTION_REQUIREMENT;
+
+native function Init();
+
+// Singleton creation / access of XComGameState_AchievementData.
+static function XComGameState_AchievementData GetAchievementData(XComGameState NewGameState)
+{
+	local XComGameState_AchievementData AchievementData;
+
+	AchievementData = XComGameState_AchievementData(`XCOMHISTORY.GetSingleGameStateObjectForClass(class'XComGameState_AchievementData', true));
+	if (AchievementData == none)
+	{
+		AchievementData = XComGameState_AchievementData(NewGameState.CreateNewStateObject(class'XComGameState_AchievementData'));
+	}
+	else
+	{
+		AchievementData = XComGameState_AchievementData(NewGameState.ModifyStateObject(class'XComGameState_AchievementData', AchievementData.ObjectID));
+	}
+
+	return AchievementData;
+}
+
+event OnInit()
+{
+	local XComOnlineProfileSettings Profile;
+
+	class'X2StrategyGameRulesetDataStructures'.static.SetTime(
+		GameStartTime, 0, 0, 0,
+		class'X2StrategyGameRulesetDataStructures'.default.START_MONTH, 
+		class'X2StrategyGameRulesetDataStructures'.default.START_DAY, 
+		class'X2StrategyGameRulesetDataStructures'.default.START_YEAR
+	);
+
+	class'X2StrategyGameRulesetDataStructures'.static.SetTime(
+		June1st, 0, 0, 0,
+		6, 1,
+		class'X2StrategyGameRulesetDataStructures'.default.START_YEAR
+	);
+
+	class'X2StrategyGameRulesetDataStructures'.static.SetTime(
+		July15th, 0, 0, 0,
+		7, 15,
+		class'X2StrategyGameRulesetDataStructures'.default.START_YEAR
+	);
+
+	class'X2StrategyGameRulesetDataStructures'.static.SetTime(
+		July31st, 0, 0, 0,
+		7, 31,
+		class'X2StrategyGameRulesetDataStructures'.default.START_YEAR
+	);
+
+	arrSkulljackedUnitGroups.Length = 0;
+
+	arrSkulljackedUnitGroups.AddItem('AdventTrooper');
+	arrSkulljackedUnitGroups.AddItem('AdventCaptain');
+	arrSkulljackedUnitGroups.AddItem('AdventShieldBearer');
+	arrSkulljackedUnitGroups.AddItem('AdventStunLancer');
+	arrSkulljackedUnitGroups.AddItem('AdventPurifier');
+	arrSkulljackedUnitGroups.AddItem('AdventPriest');
+	arrSkulljackedUnitGroups.AddItem('Cyberus');
+
+	Profile = `XPROFILESETTINGS;
+
+	if (Profile != none)
+		Profile.Data.arrbSkulljackedUnits.Length = arrSkulljackedUnitGroups.Length;
+}
+
+// Catches the beginning of a mission
+static function EventListenerReturn OnTacticalBeginPlay(Object EventData, Object EventSource, XComGameState GameState, Name Event, Object CallbackData)
+{
+	local XComGameStateHistory History;
+	local XComGameState NewGameState;
+	local XComGameState_HeadquartersXCom XComHQ;
+	local XComGameState_AchievementData AchievementData;
+	local XComGameState_Unit UnitState;
+	local StateObjectReference UnitRef;
+
+	if (GameState.GetContext().InterruptionStatus == eInterruptionStatus_Interrupt)
+	{
+		return ELR_NoInterrupt;
+	}
+
+	History = `XCOMHISTORY;
+	XComHQ = XComGameState_HeadquartersXCom(History.GetSingleGameStateObjectForClass(class'XComGameState_HeadquartersXCom'));
+
+	// Reset the relevant data from the Achievement Data singleton
+	NewGameState = class'XComGameStateContext_ChangeContainer'.static.CreateChangeState("X2AchievementTracker.OnTacticalBeginPlay");
+	AchievementData = GetAchievementData(NewGameState);
+	
+	AchievementData.bAllTiredSoldierSquad = true;
+	foreach XComHQ.Squad(UnitRef)
+	{
+		UnitState = XComGameState_Unit(History.GetGameStateForObjectID(UnitRef.ObjectID));
+		if (UnitState != none && UnitState.GetMentalState() > eMentalState_Tired)
+		{
+			// If any units are not tired or shaken, the whole squad is not tired
+			AchievementData.bAllTiredSoldierSquad = false;
+			break;
+		}		
+	}
+
+	`TACTICALRULES.SubmitGameState(NewGameState);
+
+	return ELR_NoInterrupt;
+}
+
+// Catches the end of a mission
+static function EventListenerReturn OnTacticalGameEnd(Object EventData, Object EventSource, XComGameState GameState, Name Event, Object CallbackData)
+{
+	local XComGameState NewGameState;
+	local XComGameState_AchievementData AchievementData;
+	local XComGameState_BattleData Battle;
+	local XComGameState_CampaignSettings Settings;
+	local XComGameStateHistory History;
+	local XComGameState_Unit Unit, LastUnit;
+	local XComGameState_HeadquartersXCom XComHQ;
+	local StateObjectReference UnitRef;
+	local int NumCivilianDeaths;
+	local bool AllRookies, JuneOrLater, SameClass, bNoCasualties;
+
+	if (GameState.GetContext().InterruptionStatus == eInterruptionStatus_Interrupt)
+	{
+		return ELR_NoInterrupt;
+	}
+
+	History = `XCOMHISTORY;
+	Settings = XComGameState_CampaignSettings(History.GetSingleGameStateObjectForClass(class'XComGameState_CampaignSettings'));
+	Battle = XComGameState_BattleData(History.GetSingleGameStateObjectForClass(class'XComGameState_BattleData'));
+
+	`log("XComGameState_AchievementTracker.OnTacticalGameEnd");
+
+	// Make sure the player won
+	if (!(Battle.bLocalPlayerWon && !Battle.bMissionAborted))
+	{
+		return ELR_NoInterrupt;
+	}
+
+	// Beat the game. 
+	// (According to Nauta, FinalMissionOnSuccess is called when the game returns to the shell - 
+	//  which may not happen given the current game flow.  Calling FinalMissionOnSuccess here is a 
+	//  just in case measure.)
+	if (string(Battle.MapData.ActiveMission.MissionName) == "DestroyAvatarProject")
+	{
+		FinalMissionOnSuccess();
+	}
+
+	// Sabotage an alien facility
+	if (string(Battle.MapData.ActiveMission.MissionName) == "SabotageAlienFacility")
+	{
+		`ONLINEEVENTMGR.UnlockAchievement(AT_SabotageFacility);
+	}
+
+	// Recover the Forge Item
+	if (string(Battle.MapData.ActiveMission.MissionName) == "AdventFacilityFORGE" && !class'X2TacticalGameRulesetDataStructures'.static.TacticalOnlyGameMode())
+	{
+		`ONLINEEVENTMGR.UnlockAchievement(AT_RecoverForgeItem);
+	}
+
+	// Recover the Psi Gate
+	if (string(Battle.MapData.ActiveMission.MissionName) == "AdventFacilityPSIGATE" && !class'X2TacticalGameRulesetDataStructures'.static.TacticalOnlyGameMode())
+	{
+		`ONLINEEVENTMGR.UnlockAchievement(AT_RecoverPsiGate);
+	}
+	
+	// Recover the Black Site Data
+	if (string(Battle.MapData.ActiveMission.MissionName) == "AdventFacilityBLACKSITE" && !class'X2TacticalGameRulesetDataStructures'.static.TacticalOnlyGameMode())
+	{
+		`ONLINEEVENTMGR.UnlockAchievement(AT_RecoverBlackSiteData);
+	}
+	
+	// Clear the Lost and Abandoned mission
+	if (string(Battle.MapData.ActiveMission.MissionName) == "LostAndAbandonedC")
+	{
+		`log("War of the Chosen Achievement Awarded: A New Alliance");
+		`ONLINEEVENTMGR.UnlockAchievement(AT_LostAndAbandoned);
+	}
+
+	// Kill one of the Chosen
+	if (string(Battle.MapData.ActiveMission.MissionName) == "ChosenShowdown_Assassin" ||
+		string(Battle.MapData.ActiveMission.MissionName) == "ChosenShowdown_Hunter" || 
+		string(Battle.MapData.ActiveMission.MissionName) == "ChosenShowdown_Warlock")
+	{
+		`log("War of the Chosen Achievement Awarded: A Rival Silenced");
+		`ONLINEEVENTMGR.UnlockAchievement(AT_DefeatChosen);
+	}
+
+	// Rescue a soldier captured by the Chosen
+	if (string(Battle.MapData.ActiveMission.MissionName) == "CompoundRescueOperative")
+	{
+		`log("War of the Chosen Achievement Awarded: No One Left Behind");
+		`ONLINEEVENTMGR.UnlockAchievement(AT_RescueCapturedSoldier);
+	}
+	
+	// Beat a Retaliation mission with less than 4 civilian deaths
+	if (string(Battle.MapData.ActiveMission.MissionName) == "Terror")
+	{
+		NumCivilianDeaths = 0;
+		foreach History.IterateByClassType(class'XComGameState_Unit', Unit)
+		{
+			if (Unit.IsCivilian() && Unit.IsDead())
+			{
+				NumCivilianDeaths++;
+			}
+		}
+
+		if (NumCivilianDeaths <= 3)
+		{
+			`ONLINEEVENTMGR.UnlockAchievement(AT_BeatMissionNoCivilianDeath);
+		}
+	}
+
+	if (Battle.m_strDesc == "Skirmish Mode")
+	{
+		class'X2TacticalGameRuleset'.static.ReleaseScriptLog("TLE Achievement Awarded: Complete Custom Skirmish");
+		`ONLINEEVENTMGR.UnlockAchievement(AT_CompleteCustomSkirmish);
+	}
+
+	if ((History.GetSingleGameStateObjectForClass(class'XComGameState_ChallengeData', true) != none) && `ONLINEEVENTMGR.bIsLocalChallengeModeGame)
+	{
+		class'X2TacticalGameRuleset'.static.ReleaseScriptLog("TLE Achievement Awarded: Complete Local Challenge");
+		`ONLINEEVENTMGR.UnlockAchievement(AT_CompleteLocalChallenge);
+	}
+	
+	// Check for AT_BeatMissionJuneOrLater - Beat a mission in June or later using only Rookies
+	AllRookies = true;
+	foreach History.IterateByClassType(class'XComGameState_Unit', Unit)
+	{
+		if (Unit.IsPlayerControlled() && Unit.IsSoldier())
+		{
+			if (Unit.GetSoldierRank() != 0)
+			{
+				AllRookies = false;
+				break;
+			}
+		}
+	}
+
+	JuneOrLater = class'X2StrategyGameRulesetDataStructures'.static.LessThan(`XACHIEVEMENT_TRACKER.June1st, Battle.LocalTime);
+	if (JuneOrLater && AllRookies) // Beat a mission in June or later using only Rookies
+	{
+		`ONLINEEVENTMGR.UnlockAchievement(AT_BeatMissionJuneOrLater);
+	}
+
+	// Check for AT_BeatMissionSameClass - Beat a mission on Classic+ with a squad composed entirely of soldiers of the same class (but not rookie)
+	SameClass = false;
+	if (!AllRookies)
+	{
+		LastUnit = none;
+		foreach History.IterateByClassType(class'XComGameState_Unit', Unit)
+		{
+			if (Unit.IsPlayerControlled() && Unit.IsSoldier())
+			{
+				if (LastUnit != none)
+				{
+					SameClass = true; // There must be at least two units for "same" to apply
+
+					// Each unit must have the same class as the last unit for the condition to be true
+					if (Unit.GetSoldierClassTemplate() != LastUnit.GetSoldierClassTemplate())
+					{
+						SameClass = false;
+						break;
+					}
+				}
+				LastUnit = Unit;
+			}
+		}
+	}
+
+	// Beat a mission on Commander or harder with a squad composed entirely of soldiers of the same class (but not rookie)
+	if (Settings.LowestDifficultySetting >= 2 && SameClass && `XENGINE.IsSinglePlayerGame() && !(`ONLINEEVENTMGR.bIsChallengeModeGame))
+	{
+		`ONLINEEVENTMGR.UnlockAchievement(AT_BeatMissionSameClass);
+	}
+	
+	// Clear the relevant data from the Achievement Data singleton and trigger any related achievements
+	NewGameState = class'XComGameStateContext_ChangeContainer'.static.CreateChangeState("X2AchievementTracker.OnTacticalGameEnd");
+	AchievementData = GetAchievementData(NewGameState);
+	
+	// Recover a Codex Brain
+	// Once in the mission use "DropUnit Cyberus 1 False". Then kill it and finish the mission.
+	// Only applicable in the single-player campaign (not MP, not challenge mode)
+	if (AchievementData.bKilledACyberusThisMission && `XENGINE.IsSinglePlayerGame() && !class'X2TacticalGameRulesetDataStructures'.static.TacticalOnlyGameMode())
+	{
+		`ONLINEEVENTMGR.UnlockAchievement(AT_RecoverCodexBrain);
+	}
+
+	// If the whole squad was tired at the start of the mission, check to see if they are all still alive
+	if (AchievementData.bAllTiredSoldierSquad && `XENGINE.IsSinglePlayerGame() && !(`ONLINEEVENTMGR.bIsChallengeModeGame))
+	{
+		XComHQ = XComGameState_HeadquartersXCom(History.GetSingleGameStateObjectForClass(class'XComGameState_HeadquartersXCom'));
+		bNoCasualties = true;
+
+		foreach XComHQ.Squad(UnitRef)
+		{
+			Unit = XComGameState_Unit(History.GetGameStateForObjectID(UnitRef.ObjectID));
+			if (Unit != none && (Unit.IsDead() || Unit.bCaptured))
+			{
+				bNoCasualties = false;
+				break;
+			}
+		}
+
+		if (bNoCasualties)
+		{
+			`log("War of the Chosen Achievement Awarded: Weary Warriors");
+			`ONLINEEVENTMGR.UnlockAchievement(AT_CompleteMissionTiredSoldiers);
+		}
+	}
+
+	AchievementData.bKilledACyberusThisMission = false;
+	AchievementData.bAllTiredSoldierSquad = false;
+	AchievementData.arrTemplarFocusCyclesThisMission.Length = 0;
+	AchievementData.arrReaperShadowKillsThisMission.Length = 0;
+
+	`TACTICALRULES.SubmitGameState(NewGameState);
+
+	return ELR_NoInterrupt;
+}
+
+// This is called at the start of each turn
+static function EventListenerReturn OnPlayerTurnBegun(Object EventData, Object EventSource, XComGameState GameState, Name Event, Object CallbackData)
+{
+	local XComGameState NewGameState;
+	local XComGameState_AchievementData AchievementData;
+
+	if (GameState.GetContext( ).InterruptionStatus == eInterruptionStatus_Interrupt)
+	{
+		return ELR_NoInterrupt;
+	}
+
+	// We only care about the human player's turn, not the AI's
+	if (`TACTICALRULES.GetLocalClientPlayerObjectID() != XComGameState_Player(EventSource).ObjectID)
+		return ELR_NoInterrupt;
+
+	NewGameState = class'XComGameStateContext_ChangeContainer'.static.CreateChangeState("X2AchievementTracker.OnTurnBegun");
+	AchievementData = GetAchievementData(NewGameState);
+	AchievementData.arrKillsPerUnitThisTurn.Length = 0;
+	AchievementData.iLostKillsThisTurn = 0;
+
+	`TACTICALRULES.SubmitGameState(NewGameState);
+
+	return ELR_NoInterrupt;
+}
+
+// This is called at the end of each turn
+static function EventListenerReturn OnPlayerTurnEnded(Object EventData, Object EventSource, XComGameState GameState, Name Event, Object CallbackData)
+{
+	local XComGameState NewGameState;
+	local XComGameState_AchievementData AchievementData;
+
+	if (GameState.GetContext( ).InterruptionStatus == eInterruptionStatus_Interrupt)
+	{
+		return ELR_NoInterrupt;
+	}
+	
+	// We only care about the human player's turn, not the AI's
+	if (`TACTICALRULES.GetLocalClientPlayerObjectID() != XComGameState_Player(EventSource).ObjectID)
+		return ELR_NoInterrupt;
+
+	NewGameState = class'XComGameStateContext_ChangeContainer'.static.CreateChangeState("X2AchievementTracker.OnPlayerTurnEnded");
+	AchievementData = GetAchievementData(NewGameState);
+		
+	AchievementData.arrKillsPerUnitThisTurn.Length = 0;
+	AchievementData.arrRevealedUnitsThisTurn.Length = 0;
+	AchievementData.arrUnitsKilledThisTurn.Length = 0;
+	AchievementData.iLostKillsThisTurn = 0;
+	
+	`TACTICALRULES.SubmitGameState(NewGameState);
+
+	return ELR_NoInterrupt;
+}
+
+// This is called every time an enemy is killed
+static function EventListenerReturn OnKillMail(Object EventData, Object EventSource, XComGameState NewGameState, Name EventID)
+{
+	local XComGameState_AchievementData AchievementData;
+	local XComGameState_Unit SourceUnit;
+	local XComGameState_Unit KilledUnit;
+	local int i;
+	local UnitKills NewUnitKill;
+	local bool found;
+
+	if (NewGameState.GetContext( ).InterruptionStatus == eInterruptionStatus_Interrupt)
+	{
+		return ELR_NoInterrupt;
+	}
+
+	SourceUnit = XComGameState_Unit(EventSource);
+	if (SourceUnit == none)
+		return ELR_NoInterrupt;
+
+	KilledUnit = XComGameState_Unit(EventData);
+
+	// Achievement: Kill 3 enemies in a single turn, with a single soldier, without explosives
+	if (`XENGINE.IsSinglePlayerGame() && !(`ONLINEEVENTMGR.bIsChallengeModeGame))
+	{
+		if (SourceUnit.IsEnemyUnit(KilledUnit) && !KilledUnit.bKilledByExplosion) //Don't count friendly-fire or explosive kills
+		{
+			NewGameState = class'XComGameStateContext_ChangeContainer'.static.CreateChangeState("X2AchievementTracker.OnKillMail");
+			AchievementData = GetAchievementData(NewGameState);
+
+			found = false;
+			for (i = 0; i < AchievementData.arrKillsPerUnitThisTurn.Length; i++)
+			{
+				if (AchievementData.arrKillsPerUnitThisTurn[i].UnitId == SourceUnit.ObjectID)
+				{
+					AchievementData.arrKillsPerUnitThisTurn[i].NumKills++;
+					if (SourceUnit.IsPlayerControlled() && AchievementData.arrKillsPerUnitThisTurn[i].NumKills == 3) //Achievement can only trigger on player-controlled units
+					{
+						`ONLINEEVENTMGR.UnlockAchievement(AT_TripleKill);
+					}
+
+					found = true;
+					break;
+				}
+			}
+
+			if (!found)
+			{
+				NewUnitKill.UnitID = SourceUnit.ObjectID;
+				NewUnitKill.NumKills = 1;
+
+				AchievementData.arrKillsPerUnitThisTurn.AddItem(NewUnitKill);
+			}
+			
+			`TACTICALRULES.SubmitGameState(NewGameState);
+		}
+
+		// Achievement: Kill 500 aliens (does not have to be in same game)
+		if ( SourceUnit.IsPlayerControlled() && SourceUnit.IsEnemyUnit(KilledUnit) && (KilledUnit.IsAlien() || KilledUnit.IsAdvent()) )
+		{
+			`XPROFILESETTINGS.Data.m_iGlobalAlienKills++;
+
+			if (`XPROFILESETTINGS.Data.m_iGlobalAlienKills >= 500)
+				`ONLINEEVENTMGR.UnlockAchievement(AT_Kill500);
+
+			`ONLINEEVENTMGR.SaveProfileSettings();
+		}
+	}
+
+	return ELR_NoInterrupt;
+}
+
+static function EventListenerReturn OnWeaponKillType(Object EventData, Object EventSource, XComGameState GameState, Name Event, Object CallbackData)
+{
+	local XComGameState_Ability Ability;
+	local XComGameState_Item Item;
+	local name TemplateName;
+	local XComGameStateHistory History;	
+
+	if (GameState.GetContext( ).InterruptionStatus == eInterruptionStatus_Interrupt)
+	{
+		return ELR_NoInterrupt;
+	}
+	
+	if (`XENGINE.IsSinglePlayerGame() && !(`ONLINEEVENTMGR.bIsChallengeModeGame))
+	{
+		Ability = XComGameState_Ability(EventData);
+
+		History = `XCOMHISTORY;
+		
+		Item = XComGameState_Item(History.GetGameStateForObjectID(Ability.SourceWeapon.ObjectID));
+		if (Item == none)
+			return ELR_NoInterrupt;
+
+		TemplateName = Item.GetMyTemplateName();
+
+		switch (TemplateName)
+		{
+		case 'RocketLauncher':
+			`XPROFILESETTINGS.Data.m_HeavyWeaponKillMask = `XPROFILESETTINGS.Data.m_HeavyWeaponKillMask | (0x1 << HWK_RocketLauncher);
+			break;
+
+		case 'ShredderGun':
+			`XPROFILESETTINGS.Data.m_HeavyWeaponKillMask = `XPROFILESETTINGS.Data.m_HeavyWeaponKillMask | (0x1 << HWK_ShredderGun);
+			break;
+
+		case 'Flamethrower':
+			`XPROFILESETTINGS.Data.m_HeavyWeaponKillMask = `XPROFILESETTINGS.Data.m_HeavyWeaponKillMask | (0x1 << HWK_Flamethrower);
+			break;
+
+		case 'FlamethrowerMk2':
+			`XPROFILESETTINGS.Data.m_HeavyWeaponKillMask = `XPROFILESETTINGS.Data.m_HeavyWeaponKillMask | (0x1 << HWK_HellfireProjector);
+			break;
+
+		case 'BlasterLauncher':
+			`XPROFILESETTINGS.Data.m_HeavyWeaponKillMask = `XPROFILESETTINGS.Data.m_HeavyWeaponKillMask | (0x1 << HWK_BlasterLauncher);
+			break;
+
+		case 'PlasmaBlaster':
+			`XPROFILESETTINGS.Data.m_HeavyWeaponKillMask = `XPROFILESETTINGS.Data.m_HeavyWeaponKillMask | (0x1 << HWK_PlasmaBlaster);
+			break;
+
+		case 'ShredstormCannon':
+			`XPROFILESETTINGS.Data.m_HeavyWeaponKillMask = `XPROFILESETTINGS.Data.m_HeavyWeaponKillMask | (0x1 << HWK_ShredstormCannon);
+			break;
+		}
+
+		// Achievement: Kill an enemy with every heavy weapon in the game (Doesn't have to be in the same game)
+		if (`XPROFILESETTINGS.Data.m_HeavyWeaponKillMask == ((0x1 << HeavyWeaponKill.EnumCount) - 1))
+		{
+			`ONLINEEVENTMGR.UnlockAchievement(AT_KillWithEveryHeavyWeapon);
+		}
+
+		`ONLINEEVENTMGR.SaveProfileSettings();
+	}
+	
+	return ELR_NoInterrupt;
+}
+
+static function CheckForSuccessfulAmbush(XComGameState NewGameState)
+{
+	local XComGameState_AchievementData AchievementData;
+	local bool SuccessfulAmbush;
+	local int UnitID;
+	
+	AchievementData = GetAchievementData(NewGameState);
+
+	// Ambush: On the player turn, kill every AI member of a pod as the scramble away from the moment you are revealed.
+	// So, if there was at least one reveled unit, and you kill them all the first turn they are revealed, it is a 
+	// successful ambush.
+	SuccessfulAmbush = false;
+	foreach AchievementData.arrRevealedUnitsThisTurn(UnitID)
+	{
+		SuccessfulAmbush = true;
+		if (AchievementData.arrUnitsKilledThisTurn.Find(UnitID) == INDEX_NONE)
+		{
+			SuccessfulAmbush = false;
+			break;
+		}
+	}
+
+	// Achievement: Complete a successful ambush
+	if (SuccessfulAmbush)
+	{
+		`ONLINEEVENTMGR.UnlockAchievement(AT_Ambush);
+	}
+}
+
+// This is called when a unit dies
+static function OnUnitDied(XComGameState_Unit Unit, XComGameState NewGameState, Object CauseOfDeath, const out StateObjectReference SourceStateObjectRef, bool ApplyToOwnerAndComponents, const EffectAppliedData EffectData, bool bDiedInExplosion)
+{
+	local XComGameStateHistory History;
+	local Name CharacterGroupName;
+	local Name AbilityTemplateName;
+	local X2AbilityTemplate WeaponAbilityTemplate;
+	local XComGameState_AchievementData AchievementData;
+	local XComGameState_Destructible DestructibleKiller;
+	local XComGameStateContext_Ability AbilityContext;
+	local XComGameState_Unit SourceUnit;
+	local XComGameState_Effect EffectState;
+	local Actor DestructibleActor;
+	local UnitKills NewUnitKills;
+	local int iIndex;
+
+	History = `XCOMHISTORY;
+
+	if (`XENGINE.IsSinglePlayerGame() && !(`ONLINEEVENTMGR.bIsChallengeModeGame))
+	{
+		AchievementData = GetAchievementData(NewGameState);
+		AchievementData.arrUnitsKilledThisTurn.AddItem(Unit.ObjectID);
+
+		CharacterGroupName = Unit.GetMyTemplate().CharacterGroupName;
+
+		if (CharacterGroupName == 'AdventPsiWitch' && !class'X2TacticalGameRulesetDataStructures'.static.TacticalOnlyGameMode())
+		{
+			// Achievement: Kill an Avatar
+			`ONLINEEVENTMGR.UnlockAchievement(AT_KillAvatar);
+		}
+		else if (CharacterGroupName == 'Berserker')
+		{
+			// Achievement: Kill a Berserker in melee combat
+			AbilityTemplateName = ((EffectData).AbilityInputContext).AbilityTemplateName;
+			WeaponAbilityTemplate = class'X2AbilityTemplateManager'.static.GetAbilityTemplateManager().FindAbilityTemplate(AbilityTemplateName);
+			if (WeaponAbilityTemplate.IsMelee())
+			{
+				`ONLINEEVENTMGR.UnlockAchievement(AT_KillBerserkerMelee);
+			}
+		}
+		else if (CharacterGroupName == 'Cyberus')
+		{
+			AchievementData.bKilledACyberusThisMission = true;
+		}
+		else if (CharacterGroupName == 'Sectoid')
+		{
+			// Achievement: Kill a Sectoid who is currently mind controlling a squadmate
+			if (Unit.IsUnitApplyingEffectName(class'X2Effect_MindControl'.default.EffectName))
+			{
+				`ONLINEEVENTMGR.UnlockAchievement(AT_KillSectoidMindControlling);
+			}
+		}
+		else if (CharacterGroupName == 'Sectopod')
+		{
+			// Achievement: Kill a Sectopod on the same turn you encounter it
+			if (AchievementData.arrRevealedUnitsThisTurn.Find(Unit.ObjectID) != INDEX_NONE)
+			{
+				`ONLINEEVENTMGR.UnlockAchievement(AT_InstaKillSectopod);
+			}
+		}
+		else if (CharacterGroupName == 'Viper')
+		{
+			// Achievement: Kill a Viper who is strangling a squadmate
+			if (Unit.IsUnitApplyingEffectName(class'X2Ability_Viper'.default.BindSustainedEffectName) ||
+				Unit.IsUnitApplyingEffectName(class'X2Ability_Viper'.default.BindAbilityName))
+			{
+				`ONLINEEVENTMGR.UnlockAchievement(AT_KillViperStrangling);
+			}
+		}
+
+ 		AbilityContext = XComGameStateContext_Ability(NewGameState.GetContext());
+		if (AbilityContext != none && AbilityContext.InputContext.PrimaryTarget.ObjectID != 0) // Check if the killing blow was a single target ability
+		{
+			// Save the Source Unit of the ability for later checks
+			SourceUnit = XComGameState_Unit(History.GetGameStateForObjectID(AbilityContext.InputContext.SourceObject.ObjectID));
+
+			if (CharacterGroupName == 'TheLost' && (class'X2Effect_TheLostHeadshot'.default.ValidHeadshotAbilities.Find(AbilityContext.InputContext.AbilityTemplateName) != INDEX_NONE))
+			{
+				AchievementData.iLostKillsThisTurn++;
+
+				if (AchievementData.iLostKillsThisTurn >= 15)
+				{
+					`log("War of the Chosen Achievement Awarded: Zombies in a Barrel");
+					`ONLINEEVENTMGR.UnlockAchievement(AT_LostHeadshots);
+				}
+			}
+		}
+		else
+		{
+			// If there is no ability context, check for a destructible kill
+			DestructibleKiller = XComGameState_Destructible(History.GetGameStateForObjectID(SourceStateObjectRef.ObjectID));
+			if (DestructibleKiller != none)
+			{
+				// Achievement: Cause an enemy to die in a car explosion
+				if (Unit.GetTeam() == eTeam_Alien && bDiedInExplosion)
+				{
+					DestructibleActor = DestructibleKiller.GetVisualizer();
+					if (DestructibleActor != none)
+					{
+						if (DestructibleActor.Tag == 'CarAchievement')
+							`ONLINEEVENTMGR.UnlockAchievement(AT_KillViaCarExplosion);
+					}
+				}
+
+				// Check for a kill by a Claymore
+				foreach History.IterateByClassType(class'XcomGameState_Effect', EffectState)
+				{
+					if (EffectState.CreatedObjectReference.ObjectID == DestructibleKiller.ObjectID)
+					{
+						if (X2Effect_Claymore(EffectState.GetX2Effect()) != none)
+						{
+							SourceUnit = XComGameState_Unit(History.GetGameStateForObjectID(EffectState.ApplyEffectParameters.SourceStateObjectRef.ObjectID));
+						}
+
+						break;
+					}
+				}
+			}
+		}
+
+		// If we have a source unit here, either from the ability context or a destructible, check if its a Reaper in Shadow
+		if (SourceUnit != none && SourceUnit.GetSoldierClassTemplateName() == 'Reaper' && SourceUnit.bHasSuperConcealment && SourceUnit.IsConcealed())
+		{
+			// If the Reaper hasn't achieved any Shadow kills yet, add a new data struct to track
+			if (AchievementData.arrReaperShadowKillsThisMission.Find('UnitID', SourceUnit.ObjectID) == INDEX_NONE)
+			{
+				NewUnitKills.UnitID = SourceUnit.ObjectID;
+				NewUnitKills.NumKills++;
+				AchievementData.arrReaperShadowKillsThisMission.AddItem(NewUnitKills);
+			}
+			else
+			{
+				// Update the Shadow kill data for this Reaper
+				iIndex = AchievementData.arrReaperShadowKillsThisMission.Find('UnitID', SourceUnit.ObjectID);
+				AchievementData.arrReaperShadowKillsThisMission[iIndex].NumKills++;
+
+				if (AchievementData.arrReaperShadowKillsThisMission[iIndex].NumKills >= 4)
+				{
+					`log("War of the Chosen Achievement Awarded: Born in the Darkness");
+					`ONLINEEVENTMGR.UnlockAchievement(AT_ReaperShadowKills);
+				}
+			}
+		}
+
+		// Achievement: Cause an enemy to fall to its death
+		if (NewGameState.GetContext().IsA('XComGameStateContext_Falling') && Unit.GetTeam() == eTeam_Alien)
+		{
+			`ONLINEEVENTMGR.UnlockAchievement(AT_KillViaFalling);
+		}
+
+		// Check for ambush
+		CheckForSuccessfulAmbush(NewGameState);
+	}
+}
+
+static function OnRevealAI(XComGameState NewGameState, int UnitObjectID)
+{
+	local XComGameState_AchievementData AchievementData;
+
+	AchievementData = GetAchievementData(NewGameState);
+	AchievementData.arrRevealedUnitsThisTurn.AddItem(UnitObjectID);
+}
+
+// This is the callback for beating the game
+static function FinalMissionOnSuccess()
+{
+	local bool July15thOrEarlier;
+	local XComGameState_CampaignSettings Settings;
+	local XComGameState_GameTime TimeState;
+	local XComGameStateHistory History;
+	local XComGameState_HeadquartersXCom XComHQ;
+	local XComGameState_HeadquartersAlien AlienHQ;
+	local array<XComGameState_Item> InventoryItems;
+	local XComGameState_Item InventoryItem;
+	local XComGameState_Unit Unit;
+	local StateObjectReference UnitRef;
+	local name ItemTemplateName;
+	local bool AllConventionalGear;
+
+	History = `XCOMHISTORY;
+	Settings = XComGameState_CampaignSettings(History.GetSingleGameStateObjectForClass(class'XComGameState_CampaignSettings'));
+	XComHQ = class'UIUtilities_Strategy'.static.GetXComHQ();
+	AlienHQ = class'UIUtilities_Strategy'.static.GetAlienHQ();
+	
+	`ONLINEEVENTMGR.UnlockAchievement(AT_OverthrowAny); // Overthrow the aliens at any difficulty level
+
+	if (Settings.LowestDifficultySetting >= 2) // classic mode
+	{
+		`ONLINEEVENTMGR.UnlockAchievement(AT_OverthrowClassic); // Overthrow the aliens on Classic difficulty
+
+		if (!class'X2StrategyGameRulesetDataStructures'.static.HasSquadSizeUpgrade()) // Beat the game on Classic+ difficulty without buying a Squad Size upgrade
+		{
+			`ONLINEEVENTMGR.UnlockAchievement(AT_WinGameClassicWithoutBuyingUpgrade);
+		}
+
+		TimeState = XComGameState_GameTime(`XCOMHISTORY.GetSingleGameStateObjectForClass(class'XComGameState_GameTime'));
+		July15thOrEarlier = class 'X2StrategyGameRulesetDataStructures'.static.LessThan(TimeState.CurrentTime, `XACHIEVEMENT_TRACKER.July15th);
+		if (July15thOrEarlier) // Beat the game on Classic+ difficulty by July 1st
+		{
+			`ONLINEEVENTMGR.UnlockAchievement(AT_WinGameClassicPlusByDate);
+		}
+		if (Settings.bIronmanEnabled) // Beat the game on Classic+ difficulty in Ironman mode
+		{
+			`ONLINEEVENTMGR.UnlockAchievement(AT_Ironman);
+		}
+
+		// Check for beating a classic game without losing a single soldier
+		if (XComHQ.DeadCrew.Length == 0 && AlienHQ.CapturedSoldiers.Length == 0) 
+		{
+			`ONLINEEVENTMGR.UnlockAchievement(AT_WinGameClassicPlusNoLosses);
+		}
+	}
+
+	if (Settings.LowestDifficultySetting >= 3) // impossible mode
+	{
+		`ONLINEEVENTMGR.UnlockAchievement(AT_OverthrowImpossible); // Overthrow the aliens on Impossible difficulty
+	}
+	//Checking All Units to make sure they only have Conventional Gear
+	AllConventionalGear = true;
+	foreach XComHQ.Squad(UnitRef)
+	{
+		Unit = XComGameState_Unit(History.GetGameStateForObjectID(UnitRef.ObjectID));
+		InventoryItems = Unit.GetAllInventoryItems(, true);
+		foreach InventoryItems(InventoryItem)
+		{
+			if (InventoryItem.InventorySlot != eInvSlot_Backpack) // ignore any items which were picked up as loot on the mission
+			{
+				// If the item was auto-upgraded from a Tier 0 item, and the Tier 0 item is no longer available, they are allowed
+				ItemTemplateName = InventoryItem.GetMyTemplateName();
+				if (ItemTemplateName == 'AlienGrenade' ||
+					ItemTemplateName == 'NanoMedikit' ||
+					ItemTemplateName == 'SmokeGrenadeMk2')
+				{
+					continue;
+				}
+
+				//Otherwise we're making the assumption that all of a Unit's inventory should have a Tier of 0
+				if (InventoryItem.GetMyTemplate().Tier > 0)
+				{
+					AllConventionalGear = false;
+					break;
+				}
+			}
+		}
+
+		if (!AllConventionalGear)
+			break;
+	}
+	if (AllConventionalGear)
+	{
+		`ONLINEEVENTMGR.UnlockAchievement(AT_WinGameUsingConventionalGear);
+	}
+
+	if (Settings.RequiredDLC.Find( 'TLE' ) != INDEX_NONE)
+	{
+		class'X2TacticalGameRuleset'.static.ReleaseScriptLog("TLE Achievement Awarded: Complete Campaign with TLE");
+		`ONLINEEVENTMGR.UnlockAchievement(AT_CompleTLECampaign);
+	}
+}
+
+// This is called when a unit is skulljacked
+static function OnUnitSkulljacked(XComGameState_Unit TargetUnit)
+{
+	local name UnitGroupName;
+	local bool bAllSkulljacked;
+	local int i;
+	local X2AchievementTracker Tracker;
+
+	Tracker = `XACHIEVEMENT_TRACKER;
+	UnitGroupName = TargetUnit.GetMyTemplate().CharacterGroupName;
+
+	bAllSkulljacked = true;
+	for (i = 0; i < Tracker.arrSkulljackedUnitGroups.Length; i++)
+	{
+		// Set the new unit to skulljacked
+		if (Tracker.arrSkulljackedUnitGroups[i] == UnitGroupName)
+		{
+			`XPROFILESETTINGS.Data.arrbSkulljackedUnits[i] = true;
+		}
+
+		// In the same loop, check if all units are skulljacked
+		if (!`XPROFILESETTINGS.Data.arrbSkulljackedUnits[i])
+		{
+			bAllSkulljacked = false;
+		}
+	}
+
+	// Achievement: Skulljack each different type of ADVENT soldier(does not have to be in same game)
+	if (bAllSkulljacked)
+	{
+		`ONLINEEVENTMGR.UnlockAchievement(AT_SkulljackEachAdventSoldierType);
+	}
+}
+
+static function EventListenerReturn OnMissionObjectiveComplete(Object EventData, Object EventSource, XComGameState GameState, Name Event, Object CallbackData)
+{
+	local XComGameState_BattleData BattleData;
+	local MissionObjectiveDefinition MissionObjective;
+	local XComGameState_Unit Unit;
+	local bool IsSquadConcealed;
+	
+	if (GameState.GetContext( ).InterruptionStatus == eInterruptionStatus_Interrupt)
+	{
+		return ELR_NoInterrupt;
+	}
+
+	if (`XENGINE.IsSinglePlayerGame() && !(`ONLINEEVENTMGR.bIsChallengeModeGame))
+	{
+		BattleData = XComGameState_BattleData(EventData);
+
+		// Reach the objective item in a Guerilla Ops mission with the entire squad still concealed
+		foreach BattleData.MapData.ActiveMission.MissionObjectives(MissionObjective)
+		{
+			if (MissionObjective.bCompleted &&
+				(string(MissionObjective.ObjectiveName) == "Hack" ||
+					string(MissionObjective.ObjectiveName) == "Recover" ||
+					string(MissionObjective.ObjectiveName) == "ProtectDevice" ||
+					string(MissionObjective.ObjectiveName) == "DestroyObject"))
+			{
+				IsSquadConcealed = true;
+				foreach `XCOMHISTORY.IterateByClassType(class'XComGameState_Unit', Unit)
+				{
+					if (Unit.IsPlayerControlled() && Unit.IsSoldier())
+					{
+						if (!Unit.IsSquadConcealed())
+						{
+							IsSquadConcealed = false;
+							break;
+						}
+					}
+				}
+
+				if (IsSquadConcealed)
+				{
+					`ONLINEEVENTMGR.UnlockAchievement(AT_GuerillaWarfare);
+				}
+			}
+		}
+	}
+
+	return ELR_NoInterrupt;
+}
+
+static function EventListenerReturn OnPCSApplied(Object EventData, Object EventSource, XComGameState GameState, Name Event, Object CallbackData)
+{
+	`ONLINEEVENTMGR.UnlockAchievement(AT_ApplyPCSUpgrade);
+
+	return ELR_NoInterrupt;
+}
+
+static function EventListenerReturn OnWeaponUpgraded(Object EventData, Object EventSource, XComGameState GameState, Name Event, Object CallbackData)
+{
+	local XComGameState_HeadquartersXCom XComHQ;
+	local XComGameState_Item WeaponState;
+	local array<X2WeaponUpgradeTemplate> UpgradeTemplates;
+	local X2WeaponUpgradeTemplate UpgradeTemplate;
+	local X2WeaponTemplate WeaponTemplate;
+	local bool bAllSuperior;
+	local int NumUpgradeSlots;
+
+	if (GameState.GetContext( ).InterruptionStatus == eInterruptionStatus_Interrupt)
+	{
+		return ELR_NoInterrupt;
+	}
+
+	XComHQ = class'UIUtilities_Strategy'.static.GetXComHQ();
+	WeaponState = XComGameState_Item(EventData);
+	
+	if(WeaponState != none)
+	{
+		`ONLINEEVENTMGR.UnlockAchievement(AT_UpgradeWeapon);
+
+		WeaponTemplate = X2WeaponTemplate(WeaponState.GetMyTemplate());
+		if(WeaponTemplate != none && WeaponTemplate.IsHighTech()) // First check if this is a beam weapon
+		{
+			UpgradeTemplates = WeaponState.GetMyWeaponUpgradeTemplates();
+
+			NumUpgradeSlots = WeaponTemplate.NumUpgradeSlots;
+			if (XComHQ.bExtraWeaponUpgrade)
+				NumUpgradeSlots++;
+			if (XComHQ.ExtraUpgradeWeaponCats.Find(WeaponTemplate.WeaponCat) != INDEX_NONE)
+				NumUpgradeSlots++;
+
+			// Then make sure that each slot in the weapon has been equipped with an upgrade
+			if(UpgradeTemplates.Length == NumUpgradeSlots)
+			{
+				bAllSuperior = true;
+
+				// Then check if it has all superior upgrades
+				foreach UpgradeTemplates(UpgradeTemplate)
+				{
+					if(UpgradeTemplate.Tier < 2)
+					{
+						bAllSuperior = false;
+					}
+				}
+
+				if(bAllSuperior)
+				{
+					`ONLINEEVENTMGR.UnlockAchievement(AT_UpgradeWeaponSuperior);
+				}
+			}
+		}
+	}
+
+	return ELR_NoInterrupt;
+}
+
+static function EventListenerReturn OnFacilityConstructionCompleted(Object EventData, Object EventSource, XComGameState GameState, Name Event, Object CallbackData)
+{
+	local XComGameState_FacilityXCom NewFacility;
+	local XComGameState_HeadquartersXCom NewXComHQ;
+	local XComGameStateHistory History;
+	local XComGameState_HeadquartersRoom RoomState;
+	local bool bAllRoomsFilled;
+	local int idx;
+
+	if (GameState.GetContext( ).InterruptionStatus == eInterruptionStatus_Interrupt)
+	{
+		return ELR_NoInterrupt;
+	}
+	
+	NewFacility = XComGameState_FacilityXCom(EventData);
+
+	if(NewFacility != none)
+	{
+		History = `XCOMHISTORY;
+		NewXComHQ = XComGameState_HeadquartersXCom(History.GetSingleGameStateObjectForClass(class'XComGameState_HeadquartersXCom'));
+
+		if(NewFacility.GetMyTemplateName() == 'ResistanceComms')
+		{
+			`ONLINEEVENTMGR.UnlockAchievement(AT_BuildResistanceComms);
+		}
+		else if(NewFacility.GetMyTemplateName() == 'ShadowChamber')
+		{
+			`ONLINEEVENTMGR.UnlockAchievement(AT_BuildShadowChamber);
+		}
+
+		bAllRoomsFilled = true;
+		for(idx = 0; idx < NewXComHQ.Rooms.Length; idx++)
+		{
+			RoomState = XComGameState_HeadquartersRoom(History.GetGameStateForObjectID(NewXComHQ.Rooms[idx].ObjectID));
+
+			if(RoomState.GetFacility() == none)
+			{
+				bAllRoomsFilled = false;
+				break;
+			}
+		}
+
+		if(bAllRoomsFilled)
+		{
+			`ONLINEEVENTMGR.UnlockAchievement(AT_BuildEverySlot);
+		}
+	}
+
+	return ELR_NoInterrupt;
+}
+
+static function EventListenerReturn OnFacilityUpgradeCompleted(Object EventData, Object EventSource, XComGameState GameState, Name Event, Object CallbackData)
+{
+	local XComGameState_FacilityUpgrade UpgradeState;
+
+	if (GameState.GetContext( ).InterruptionStatus == eInterruptionStatus_Interrupt)
+	{
+		return ELR_NoInterrupt;
+	}
+
+	UpgradeState = XComGameState_FacilityUpgrade(EventData);
+
+	if (!UpgradeState.GetMyTemplate().bHidden)
+	{
+		`ONLINEEVENTMGR.UnlockAchievement(AT_UpgradeFacility);
+	}
+
+	return ELR_NoInterrupt;
+}
+
+static function EventListenerReturn OnPOICompleted(Object EventData, Object EventSource, XComGameState GameState, Name Event, Object CallbackData)
+{
+	if (GameState.GetContext( ).InterruptionStatus == eInterruptionStatus_Interrupt)
+	{
+		return ELR_NoInterrupt;
+	}
+
+	`ONLINEEVENTMGR.UnlockAchievement(AT_CompletePOI);
+
+	return ELR_NoInterrupt;
+}
+
+static function EventListenerReturn OnRegionContacted(Object EventData, Object EventSource, XComGameState GameState, Name Event, Object CallbackData)
+{
+	local XComGameStateHistory History;
+	local XComGameState_Continent Continent;
+	local bool bEveryContinentBonus;
+
+	if (GameState.GetContext( ).InterruptionStatus == eInterruptionStatus_Interrupt)
+	{
+		return ELR_NoInterrupt;
+	}
+	
+	History = `XCOMHISTORY;
+
+	`ONLINEEVENTMGR.UnlockAchievement(AT_ContactRegion);
+
+	bEveryContinentBonus = true;
+	foreach History.IterateByClassType(class'XComGameState_Continent', Continent)
+	{
+		if (!Continent.bContinentBonusActive)
+		{
+			bEveryContinentBonus = false;
+			break;
+		}
+	}
+
+	// Achievement: Get all of the continent bonuses in a single game
+	if (bEveryContinentBonus)
+	{
+		`ONLINEEVENTMGR.UnlockAchievement(AT_GetAllContinentBonuses);
+	}
+
+	return ELR_NoInterrupt;
+}
+
+static function EventListenerReturn OnOutpostBuilt(Object EventData, Object EventSource, XComGameState GameState, Name Event, Object CallbackData)
+{
+	local XComGameStateHistory History;
+	local XComGameState_Continent Continent;
+	local XComGameState_WorldRegion Region;
+	local StateObjectReference RegionRef;
+	local bool bOutpostFound, bOutpostOnAllContinents, bEveryContinentBonus;
+
+	if (GameState.GetContext( ).InterruptionStatus == eInterruptionStatus_Interrupt)
+	{
+		return ELR_NoInterrupt;
+	}
+	
+	History = `XCOMHISTORY;
+
+	bOutpostOnAllContinents = true;
+	bEveryContinentBonus = true;
+	foreach History.IterateByClassType(class'XComGameState_Continent', Continent)
+	{
+		bOutpostFound = false;
+
+		foreach Continent.Regions(RegionRef)
+		{
+			Region = XComGameState_WorldRegion(History.GetGameStateForObjectID(RegionRef.ObjectID));
+			if (Region.ResistanceLevel >= eResLevel_Outpost)
+			{
+				bOutpostFound = true;
+			}
+		}
+
+		if (!bOutpostFound)
+		{
+			bOutpostOnAllContinents = false;
+			bEveryContinentBonus = false; // Impossible to have every continent bonus if you don't have an outpost on every continent
+			break;
+		}
+
+		if (!Continent.bContinentBonusActive)
+		{
+			bEveryContinentBonus = false;
+		}
+	}
+
+	if (bOutpostOnAllContinents)
+	{
+		`ONLINEEVENTMGR.UnlockAchievement(AT_BuildRadioEveryContinent);
+	}
+
+	// Achievement: Get all of the continent bonuses in a single game
+	if (bEveryContinentBonus)
+	{
+		`ONLINEEVENTMGR.UnlockAchievement(AT_GetAllContinentBonuses);
+	}
+
+	return ELR_NoInterrupt;
+}
+
+static function EventListenerReturn OnResearchCompleted(Object EventData, Object EventSource, XComGameState GameState, Name Event, Object CallbackData)
+{
+	local XComGameState_Tech TechState;
+
+	if (GameState.GetContext( ).InterruptionStatus == eInterruptionStatus_Interrupt)
+	{
+		return ELR_NoInterrupt;
+	}
+
+	TechState = XComGameState_Tech(EventData);
+
+	if (TechState != none)
+	{
+		switch (TechState.GetMyTemplateName())
+		{
+		case 'AutopsyAdventPsiWitch':
+			`ONLINEEVENTMGR.UnlockAchievement(AT_CompleteAvatarAutopsy);
+			break;
+		case 'ExperimentalAmmo':
+		case 'ExperimentalGrenade':
+		case 'ExperimentalArmor':
+			`ONLINEEVENTMGR.UnlockAchievement(AT_BuildExperimentalItem);
+			break;
+		default:
+			break;
+		}
+	}
+
+	return ELR_NoInterrupt;
+}
+
+static function EventListenerReturn OnBlackMarketGoodsSold(Object EventData, Object EventSource, XComGameState GameState, Name Event, Object CallbackData)
+{
+	if (GameState.GetContext( ).InterruptionStatus == eInterruptionStatus_Interrupt)
+	{
+		return ELR_NoInterrupt;
+	}
+
+	if (`XPROFILESETTINGS.Data.m_BlackMarketSuppliesReceived >= 1000)
+	{
+		`ONLINEEVENTMGR.UnlockAchievement(AT_BlackMarket);
+	}
+
+	return ELR_NoInterrupt;
+}
+
+static function EventListenerReturn OnFinalMissionStarted(Object EventData, Object EventSource, XComGameState GameState, Name Event, Object CallbackData)
+{
+	if (GameState.GetContext( ).InterruptionStatus == eInterruptionStatus_Interrupt)
+	{
+		return ELR_NoInterrupt;
+	}
+
+	`ONLINEEVENTMGR.UnlockAchievement(AT_CreateDarkVolunteer);
+
+	return ELR_NoInterrupt;
+}
+
+static function EventListenerReturn OnFactionInfluenceIncreased(Object EventData, Object EventSource, XComGameState GameState, Name Event, Object CallbackData)
+{
+	local XComGameStateHistory History;
+	local XComGameState_ResistanceFaction FactionState;
+	local bool bAllFactionsHighInfluence;
+
+	if (GameState.GetContext().InterruptionStatus == eInterruptionStatus_Interrupt)
+	{
+		return ELR_NoInterrupt;
+	}
+
+	History = `XCOMHISTORY;
+	
+	bAllFactionsHighInfluence = true;
+	foreach History.IterateByClassType(class'XComGameState_ResistanceFaction', FactionState)
+	{
+		if (FactionState.Influence < eFactionInfluence_Influential)
+		{
+			bAllFactionsHighInfluence = false;
+			break; // Only needs to fail once
+		}
+	}
+	
+	if (bAllFactionsHighInfluence)
+	{
+		`log("War of the Chosen Achievement Awarded: Fully Operational Resistance");
+		`ONLINEEVENTMGR.UnlockAchievement(AT_HighInfluenceAllFactions);
+	}
+
+	return ELR_NoInterrupt;
+}
+
+static function EventListenerReturn OnBondLevelUp(Object EventData, Object EventSource, XComGameState GameState, Name Event, Object CallbackData)
+{
+	local XComGameState_Unit UnitState, LinkedUnitState;
+	local SoldierBond Bond;
+
+	if (GameState.GetContext().InterruptionStatus == eInterruptionStatus_Interrupt)
+	{
+		return ELR_NoInterrupt;
+	}
+
+	UnitState = XComGameState_Unit(EventData);
+	LinkedUnitState = XComGameState_Unit(EventSource);
+
+	if (UnitState != none && LinkedUnitState != none)
+	{
+		if (UnitState.GetBondData(LinkedUnitState.GetReference(), Bond))
+		{
+			if (Bond.BondLevel >= (class'X2StrategyGameRulesetDataStructures'.default.CohesionThresholds.Length - 1))
+			{
+				`log("War of the Chosen Achievement Awarded: It Takes Two");
+				`ONLINEEVENTMGR.UnlockAchievement(AT_MaxLevelBond);
+			}
+		}
+	}
+
+	return ELR_NoInterrupt;
+}
+
+static function EventListenerReturn OnFocusLevelChanged(Object EventData, Object EventSource, XComGameState GameState, Name Event, Object CallbackData)
+{
+	local XComGameState NewGameState;
+	local XComGameState_Unit UnitState;
+	local XComGameState_Effect_TemplarFocus FocusState;
+	local XComGameState_AchievementData AchievementData;
+	local FocusCycle FocusCycleData;
+	local int iIndex;
+
+	if (GameState.GetContext().InterruptionStatus == eInterruptionStatus_Interrupt)
+	{
+		return ELR_NoInterrupt;
+	}
+	
+	if (`XENGINE.IsSinglePlayerGame() && !(`ONLINEEVENTMGR.bIsChallengeModeGame))
+	{
+		FocusState = XComGameState_Effect_TemplarFocus(EventData);
+		UnitState = XComGameState_Unit(EventSource);
+
+		NewGameState = class'XComGameStateContext_ChangeContainer'.static.CreateChangeState("X2AchievementTracker.OnFocusLevelChanged");
+		AchievementData = GetAchievementData(NewGameState);
+
+		// Ensure the Templar has an entry in the data array for this mission
+		if (AchievementData.arrTemplarFocusCyclesThisMission.Find('UnitID', UnitState.ObjectID) == INDEX_NONE)
+		{
+			FocusCycleData.UnitID = UnitState.ObjectID;
+			AchievementData.arrTemplarFocusCyclesThisMission.AddItem(FocusCycleData);
+		}
+
+		// Update the Focus Cycle data for the Templar
+		iIndex = AchievementData.arrTemplarFocusCyclesThisMission.Find('UnitID', UnitState.ObjectID);
+		if (iIndex != INDEX_NONE)
+		{
+			FocusCycleData = AchievementData.arrTemplarFocusCyclesThisMission[iIndex];
+
+			if (FocusState.FocusLevel == FocusState.GetMaxFocus(UnitState))
+			{
+				// Award the achievement if the Templar has completed the Focus cycle
+				if (FocusCycleData.bReachedMaxFocus && FocusCycleData.bSpentAllFocus)
+				{
+					`log("War of the Chosen Achievement Awarded: Circle of Psi");
+					`ONLINEEVENTMGR.UnlockAchievement(AT_TemplarFocusCycle);
+				}
+				else // If the Templar has reached max focus, they have completed step 1
+				{
+					FocusCycleData.bReachedMaxFocus = true;
+				}
+			}
+
+			// If the Templar was at max focus and are now at zero again, flag completing step 2
+			if (FocusState.FocusLevel == 0 && FocusCycleData.bReachedMaxFocus)
+			{
+				FocusCycleData.bSpentAllFocus = true;
+			}
+
+			// Resave the modified Focus Cycle data
+			AchievementData.arrTemplarFocusCyclesThisMission[iIndex] = FocusCycleData;
+		}
+
+		`TACTICALRULES.SubmitGameState(NewGameState);
+	}
+
+	return ELR_NoInterrupt;
+}
+
+static function EventListenerReturn OnAbilityActivated(Object EventData, Object EventSource, XComGameState GameState, Name Event, Object CallbackData)
+{
+	local XComGameStateHistory History;
+	local XComGameStateContext_Ability AbilityContext;
+	local XComGameState_Ability AbilityState;
+	local X2AbilityTemplate	AbilityTemplate;
+	local XComGameState_Unit Shooter, NewShooter;
+	local array<StateObjectReference> AllTargets;
+	local StateObjectReference TargetRef;
+	local XComGameState NewGameState;
+	local UnitValue TargetValue;
+	local name TargetName;
+
+	History = `XCOMHISTORY;
+
+	if (`XENGINE.IsSinglePlayerGame() && !(`ONLINEEVENTMGR.bIsChallengeModeGame))
+	{
+		AbilityContext = XComGameStateContext_Ability(GameState.GetContext());
+		if (AbilityContext == none)
+			return ELR_NoInterrupt;
+
+		if (AbilityContext.InterruptionStatus == eInterruptionStatus_Interrupt)
+		{
+			return ELR_NoInterrupt;
+		}
+
+		AbilityState = XComGameState_Ability(EventData);
+		if (AbilityState == none)
+			return ELR_NoInterrupt;
+
+		AbilityTemplate = AbilityState.GetMyTemplate();
+
+		// Achievement for a Skirmisher to use offensive actions against the same target multiple times in a single turn.
+		Shooter = XComGameState_Unit(History.GetGameStateForObjectID(AbilityContext.InputContext.SourceObject.ObjectID));
+		if ((Shooter.GetSoldierClassTemplateName() == 'Skirmisher') && (AbilityTemplate.Hostility == eHostility_Offensive) &&
+			(Shooter.GetTeam() == eTeam_XCom) && AbilityContext.IsResultContextHit() && (AbilityTemplate.DataName != 'SkirmisherPostAbilityMelee'))
+		{
+			AllTargets = AbilityContext.InputContext.MultiTargets;
+			if (AllTargets.Find('ObjectID', AbilityContext.InputContext.PrimaryTarget.ObjectID) == INDEX_NONE)
+				AllTargets.AddItem(AbilityContext.InputContext.PrimaryTarget);
+
+			if (AllTargets.Length > 0)
+			{
+				NewGameState = class'XComGameStateContext_ChangeContainer'.static.CreateChangeState("X2AchievementTracker.OnAbilityActivated");
+				NewShooter = XComGameState_Unit(NewGameState.ModifyStateObject(class'XComGameState_Unit', Shooter.ObjectID));
+
+				foreach AllTargets(TargetRef)
+				{
+					TargetName = name("SKIRMISHER_ACHIEVEMENT_"$TargetRef.ObjectID);
+					if (!NewShooter.GetUnitValue(TargetName, TargetValue))
+					{
+						TargetValue.fValue = 0.0;
+					}
+					TargetValue.fValue += 1.0;
+					NewShooter.SetUnitFloatValue(TargetName, TargetValue.fValue, eCleanup_BeginTurn);
+
+					if (TargetValue.fValue >= default.SKIRMISHER_MULTI_ACTION_REQUIREMENT)
+					{
+						`ONLINEEVENTMGR.UnlockAchievement(AT_SkirmisherMultiActions);
+						`log("War of the Chosen Achievement Awarded: Can't Stop the Fighting");
+					}
+				}
+
+				`TACTICALRULES.SubmitGameState(NewGameState);
+				NewShooter = none;
+			}
+		}
+	}
+
+	return ELR_NoInterrupt;
+}
+
+function SimulateAchievementCondition(int AchievementToSimulate)
+{
+	local TDateTime	May1st;
+	local XComGameState_BattleData Battle;
+	local XComGameState_CampaignSettings Settings;
+	local XComGameStateHistory History;
+	local XComGameState_Unit Unit;
+	local XComGameState NewGameState;
+
+	History = `XCOMHISTORY;
+	Battle = XComGameState_BattleData(`XCOMHISTORY.GetSingleGameStateObjectForClass(class'XComGameState_BattleData'));
+	Settings = XComGameState_CampaignSettings(History.GetSingleGameStateObjectForClass(class'XComGameState_CampaignSettings'));
+	NewGameState = History.GetStartState();
+
+	`log("XComGameState_AchievementTracker.SimulateAchievementCondition");
+
+	switch (AchievementToSimulate)
+	{
+	case AT_CompleteTutorial:
+		Battle.m_bIsTutorial = true;
+		break;
+
+	case AT_BeatMissionJuneOrLater: // Beat a mission in June or later using only Rookies
+		// Set each soldier to rank Rookie
+		foreach History.IterateByClassType(class'XComGameState_Unit', Unit)
+		{
+			if (Unit.IsPlayerControlled() && Unit.IsSoldier())
+			{
+				Unit.ResetRankToRookie(); // Sets the ranking to 0
+			}
+		}
+
+		Battle.LocalTime = July31st;
+		break;
+
+	case AT_BeatMissionSameClass: // Beat a mission on Classic+ with a squad composed entirely of soldiers of the same class (but not rookie)
+		Settings.SetDifficulty(2);
+		foreach History.IterateByClassType(class'XComGameState_Unit', Unit)
+		{
+			if (Unit.IsPlayerControlled() && Unit.IsSoldier())
+			{
+				Unit.ResetRankToRookie();                      // Sets the ranking to 0
+				Unit.RankUpSoldier(NewGameState, 'Sharpshooter'); // Increases ranking (so not a Rookie) and sets class to 'Sharpshooter'
+			}
+		}
+		break;
+
+	case AT_WinGameClassicPlusByDate: // Beat the game on Classic+ difficulty by June 1st
+		class'X2StrategyGameRulesetDataStructures'.static.SetTime(
+			May1st, 0, 0, 0,
+			5, 1,
+		class'X2StrategyGameRulesetDataStructures'.default.START_YEAR
+			);
+		Settings.SetDifficulty(2);
+		Battle.LocalTime = May1st;
+		break;
+
+	case AT_Ironman: // Beat the game on Classic+ difficulty in Ironman mode
+		Settings.SetDifficulty(2);
+		Settings.SetIronmanEnabled(true);
+		break;
+
+	case AT_WinGameClassicPlusNoLosses: // Beat the game on Classic+ without losing a soldier
+		Settings.SetDifficulty(2);
+		break;
+	
+	case AT_WinGameClassicWithoutBuyingUpgrade: // Beat the game on Classic+ difficulty without buying a Squad Size upgrade
+		Settings.SetDifficulty(2);
+		break;
+
+	case AT_OverthrowAny: // Overthrow the aliens at any difficulty level
+		Settings.SetDifficulty(1);
+		break;
+
+	case AT_OverthrowClassic: // Overthrow the aliens on Classic difficulty
+		Settings.SetDifficulty(2);
+		break;
+
+	case AT_OverthrowImpossible: // Overthrow the aliens on Impossible difficulty
+		Settings.SetDifficulty(3);
+		break;
+	}
+}
+
+defaultproperties
+{
+	SKIRMISHER_MULTI_ACTION_REQUIREMENT=3
+}

--- a/X2WOTCCommunityHighlander/Src/XComGame/Classes/X2ItemTemplate.uc
+++ b/X2WOTCCommunityHighlander/Src/XComGame/Classes/X2ItemTemplate.uc
@@ -362,6 +362,30 @@ function bool CanBeLootedByUnit(XComGameState_Item LootItem, XComGameState_Unit 
 	return true;
 }
 
+// Start Issue #93
+function int GetNumUpgradeSlots()
+{
+	local X2WeaponTemplate SelfAsWeapon;
+	local int idx;
+
+	SelfAsWeapon = X2WeaponTemplate(self);
+
+	if (SelfAsWeapon != none)
+	{
+		return SelfAsWeapon.NumUpgradeSlots;
+	}
+
+	idx = class'CHHelpers'.default.NonWeaponUpgradeSlots.Find('TemplateName', DataName);
+
+	if (idx != INDEX_NONE)
+	{
+		return class'CHHelpers'.default.NonWeaponUpgradeSlots[idx].NumUpgradeSlots;
+	}
+
+	return 0;
+}
+// End Issue #93
+
 DefaultProperties
 {
 	iItemSize=1;

--- a/X2WOTCCommunityHighlander/Src/XComGame/Classes/XComGameState_HeadquartersXCom.uc
+++ b/X2WOTCCommunityHighlander/Src/XComGame/Classes/XComGameState_HeadquartersXCom.uc
@@ -4651,6 +4651,17 @@ static function UpgradeItems(XComGameState NewGameState, name CreatorTemplateNam
 			if (!XComHQ.HasItem(UpgradeItemTemplate))
 			{
 				UpgradedItemState = UpgradeItemTemplate.CreateInstanceFromTemplate(NewGameState);
+				// Issue #289 - handle upgrades for infinite items
+				/// HL-Docs: feature:ItemUpgraded; issue:289; tags:strategy,events
+				/// This is an event that allows mods to perform non-standard handling to item states
+				/// when they are upgraded to a new tier. It is fired up to four times during upgrading:
+				/// * When upgrading the infinite item, if any.
+				/// * When upgrading utility items, like grenades and medkits.
+				/// * When upgrading unequipped items that have attachments
+				/// * When upgrading equipped items that have attachments
+				///
+				/// The infinite item upgrade is the only firing that does not contain an EventData
+				`XEVENTMGR.TriggerEvent('ItemUpgraded', UpgradedItemState, none, NewGameState);
 				XComHQ.AddItemToHQInventory(UpgradedItemState);
 			}
 		}
@@ -4668,6 +4679,7 @@ static function UpgradeItems(XComGameState NewGameState, name CreatorTemplateNam
 					// Otherwise match the base items quantity
 					UpgradedItemState = UpgradeItemTemplate.CreateInstanceFromTemplate(NewGameState);
 					UpgradedItemState.Quantity = BaseItemState.Quantity;
+					`XEVENTMGR.TriggerEvent('ItemUpgraded', UpgradedItemState, BaseItemState, NewGameState); // Issue #289 - handle upgrades for utility items like grenades and medkits
 
 					// Then add the upgrade item and remove all of the base items from the inventory
 					XComHQ.PutItemInInventory(NewGameState, UpgradedItemState);
@@ -4703,6 +4715,7 @@ static function UpgradeItems(XComGameState NewGameState, name CreatorTemplateNam
 							UpgradedItemState.ApplyWeaponUpgradeTemplate(WeaponUpgradeTemplate);
 						}
 					}
+					`XEVENTMGR.TriggerEvent('ItemUpgraded', UpgradedItemState, InventoryItemState, NewGameState); // Issue #289 - handle upgrades for unequipped items with attachments
 
 					// Delete the old item, and add the new item to the inventory
 					NewGameState.RemoveStateObject(InventoryItemState.GetReference().ObjectID);
@@ -4747,6 +4760,7 @@ static function UpgradeItems(XComGameState NewGameState, name CreatorTemplateNam
 									UpgradedItemState.ApplyWeaponUpgradeTemplate(WeaponUpgradeTemplate);
 								}
 							}
+							`XEVENTMGR.TriggerEvent('ItemUpgraded', UpgradedItemState, InventoryItemState, NewGameState); // Issue #289 - handle upgrades for equipped items with attachments
 
 							// Delete the old item
 							NewGameState.RemoveStateObject(InventoryItemState.GetReference().ObjectID);

--- a/X2WOTCCommunityHighlander/Src/XComGame/Classes/XComGameState_LadderProgress.uc
+++ b/X2WOTCCommunityHighlander/Src/XComGame/Classes/XComGameState_LadderProgress.uc
@@ -1116,7 +1116,7 @@ private static function UpdateUnitState( XComGameState StartState, XComGameState
 	PrimaryWeapon = UnitState.GetPrimaryWeapon( );
 	PrimaryWeapon = XComGameState_Item( StartState.GetGameStateForObjectID( PrimaryWeapon.ObjectID ) );
 	WeaponTemplate = X2WeaponTemplate( PrimaryWeapon.GetMyTemplate( ) );
-	if (WeaponTemplate.NumUpgradeSlots > 0)
+	if (WeaponTemplate.GetNumUpgradeSlots() > 0) // Single line for Issue #93
 		PrimaryWeapon.WipeUpgradeTemplates( );
 
 	ItemManager = class'X2ItemTemplateManager'.static.GetItemTemplateManager();
@@ -1151,7 +1151,7 @@ private static function UpdateUnitState( XComGameState StartState, XComGameState
 						SwapUtilityItem( StartState, UnitState, ItemName, 1 );
 					}
 				}
-				else if ((WeaponUpgradeTemplate != none) && (WeaponTemplate.NumUpgradeSlots > 0))
+				else if ((WeaponUpgradeTemplate != none) && (WeaponTemplate.GetNumUpgradeSlots() > 0)) // Single line for Issue #93
 				{
 					WeaponUpgrades = PrimaryWeapon.GetMyWeaponUpgradeTemplateNames( );
 
@@ -1166,7 +1166,7 @@ private static function UpdateUnitState( XComGameState StartState, XComGameState
 
 					if (index == WeaponUpgrades.Length)
 					{
-						if (index < WeaponTemplate.NumUpgradeSlots)
+						if (index < WeaponTemplate.GetNumUpgradeSlots()) // Single line for Issue #93
 						{
 							PrimaryWeapon.ApplyWeaponUpgradeTemplate( WeaponUpgradeTemplate );
 						}

--- a/X2WOTCCommunityHighlander/X2WOTCCommunityHighlander.x2proj
+++ b/X2WOTCCommunityHighlander/X2WOTCCommunityHighlander.x2proj
@@ -205,6 +205,9 @@
     <Content Include="Src\XComGame\Classes\UIHackingScreen.uc">
       <SubType>Content</SubType>
     </Content>
+    <Content Include="Src\XComGame\Classes\UILadderUpgradeScreen.uc">
+      <SubType>Content</SubType>
+    </Content>
     <Content Include="Src\XComGame\Classes\UIListItemString.uc">
       <SubType>Content</SubType>
     </Content>
@@ -359,6 +362,9 @@
       <SubType>Content</SubType>
     </Content>
     <Content Include="Src\XComGame\Classes\X2Ability_GrenadierAbilitySet.uc">
+      <SubType>Content</SubType>
+    </Content>
+    <Content Include="Src\XComGame\Classes\X2AchievementTracker.uc">
       <SubType>Content</SubType>
     </Content>
     <Content Include="Src\XComGame\Classes\X2CovertActionTemplate.uc">

--- a/docs_src/docs/dlcinfo.md
+++ b/docs_src/docs/dlcinfo.md
@@ -1,0 +1,13 @@
+<h1>X2DownloadableContentInfo Hooks</h1>
+
+Many of the Highlander's features utilize function calls to the subclasses of
+X2DownloadableContentInfo that all mods require. These are known colloquially
+as DlcInfo hooks, and are commonly used as an alternative when an event will
+not work for a given feature.
+
+Mods can define a function of the same name with the same arguments in their
+X2DownloadableContentInfo file, and then perform any custom handling.
+
+Unlike events, these DlcInfo hooks are not limited to two arguments. However,
+they are much slower than events are, so events should generally be used.
+


### PR DESCRIPTION
Retry of #732, this time without being a 2 year old branch.

Implements Issue #93 changes
Implements Issue #289 changes

Allows any item type to be upgraded, and allows for upgrade slot handling on a per-state basis.