### PR TITLE
Fire event to allow overriding CA risk chances (#779)

### DIFF
--- a/X2WOTCCommunityHighlander/Src/XComGame/Classes/XComGameState_CovertAction.uc
+++ b/X2WOTCCommunityHighlander/Src/XComGame/Classes/XComGameState_CovertAction.uc
@@ -1311,7 +1311,53 @@ function GetRisksStrings(out array<string> Labels, out array<string> Values)
 			Values.AddItem(GetRiskDifficultyLabel(Risks[idx].Level));
 		}
 	}
+
+	TriggerOverrideRiskStrings(Labels, Values);  // Issue #779
 }
+
+// Start Issue #779
+/// HL-Docs: feature:CovertAction_OverrideRiskStrings; issue:779; tags:strategy
+/// Allows listeners to override how risk chances are displayed in the covert
+/// actions screen (UICovertActions). The names of each risk and the texts
+/// displayed to represent the chance of each one occurring are passed in the
+/// event as two separate arrays of strings.
+///
+/// Note that the two arrays are in the same order, i.e. the first element of
+/// each array corresponds to the first risk, the second element to the second
+/// risk, and so on.
+//
+/// Also be aware that the existing texts for the chance values will be HTML
+/// markup, with some entries using `<font>` tags to color the text.
+///
+/// ```unrealscript
+/// EventID: CovertAction_OverrideRiskStrings
+/// EventData: XComLWTuple {
+///     Data: [
+///       inout array<string> RiskLabels,
+///       inout array<string> RiskChanceTexts
+///     ]
+/// }
+/// EventSource: self (XCGS_CovertAction)
+/// NewGameState: no
+/// ```
+private function TriggerOverrideRiskStrings(out array<string> Labels, out array<string> Values)
+{
+	local XComLWTuple OverrideTuple;
+
+	OverrideTuple = new class'XComLWTuple';
+	OverrideTuple.Id = 'CovertAction_OverrideRiskStrings';
+	OverrideTuple.Data.Add(2);
+	OverrideTuple.Data[0].kind = XComLWTVArrayStrings;
+	OverrideTuple.Data[0].as = Labels;
+	OverrideTuple.Data[1].kind = XComLWTVArrayStrings;
+	OverrideTuple.Data[1].as = Values;
+
+	`XEVENTMGR.TriggerEvent(OverrideTuple.Id, OverrideTuple, self);
+
+	Labels = OverrideTuple.Data[0].as;
+	Values = OverrideTuple.Data[1].as;
+}
+// End Issue #779
 
 function string GetStaffRisksAppliedString(int idx)
 {


### PR DESCRIPTION
This change introduces the following event that allows mods to change how covert action risk chances are displayed:
```
{
  ID: CovertAction_OverrideRiskStrings
  Data: [
       inout array<string> RiskLabels,
       inout array<string> RiskChanceTexts ]
  Source: self (XCGS_CovertAction)
}
```

Resolves #779.