### PR TITLE
Trigger docs build (but not deploy) on PR pushes as well

### DIFF
--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -1,12 +1,9 @@
 name: docs
 
-on:
-  push:	
-    branches:	
-      - master
+on: [push, pull_request]
 
 jobs:
-  build-and-deploy:
+  build:
     runs-on: ubuntu-latest
     steps:
     - uses: actions/setup-python@v1
@@ -20,6 +17,22 @@ jobs:
         pip install mkdocs
         cd mkdocs
         mkdocs build -d ../target
+    - name: Upload the built docs
+      uses: actions/upload-artifact@v1
+      with:
+        name: docs-html
+        path: target
+
+  deploy:
+    runs-on: ubuntu-latest
+    needs: build
+    if: github.event == 'push' && github.ref == 'master'
+    steps:
+    - name: Get the built docs
+      uses: actions/download-artifact@v1
+      with:
+        name: docs-html
+        path: target
     - name: Deploy
       uses: crazy-max/ghaction-github-pages@v1
       with:

--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -26,7 +26,7 @@ jobs:
   deploy:
     runs-on: ubuntu-latest
     needs: build
-    if: github.event == 'push' && github.ref == 'master'
+    if: github.event_name == 'push' && github.ref == 'refs/heads/master'
     steps:
     - name: Get the built docs
       uses: actions/download-artifact@v1


### PR DESCRIPTION
**This is a concept**. @robojumper if this looks ok, I will proceed with testing this

Splits the `docs` workflow into 2 jobs - `build` and `deploy` (with latter requiring former). This way, we can run the `build` on PRs as well, so that we can check that the newly introduced code doesn't break the docs script. Deployment is still done only for `master` pushes.

A bonus point of this change is that you can download the built docs and open them locally (if you don't want to/can't build them yourself). Example screenshot from GitHub's docs:

![image](https://user-images.githubusercontent.com/2865341/74014824-21d9cd00-4998-11ea-9c36-d542baa099aa.png)

These are stored for 90 days and then deleted