### PR TITLE
Issue #746 Implementation (XComEncounter.ini changes taking effect in Legacy Ops)

### DIFF
--- a/X2WOTCCommunityHighlander/Src/XComGame/Classes/XComGameState_LadderProgress.uc
+++ b/X2WOTCCommunityHighlander/Src/XComGame/Classes/XComGameState_LadderProgress.uc
@@ -339,6 +339,9 @@ static function ProceedToNextRung( )
 			NextMissionLadder = XComGameState_LadderProgress( History.GetSingleGameStateObjectForClass( class'XComGameState_LadderProgress' ) );
 			NextMissionLadder.CumulativeScore = LadderData.CumulativeScore;
 
+			// SingleLine for Issue #746, applies any 'NarrativeLadderConfig' config changes
+			NextMissionLadder.PopulateFromNarrativeConfig();
+
 			// transfer over the active set of player choices (overwriting the choices they had made the previous time)
 			NextMissionLadder.ProgressionUpgrades = LadderData.ProgressionUpgrades;
 


### PR DESCRIPTION
Implements #746. Changes to the encounter groups are now accommodated, with some limitations. It only works with `ForceSpawnTemplateNames`, if `EncounterLeaderSpawnList` or `EncounterFollowerSpawnList` are not blank, then no changes are made for that encounter at all. It changes the Encounter to match the `ForceSpawnTemplateNames` list, up to the specified `MaxSpawnCount` limit. The new list can be shorter *or* longer than for the original encounter.
Also brought enhancements for #307. The #308 PR for that stopped short of allowing changes to the squad size. That is now possible, along with allowing the CharacterTemplate to be different, so switching between normal soldiers and faction soldiers or SPARKs is now supported, for example. Or switching in out Central or Shen, who have custom character templates.