### PR TITLE
Implemented scripted versions for ability target styles

### DIFF
--- a/X2WOTCCommunityHighlander/Src/XComGame/Classes/CHHelpers.uc
+++ b/X2WOTCCommunityHighlander/Src/XComGame/Classes/CHHelpers.uc
@@ -493,3 +493,35 @@ static function array<XComGameState_Player> GetEnemyPlayers( XGPlayer AIPlayer)
     return EnemyPlayers;
 }
 // end issue #619
+
+static function XComGameState_Ability CreateAbilityStateFromTemplate (XComGameState NewGameState, X2AbilityTemplate Template)
+{
+	if (DoesAbilityNeedCHState(Template))
+	{
+		`log(Template.DataName @ "state created custom",, 'CreateAbilityStateFromTemplate');
+		return XComGameState_Ability(NewGameState.CreateNewStateObject(class'XComGameState_Ability_CH', Template));
+	}
+
+	`log(Template.DataName @ "state created default",, 'CreateAbilityStateFromTemplate');
+	return XComGameState_Ability(NewGameState.CreateNewStateObject(class'XComGameState_Ability', Template));
+}
+
+static private function bool DoesAbilityNeedCHState (X2AbilityTemplate Template)
+{
+	if (Template.AbilityTargetStyle != none && Template.AbilityTargetStyle.IsA(class'X2AbilityTarget_Scripted'.Name))
+	{
+		return true;
+	}
+
+	if (Template.AbilityMultiTargetStyle != none && Template.AbilityMultiTargetStyle.IsA(class'X2AbilityMultiTarget_Scripted'.Name))
+	{
+		return true;
+	}
+
+	if (Template.AbilityPassiveAOEStyle != none && Template.AbilityPassiveAOEStyle.IsA(class'X2AbilityPassiveAOE_Scripted'.Name))
+	{
+		return true;
+	}
+
+	return false;
+}

--- a/X2WOTCCommunityHighlander/Src/XComGame/Classes/X2AbilityMultiTarget_Scripted.uc
+++ b/X2WOTCCommunityHighlander/Src/XComGame/Classes/X2AbilityMultiTarget_Scripted.uc
@@ -1,0 +1,4 @@
+// Similar to AnimNotify_Scripted
+
+class X2AbilityMultiTarget_Scripted extends X2AbilityMultiTargetStyle abstract;
+

--- a/X2WOTCCommunityHighlander/Src/XComGame/Classes/X2AbilityPassiveAOE_Scripted.uc
+++ b/X2WOTCCommunityHighlander/Src/XComGame/Classes/X2AbilityPassiveAOE_Scripted.uc
@@ -1,0 +1,4 @@
+// Similar to AnimNotify_Scripted
+
+class X2AbilityPassiveAOE_Scripted extends X2AbilityPassiveAOEStyle abstract;
+

--- a/X2WOTCCommunityHighlander/Src/XComGame/Classes/X2AbilityTarget_Scripted.uc
+++ b/X2WOTCCommunityHighlander/Src/XComGame/Classes/X2AbilityTarget_Scripted.uc
@@ -1,0 +1,4 @@
+// Similar to AnimNotify_Scripted
+
+class X2AbilityTarget_Scripted extends X2AbilityTargetStyle abstract;
+

--- a/X2WOTCCommunityHighlander/Src/XComGame/Classes/X2AbilityTemplate.uc
+++ b/X2WOTCCommunityHighlander/Src/XComGame/Classes/X2AbilityTemplate.uc
@@ -256,11 +256,13 @@ function InitAbilityForUnit(XComGameState_Ability AbilityState, XComGameState_Un
 
 function XComGameState_Ability CreateInstanceFromTemplate(XComGameState NewGameState)
 {
-	local XComGameState_Ability Ability;	
+	/*local XComGameState_Ability Ability;	
 
 	Ability = XComGameState_Ability(NewGameState.CreateNewStateObject(class'XComGameState_Ability', self));
 
-	return Ability;
+	return Ability;*/
+
+	return class'CHHelpers'.static.CreateAbilityStateFromTemplate(NewGameState, self);
 }
 
 function AddTargetEffect(X2Effect Effect)

--- a/X2WOTCCommunityHighlander/Src/XComGame/Classes/XComGameState_Ability_CH.uc
+++ b/X2WOTCCommunityHighlander/Src/XComGame/Classes/XComGameState_Ability_CH.uc
@@ -1,0 +1,102 @@
+class XComGameState_Ability_CH extends XComGameState_Ability;
+
+simulated function name GatherAbilityTargets(out array<AvailableTarget> Targets, optional XComGameState_Unit OverrideOwnerState)
+{
+	local int i, j;
+	local XComGameState_Unit kOwner;
+	local name AvailableCode;
+	local XComGameStateHistory History;
+
+	`log("Entered script version for" @ GetMyTemplateName(),, 'GatherAbilityTargets');
+
+	GetMyTemplate();
+	History = `XCOMHISTORY;
+	kOwner = XComGameState_Unit(History.GetGameStateForObjectID(OwnerStateObject.ObjectID));
+	if (OverrideOwnerState != none)
+		kOwner = OverrideOwnerState;
+
+	if (m_Template != None)
+	{
+		AvailableCode = m_Template.AbilityTargetStyle.GetPrimaryTargetOptions(self, Targets);
+		if (AvailableCode != 'AA_Success')
+			return AvailableCode;
+	
+		for (i = Targets.Length - 1; i >= 0; --i)
+		{
+			AvailableCode = m_Template.CheckTargetConditions(self, kOwner, History.GetGameStateForObjectID(Targets[i].PrimaryTarget.ObjectID));
+			if (AvailableCode != 'AA_Success')
+			{
+				Targets.Remove(i, 1);
+			}
+		}
+
+		if (m_Template.AbilityMultiTargetStyle != none)
+		{
+			m_Template.AbilityMultiTargetStyle.GetMultiTargetOptions(self, Targets);
+			for (i = Targets.Length - 1; i >= 0; --i)
+			{
+				for (j = Targets[i].AdditionalTargets.Length - 1; j >= 0; --j)
+				{
+					AvailableCode = m_Template.CheckMultiTargetConditions(self, kOwner, History.GetGameStateForObjectID(Targets[i].AdditionalTargets[j].ObjectID));
+					if (AvailableCode != 'AA_Success' || (Targets[i].AdditionalTargets[j].ObjectID == Targets[i].PrimaryTarget.ObjectID) && !m_Template.AbilityMultiTargetStyle.bAllowSameTarget)
+					{
+						Targets[i].AdditionalTargets.Remove(j, 1);
+					}
+				}
+
+				AvailableCode = m_Template.AbilityMultiTargetStyle.CheckFilteredMultiTargets(self, Targets[i]);
+				if (AvailableCode != 'AA_Success')
+					Targets.Remove(i, 1);
+			}
+		}
+
+		//The Multi-target style may have deemed some primary targets invalid in calls to CheckFilteredMultiTargets - so CheckFilteredPrimaryTargets must come afterwards.
+		AvailableCode = m_Template.AbilityTargetStyle.CheckFilteredPrimaryTargets(self, Targets);
+		if (AvailableCode != 'AA_Success')
+			return AvailableCode;
+
+		Targets.Sort(SortAvailableTargets);
+	}
+	return 'AA_Success';
+}
+
+simulated function int SortAvailableTargets(AvailableTarget TargetA, AvailableTarget TargetB)
+{
+	local XComGameStateHistory History;
+	local XComGameState_Destructible DestructibleA, DestructibleB;
+	local int HitChanceA, HitChanceB;
+	local ShotBreakdown BreakdownA, BreakdownB;
+
+	if (TargetA.PrimaryTarget.ObjectID != 0 && TargetB.PrimaryTarget.ObjectID == 0)
+	{
+		return -1;
+	}
+	if (TargetB.PrimaryTarget.ObjectID != 0 && TargetA.PrimaryTarget.ObjectID == 0)
+	{
+		return 1;
+	}
+	if (TargetA.PrimaryTarget.ObjectID == 0 && TargetB.PrimaryTarget.ObjectID == 0)
+	{
+		return 1;
+	}
+	History = `XCOMHISTORY;
+	DestructibleA = XComGameState_Destructible(History.GetGameStateForObjectID(TargetA.PrimaryTarget.ObjectID));
+	DestructibleB = XComGameState_Destructible(History.GetGameStateForObjectID(TargetB.PrimaryTarget.ObjectID));
+	if (DestructibleA != none && DestructibleB == none)
+	{
+		return -1;
+	}
+	if (DestructibleB != none && DestructibleA == none)
+	{
+		return 1;
+	}
+
+	HitChanceA = GetShotBreakdown(TargetA, BreakdownA);
+	HitChanceB = GetShotBreakdown(TargetB, BreakdownB);
+	if (HitChanceA < HitChanceB)
+	{
+		return -1;
+	}
+
+	return 1;
+}

--- a/X2WOTCCommunityHighlander/X2WOTCCommunityHighlander.x2proj
+++ b/X2WOTCCommunityHighlander/X2WOTCCommunityHighlander.x2proj
@@ -317,7 +317,16 @@
     <Content Include="Src\XComGame\Classes\UIX2PanelHeader.uc">
       <SubType>Content</SubType>
     </Content>
+    <Content Include="Src\XComGame\Classes\X2AbilityMultiTarget_Scripted.uc">
+      <SubType>Content</SubType>
+    </Content>
+    <Content Include="Src\XComGame\Classes\X2AbilityPassiveAOE_Scripted.uc">
+      <SubType>Content</SubType>
+    </Content>
     <Content Include="Src\XComGame\Classes\X2AbilityTag.uc">
+      <SubType>Content</SubType>
+    </Content>
+    <Content Include="Src\XComGame\Classes\X2AbilityTarget_Scripted.uc">
       <SubType>Content</SubType>
     </Content>
     <Content Include="Src\XComGame\Classes\X2AbilityTemplate.uc">
@@ -477,6 +486,9 @@
       <SubType>Content</SubType>
     </Content>
     <Content Include="Src\XComGame\Classes\XComGameState_Ability.uc">
+      <SubType>Content</SubType>
+    </Content>
+    <Content Include="Src\XComGame\Classes\XComGameState_Ability_CH.uc">
       <SubType>Content</SubType>
     </Content>
     <Content Include="Src\XComGame\Classes\XComGameState_AdventChosen.uc">


### PR DESCRIPTION
Based on discord suggestion by @robojumper, only affects abilities that use a scripted style(s)

Demo: https://github.com/Xymanek/X2WOTCCommunityHighlander/commit/36c5b96a626e6474e45dbac59aba100e53eaa570

```
[0107.18] CreateAbilityStateFromTemplate: HoloTargeting state created default
[0107.18] CreateAbilityStateFromTemplate: ChainShot state created default
[0107.18] CreateAbilityStateFromTemplate: HailOfBullets state created custom
[0107.18] CreateAbilityStateFromTemplate: BulletShred state created default
```

```
[0115.41] Log: X2TacticalGameRuleset_0 TurnPhase_UnitActions: Check for Available Actions
[0115.41] GatherAbilityTargets: Entered script version for HailOfBullets
[0115.41] X2AbilityTarget_Scripted: GetPrimaryTargetOptions
[0115.41] X2AbilityTarget_Scripted: CheckFilteredPrimaryTargets
[0115.41] ScriptLog: XComTacticalInput.uc, Transition to/from State None detected. BeginState ActiveUnit_Moving from None
```

cc @Iridar (I did this to prove you wrong :trollface: ), @pledbrook (I know LW2 needed this)