### PR TITLE
UI Docs: See PR description because too many

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -50,18 +50,13 @@ RunPriorityGroup=RUN_STANDARD
 - Triggers the events `OverrideUIArmoryScale`, `OverrideUIVIPScale`, and `OverrideCharCustomizationScale` for strategy unit scaling (#229)
 - Triggers the event `RegionOutpostBuildStart` to add a strategy reward similar to the 'Resistance Network' resistance order, but for Radio Relays instead of Network Contacts. (#279)
 - Triggers the event `GeoscapeFlightModeUpdate` to allow mods to respond to geoscape mode change (#358)
-- Triggers the event `UIAvengerShortcuts_ShowCQResistanceOrders` to allow to override the presence of Resistance Orders button in `UIAvengerShortcuts` (#368)
-- Triggers the event `Geoscape_ResInfoButtonVisible` to allow to override the visibility of resistance orders button in `UIStrategyMap_HUD` (#365)
 - Triggers the event `NumCovertActionsToAdd` to allow mods to modfiy number of Covert Actions (#373)
 - Triggers the event `CompleteRespecSoldier` when a training center soldier respec was completed. (#339)
 - Triggers the events `UIArmory_WeaponUpgrade_SlotsUpdated` and `UIArmory_WeaponUpgrade_NavHelpUpdated`
   in `UIArmory_WeaponUpgrade` (#417)
-- Triggers the event `GetCovertActionEvents_Settings` to allow showing all covert actions in the correct order in the event queue (#391)
 - Triggers the event `CovertActionRisk_AlterChanceModifier` when calculated covert action risks. (#434)
 - Triggers the event `AllowDarkEventRisk` during XComGameState_CovertAction::EnableDarkEventRisk to allow alterations of standard logic (#434)
 - Triggers the event `AllowDarkEventRisk` during XComGameState_CovertAction::CreateRisks to allow alterations of standard logic (#692)
-- Triggers the event `UIStrategyPolicy_ScreenInit` at the end of UIStrategyPolicy::InitScreen (#440)
-- Triggers the event `UIStrategyPolicy_ShowCovertActionsOnClose` on UIStrategyPolicy::CloseScreen call (#440)
 - Triggers the event `CovertAction_ShouldBeVisible` on XComGameState_CovertAction::ShouldBeVisible call (#438)
 - Triggers the event `CovertAction_CanInteract` on XComGameState_CovertAction::CanInteract call (#438)
 - Triggers the event `CovertAction_ActionSelectedOverride` on XComGameState_CovertAction::DisplaySelectionPrompt call (#438)
@@ -70,7 +65,6 @@ RunPriorityGroup=RUN_STANDARD
 - Triggers the event `CovertAction_ModifyNarrativeParamTag` on XComGameState_CovertAction::GetNarrative call (#438)
 - Triggers the event `ShouldCleanupCovertAction` to allow mod control over Covert Action deletion. (#435)
 - Triggers the event `BlackMarketGoodsReset` when the Black Market goods are reset (#473)
-- Triggers the event `OverrideImageForItemAvaliable` to allow mods to override the image shown in eAlert_ItemAvailable (#491)
 - Triggers the event `OverrideCurrentDoom` to allow mods to override doom amount for doom updates (#550)
 - Triggers the event `PreEndOfMonth` to notify mods that the game is about to start its end-of-month processing (#539)
 - Triggers the event `ProcessNegativeIncome` to allow mods to do their own processing when XCOM's income at the
@@ -132,7 +126,6 @@ RunPriorityGroup=RUN_STANDARD
 
 ### Modding Exposures
 - Allows mods to add custom items to the Avenger Shortcuts (#163)
-- UIScanButton now calls OnMouseEventDelegate (#483). Note: DO NOT call ProcessMouseEvents, just set the delegate directly
 - Remove `private` from `X2AIBTBehaviorTree.Behaviors` so that mods can change the behavior trees without
   overwriting all the necessary entries (#410)
 - Removed `protectedwrite` from `AcquiredTraits`, `PendingTraits`, and `CuredTraits` in `XComGameState_Unit`, allowing Traits to be modified by external sources (#681)

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -104,17 +104,12 @@ RunPriorityGroup=RUN_STANDARD
 - Triggers the event `CovertActionAllowCheckForProjectOverlap` to allow mods to forbid the "de-bunching" logic
   on CA start (#584)
 - Triggers the event `AllowActionToSpawnRandomly` to allow mods to prevent certain CAs from being randomly spawned (#594)
-- Triggers the event `OverridePromotionUIClasses` to allow mods to override the UI classes used for the
-  three different promotion screens (#600)
 - Triggers the event `OverrideRespecSoldierProjectPoints` to allow mods to customize how long it should
   take to respec a given soldier (#624)
 - Triggers the event `OverrideScienceScore` to allow mods to override the XCOM HQ science score, for
   example to add their own bonuses or to remove scientists that are engaged in other activities.
 - Triggers the event `CanTechBeInspired` to allow mods to block techs from being inspired, even if they
   meet the vanilla game's conditions for it (#633)
-- Triggers the event `OverrideMissionImage` to allow mods to customize mission's image (used in UIMission and subclasses) (#635)
-- Triggers the event `UIResistanceReport_ShowCouncil` to allow mods to override whether the council guy (and his remarks)
-  is shown on the end-of-month report or not (#663)
 - Triggers the event `OverrideNextRetaliationDisplay` to allow mods to customize and/or enable/disable "next retaliation"
   display in `UIAdventOperations` (#667)
 - Triggers the event `ItemAddedToSlot` & `ItemRemovedFromSlot` to allow mods to change Items that have been Equipped/Unequipped during runtime(#694)
@@ -300,18 +295,10 @@ RunPriorityGroup=RUN_STANDARD
 - `AbilityTagExpandHandler_CH` expands vanilla AbilityTagExpandHandler to allow reflection
 
 ### Event Hooks
-- Triggers the events `SoldierClassIcon`, `SoldierClassDisplayName`,
-  `SoldierClassSummary` that allow replacement of the class icon/display
-  name/summary dynamically e.g. depending on UnitState or Soldier Loadout,
-  and adds accessor functions for those to XComGameState_Unit. (#106)
-- `GetPCSImageTuple` added to allow customising PCS Image string (#110)
 - Triggers the event `OverrideHasHeavyWeapon` that allows to override the result of `XComGameState_Unit.HasHeavyWeapon` (#172)
 - `OverrideItemMinEquipped` added to allow mods to override the min number of equipped items in a slot (#171)
 - `AddConversation` added to allow mods to change narrative behavior before they are played (#204)
 - `OverrideRandomizeAppearance` added to allow mods to block updating appearance when switching armors (#299)
-- `XComGameState_Unit` triggers `SoldierRankName`, `SoldierShortRankName` and
-  `SoldierRankIcon` events that allow listeners to override the those particular
-  properties of a soldier's rank, i.e. rank name, short name and icon (#408)
 
 ### Configuration
 - Able to list classes as excluded from AWC Skill Rolling, so they can still

--- a/X2WOTCCommunityHighlander/Src/XComGame/Classes/UIAlert.uc
+++ b/X2WOTCCommunityHighlander/Src/XComGame/Classes/UIAlert.uc
@@ -3415,6 +3415,18 @@ simulated function BuildItemAvailableAlert()
 }
 
 // Start issue #491
+/// HL-Docs: feature:OverrideImageForItemAvaliable; issue:491; tags:strategy,ui
+/// Allows overriding the image shown for an item in the `eAlert_ItemAvailable` alert.
+///
+/// This alert is triggered when a tech completes and makes available a new item for building, but, if it happens
+/// to target a singular weapon (rather than the upgrade schematic), shows a weapon without
+/// attachments (as specified in the Template's `strImage`). This event gives mods a chance to fix it.
+///
+/// ```unrealscript
+/// ID: OverrideImageForItemAvaliable,
+/// Data: [inout string ImagePath, in X2ItemTemplate ItemTemplate],
+/// Source: UIAlert
+/// ```
 simulated function string GetImageForItemAvaliable(X2ItemTemplate ItemTemplate)
 {
 	local XComLWTuple Tuple;

--- a/X2WOTCCommunityHighlander/Src/XComGame/Classes/UIAvengerShortcuts.uc
+++ b/X2WOTCCommunityHighlander/Src/XComGame/Classes/UIAvengerShortcuts.uc
@@ -1126,7 +1126,16 @@ reliable client function array<UIAvengerShortcutMessage> GetCommandersQuartersMe
 	return Messages;
 }
 
- // Start issue #368
+// Start issue #368
+/// HL-Docs: feature:UIAvengerShortcuts_ShowCQResistanceOrders; issue:368; tags:strategy,ui
+/// Allows overriding whether the resistance orders button should be shown in `UIAvengerShortcuts`.
+/// Default: After the first month if any faction met.
+///
+/// ```unrealscript
+/// ID: UIAvengerShortcuts_ShowCQResistanceOrders,
+/// Data: [inout bool ShouldShow],
+/// Source: UIAvengerShortcuts
+/// ```
  simulated protected function bool ShouldShowResistanceOrders()
  {
 	local XComGameState_HeadquartersResistance ResHQ;

--- a/X2WOTCCommunityHighlander/Src/XComGame/Classes/UIResistanceReport.uc
+++ b/X2WOTCCommunityHighlander/Src/XComGame/Classes/UIResistanceReport.uc
@@ -54,6 +54,16 @@ simulated function InitScreen(XComPlayerController InitController, UIMovie InitM
 }
 
 // Start issue #663
+/// HL-Docs: feature:UIResistanceReport_ShowCouncil; issue:663; tags:strategy,ui
+/// Allows overriding whether to show the council guy and his remarks in the background
+/// at the end of month.
+///
+///
+/// ```unrealscript
+/// ID: UIResistanceReport_ShowCouncil,
+/// Data: [inout bool ShouldShow],
+/// Source: UIResistanceReport
+/// ```
 protected simulated function bool TriggerShouldShowCouncil ()
 {
 	local XComLWTuple Tuple;

--- a/X2WOTCCommunityHighlander/Src/XComGame/Classes/UIScanButton.uc
+++ b/X2WOTCCommunityHighlander/Src/XComGame/Classes/UIScanButton.uc
@@ -286,6 +286,10 @@ simulated function OnMouseEvent(int cmd, array<string> args)
 	}
 
 	// Start issue #483. Note: DO NOT call ProcessMouseEvents, just set the delegate directly
+	/// HL-Docs: feature:UIScanButtonOnMouseEvent; issue:483; tags:strategy,ui
+	/// `UIScanButton` now triggers its `OnMouseEventDelegate` if set. Do not
+	/// call `ProcessMouseEvents`, <del>do not pass go, do not collect $200,</del> just set
+	/// the delegate directly.
 	if (OnMouseEventDelegate != none)
 	{
 		OnMouseEventDelegate(self, cmd);

--- a/X2WOTCCommunityHighlander/Src/XComGame/Classes/UIStrategyMap_HUD.uc
+++ b/X2WOTCCommunityHighlander/Src/XComGame/Classes/UIStrategyMap_HUD.uc
@@ -282,6 +282,15 @@ simulated function UpdateData()
 }
 
 // Start issue #365
+/// HL-Docs: feature:Geoscape_ResInfoButtonVisible; issue:365; tags:strategy,ui
+/// Allows overriding whether the resistance info button should be visible.
+/// Default: After the first month if any faction met and not in flight.
+///
+/// ```unrealscript
+/// ID: Geoscape_ResInfoButtonVisible,
+/// Data: [inout bool ShouldShow, in bool InFlight],
+/// Source: UIStrategyMap_HUD
+/// ```
 simulated protected function bool ShouldShowResInfoButton(XComGameState_HeadquartersResistance ResHQ)
 {
 	local XComLWTuple Tuple;

--- a/X2WOTCCommunityHighlander/Src/XComGame/Classes/UIStrategyPolicy.uc
+++ b/X2WOTCCommunityHighlander/Src/XComGame/Classes/UIStrategyPolicy.uc
@@ -83,6 +83,15 @@ simulated function InitScreen(XComPlayerController InitController, UIMovie InitM
 	UpdateNavHelp(); //bsg-crobinson (5.12.17): Update navhelp when screen is inited
 
 	// Issue #440
+	/// HL-Docs: feature:UIStrategyPolicy_ScreenInit; issue:440; tags:strategy,ui
+	/// Triggers the event `UIStrategyPolicy_ScreenInit` immediately after opening the
+	/// `UIStrategyPolicy` screen, before it has fully initialized. Can be used to make
+	/// modifications to camera transition behavior that would be too late in a ScreenListener.
+	///
+	/// ```unrealscript
+	/// ID: UIStrategyPolicy_ScreenInit,
+	/// Source: UIStrategyPolicy
+	/// ```
 	`XEVENTMGR.TriggerEvent('UIStrategyPolicy_ScreenInit', , self);
 }
 
@@ -1846,6 +1855,19 @@ simulated function CloseScreen()
 	ResHQ = XComGameState_HeadquartersResistance(`XCOMHISTORY.GetSingleGameStateObjectForClass(class'XComGameState_HeadquartersResistance'));
 
 	// Issue #440 Start
+
+	/// HL-Docs: feature:UIStrategyPolicy_ShowCovertActionsOnClose; issue:365; tags:strategy,ui
+	/// Allows overriding whether to show the `UICovertActions` screen after closing
+	/// the `UIStrategyPolicy` screen.
+	///
+	/// Default: Show if `UIStrategyPolicy` was created as part of the end-of-month report
+	/// and no covert actions are in progress.
+	///
+	/// ```unrealscript
+	/// ID: UIStrategyPolicy_ShowCovertActionsOnClose,
+	/// Data: [inout bool ShouldShow],
+	/// Source: UIStrategyPolicy
+	/// ```
 	Tuple = new class'XComLWTuple';
 	Tuple.Id = 'UIStrategyPolicy_ShowCovertActionsOnClose';
 	Tuple.Data.Add(1);

--- a/X2WOTCCommunityHighlander/Src/XComGame/Classes/UIUtilities_Image.uc
+++ b/X2WOTCCommunityHighlander/Src/XComGame/Classes/UIUtilities_Image.uc
@@ -838,6 +838,16 @@ simulated static function string GetPCSImage(XComGameState_Item Item)
 	StatType = class'UIUtilities_Strategy'.static.GetStatBoost(Item).StatType;
     
 	// Start Issue #110: OnGetPCSImage Event
+	/// HL-Docs: feature:OnGetPCSImage; issue:110; tags:strategy,ui
+	/// Allows overriding the UI image for a PCS. The base game switches on the
+	/// stat being boosted, which precludes custom PCS from having a custom icon.
+	/// Note that for historical reasons, the tuple ID is `GetPCSImageTuple` while
+	/// the event ID is `OnGetPCSImage`.
+	///
+	/// ```unrealscript
+	/// ID: OnGetPCSImage,
+	/// Data: [in XComGameState_Item ItemState, out string ImagePath],
+	/// ```
 	Tuple = new class'XComLWTuple';
 	Tuple.id = 'GetPCSImageTuple';
 	Tuple.Data.Add(2);

--- a/X2WOTCCommunityHighlander/Src/XComGame/Classes/XComGameState_HeadquartersXCom.uc
+++ b/X2WOTCCommunityHighlander/Src/XComGame/Classes/XComGameState_HeadquartersXCom.uc
@@ -7987,6 +7987,19 @@ function GetResistanceEvents(out array<HQEvent> arrEvents)
 
 //---------------------------------------------------------------------------------------
 // chl issue #518 start: added tuple & event 'ForceNoCovertActionNagFirstMonth'
+
+/// HL-Docs: feature:GetCovertActionEvents_Settings; issue:391; tags:strategy,ui
+/// Allows configuring the behavior of covert actions in the event queue.  
+/// `AddAll` allows multiple covert actions, `InsertSorted` inserts them into position
+/// based on time remaining.
+///
+/// Default: Only one covert action is added at the end.
+///
+/// ```unrealscript
+/// ID: GetCovertActionEvents_Settings,
+/// Data: [out bool AddAll, out bool InsertSorted],
+/// Source: XCGS_HeadquartersXCom
+/// ```
 function GetCovertActionEvents(out array<HQEvent> arrEvents)
 {
 	local XComGameStateHistory History;

--- a/X2WOTCCommunityHighlander/Src/XComGame/Classes/XComGameState_MissionSite.uc
+++ b/X2WOTCCommunityHighlander/Src/XComGame/Classes/XComGameState_MissionSite.uc
@@ -1928,6 +1928,14 @@ simulated function TriggerOverrideMissionSiteIconImage(out string ImagePath)
 // End Issue #537
 
 // Start issue #635
+/// HL-Docs: feature:OverrideMissionImage; issue:635; tags:strategy,ui
+/// Allows overriding the image shown for a mission in the `UIMission` screen.
+///
+/// ```unrealscript
+/// ID: OverrideMissionImage,
+/// Data: [inout string ImagePath],
+/// Source: XCGS_MissionSite
+/// ```
 function string GetMissionImage ()
 {
 	local XComLWTuple Tuple;

--- a/X2WOTCCommunityHighlander/Src/XComGame/Classes/XComGameState_Unit.uc
+++ b/X2WOTCCommunityHighlander/Src/XComGame/Classes/XComGameState_Unit.uc
@@ -14744,6 +14744,31 @@ function bool UnitIsValidForPhotobooth()
 }
 
 // Start Issue #106
+/// HL-Docs: feature:DynamicSoldierClassDisplay; issue:106; tags:strategy,ui
+/// Mods may want to manipulate the way a soldier's class is displayed (in terms
+/// of icon/name/description) in more dynamic ways. For example, *RPGOverhaul*
+/// has a single soldier class and the way it is displayed depends on selected
+/// skills and loadouts. There are three events with mostly self-explanatory names:
+/// ```unrealscript
+/// ID: SoldierClassIcon,
+/// Data: [inout string IconImagePath],
+/// Source: XCGS_Unit
+/// ```
+///
+/// ```unrealscript
+/// ID: SoldierClassDisplayName,
+/// Data: [inout string DisplayName],
+/// Source: XCGS_Unit
+/// ```
+///
+/// ```unrealscript
+/// ID: SoldierClassSummary,
+/// Data: [inout string DisplaySummary],
+/// Source: XCGS_Unit
+/// ```
+///
+/// There is a sister feature [`DynamicSoldierRankDisplay`](./DynamicSoldierRankDisplay.md)
+/// that extends this to rank icon/name.
 function String GetSoldierClassIcon()
 {
 	local XComLWTuple Tuple;
@@ -14808,6 +14833,32 @@ function String GetSoldierClassSummary()
 //         unit's current rank. If this is -1, then the current rank is
 //         returned as usual.
 //
+/// HL-Docs: feature:DynamicSoldierRankDisplay; issue:408; tags:strategy,ui
+/// Mods may want to manipulate the way a soldier's rank is displayed (in terms
+/// of icon/name/description) in more dynamic ways. For example, *LWOTC*
+/// shows officer ranks for units with special officer abilities.
+/// There are three events with mostly self-explanatory names:
+///
+/// ```unrealscript
+/// ID: SoldierRankName,
+/// Data: [in int Rank, inout string DisplayRankName],
+/// Source: XCGS_Unit
+/// ```
+///
+/// ```unrealscript
+/// ID: SoldierShortRankName,
+/// Data: [in int Rank, inout string DisplayShortRankName],
+/// Source: XCGS_Unit
+/// ```
+///
+/// ```unrealscript
+/// ID: SoldierRankIcon,
+/// Data: [in int Rank, inout string IconImagePath],
+/// Source: XCGS_Unit
+/// ```
+///
+/// There is a sister feature [`DynamicSoldierClassDisplay`](./DynamicSoldierClassDisplay.md)
+/// that extends this to class icon/name.
 function string GetSoldierRankName(optional int Rank = -1)
 {
 	local XComLWTuple OverrideTuple;

--- a/X2WOTCCommunityHighlander/Src/XComGame/Classes/XComHQPresentationLayer.uc
+++ b/X2WOTCCommunityHighlander/Src/XComGame/Classes/XComHQPresentationLayer.uc
@@ -1,12 +1,15 @@
 class XComHQPresentationLayer extends XComPresentationLayerBase;
 
 // Start Issue #600
+/// HL-Docs: ref:OverridePromotionUIClass
+/// HL-Include:
 enum CHLPromotionScreenType
 {
 	eCHLPST_Standard,
 	eCHLPST_Hero,
 	eCHLPST_PsiOp
 };
+///
 // End Issue #600
 
 var XGHQCamera						m_kCamera;
@@ -1511,18 +1514,38 @@ function ShowPromotionUI(StateObjectReference UnitRef, optional bool bInstantTra
 
 // Start Issue #600
 //
-// Fires an 'OverridePromotionUIClass' event that allows mods to override
-// the UI class used for a given promotion screen. Note that any class
-// provided by a mod must be UIArmory_Promotion or a subclass of it.
-//
-// The event itself takes the form:
-//
-//   {
-//      ID: OverridePromotionUIClass,
-//      Data: [in int PromotionScreenType, inout class PromotionUIClass],
-//      Source: self (XComHQPresentationLayer)
-//   }
-//
+/// HL-Docs: feature:OverridePromotionUIClass; issue:600; tags:strategy,ui
+/// Fires an event that allows mods to override
+/// the UI class used for a given promotion screen. Note that any class
+/// provided by a mod must be UIArmory_Promotion or a subclass of it.
+///
+/// ```unrealscript
+/// ID: OverridePromotionUIClass,
+/// Data: [in int PromotionScreenType, inout class PromotionUIClass],
+/// Source: XComHQPresentationLayer
+/// ```
+///
+/// The following simplified example is taken from [Community Promotion Screen](https://github.com/X2CommunityCore/X2CommunityPromotionScreen):
+///
+/// ```unrealscript
+/// local XComLWTuple Tuple;
+/// local CHLPromotionScreenType ScreenType;
+///
+/// Tuple = XComLWTuple(EventData);
+///
+/// ScreenType = CHLPromotionScreenType(Tuple.Data[0].i);
+///
+/// if ((ScreenType == eCHLPST_PsiOp && ShouldOverridePsiPromotionScreen()) ||
+/// 		(ScreenType == eCHLPST_Hero && ShouldOverrideHeroPromotionScreen()) ||
+/// 		(ScreenType == eCHLPST_Standard && ShouldOverrideStandardPromotionScreen()))
+/// {
+/// 	Tuple.Data[1].o = class'NPSBDP_UIArmory_PromotionHero';
+/// }
+///
+/// return ELR_NoInterrupt;
+/// ```
+///
+/// The integer values of `PromotionScreenType` correspond to the `CHLPromotionScreenType` enum.
 function class<UIArmory_Promotion> TriggerOverridePromotionUIClass(CHLPromotionScreenType ScreenType)
 {
 	local XComLWTuple Tuple;


### PR DESCRIPTION
Features: UIAvengerShortcuts_ShowCQResistanceOrders, Geoscape_ResInfoButtonVisible, GetCovertActionEvents_Settings, UIStrategyPolicy_ScreenInit, UIStrategyPolicy_ShowCovertActionsOnClose, OverrideImageForItemAvaliable, UIScanButtonOnMouseEvent, OverridePromotionUIClasses, OverrideMissionImage, UIResistanceReport_ShowCouncil, DynamicSoldierClassDisplay, DynamicSoldierRankDisplay

Documents #368, #365, #391, #440, #491, #483, #600, #635, #663, #106, #110, #408.

(Remove needs-docs tags when this is merged).

Closes #600, closes #635, closes #663, closes #408.

Based on #798, merge that first.