### PR TITLE
Update risk level on risk chance recalculation (#777)

### DIFF
--- a/X2WOTCCommunityHighlander/Src/XComGame/Classes/XComGameState_CovertAction.uc
+++ b/X2WOTCCommunityHighlander/Src/XComGame/Classes/XComGameState_CovertAction.uc
@@ -971,6 +971,12 @@ function RecalculateRiskChanceToOccurModifiers()
 		}
 
 		Risks[idx].ChanceToOccurModifier = CalculateRiskChanceToOccurModifiers(Risks[idx], bChosenIncreaseRisks, bDarkEventRisk);
+		// Start Issue #777
+		/// HL-Docs: ref:Bugfixes; issue:777
+		/// Covert action risk level will now be updated when a risk's chance to occur
+		/// is recalculated, which ensures the risks panel displays the correct chance.
+		Risks[idx].Level = GetRiskLevel(Risks[idx]);
+		// End Issue #777
 	}
 }
 // Issue #436 End

--- a/X2WOTCCommunityHighlander/Src/XComGame/Classes/XComGameState_CovertAction.uc
+++ b/X2WOTCCommunityHighlander/Src/XComGame/Classes/XComGameState_CovertAction.uc
@@ -962,19 +962,19 @@ function RecalculateRiskChanceToOccurModifiers()
 		bChosenIncreaseRisks = GetFaction().GetRivalChosen().ShouldIncreaseCovertActionRisks();
 		RiskTemplate = X2CovertActionRiskTemplate(StratMgr.FindStrategyElementTemplate(Risks[idx].RiskTemplateName));
 		if (RiskTemplate.IsRiskAvailableFn == none || RiskTemplate.IsRiskAvailableFn(GetFaction()))
-        {
-            bDarkEventRisk = false;
-            if (ResHQ.CovertActionDarkEventRisks.Find(Risks[idx].RiskTemplateName) != INDEX_NONE)
-            {
-                bDarkEventRisk = true;
-            }
+		{
+			bDarkEventRisk = false;
+			if (ResHQ.CovertActionDarkEventRisks.Find(Risks[idx].RiskTemplateName) != INDEX_NONE)
+			{
+				bDarkEventRisk = true;
+			}
 		}
 
 		Risks[idx].ChanceToOccurModifier = CalculateRiskChanceToOccurModifiers(Risks[idx], bChosenIncreaseRisks, bDarkEventRisk);
 		// Start Issue #777
-		/// HL-Docs: ref:Bugfixes; issue:777
-		/// Covert action risk level will now be updated when a risk's chance to occur
-		/// is recalculated, which ensures the risks panel displays the correct chance.
+		//
+		// Covert action risk level will now be updated when a risk's chance to occur
+		// is recalculated, which ensures the risks panel displays the correct chance.
 		Risks[idx].Level = GetRiskLevel(Risks[idx]);
 		// End Issue #777
 	}


### PR DESCRIPTION
This change simply ensures that the risk level (low, moderate, high) is updated whenever the associated risk's chance to occur is changed via `XCGS_CovertAction.RecalculateRiskChanceToOccurModifiers()`.

Fixes #777.