### PR TITLE
Fix covert action report if rewards prevented (#810)

### DIFF
--- a/X2WOTCCommunityHighlander/Src/XComGame/Classes/UICovertActionStaffSlot.uc
+++ b/X2WOTCCommunityHighlander/Src/XComGame/Classes/UICovertActionStaffSlot.uc
@@ -171,7 +171,10 @@ function UpdateData()
 				PromoteLabel = (Unit.ShowPromoteIcon()) ? class'UISquadSelect_ListItem'.default.m_strPromote : "";
 				Value4 = Caps(ActionState.GetStaffRisksAppliedString(StaffIndex)); // Value 4 is automatically red / negative!
 
-				if (!Unit.bCaptured)
+				// Issue #810: Don't display XP and cohesion gain if rewards weren't
+				// given on completion of the covert action (since XP and cohesion are
+				// not granted in that case).
+				if (!Unit.bCaptured && !GetAction().RewardsNotGivenOnCompletion)
 				{
 					Value1 = m_strGainedXP; // Gained Experience
 					CohesionUnitNames = GetCohesionRewardUnits();

--- a/X2WOTCCommunityHighlander/Src/XComGame/Classes/UICovertActionStaffSlot.uc
+++ b/X2WOTCCommunityHighlander/Src/XComGame/Classes/UICovertActionStaffSlot.uc
@@ -174,7 +174,7 @@ function UpdateData()
 				// Issue #810: Don't display XP and cohesion gain if rewards weren't
 				// given on completion of the covert action (since XP and cohesion are
 				// not granted in that case).
-				if (!Unit.bCaptured && !GetAction().RewardsNotGivenOnCompletion)
+				if (!Unit.bCaptured && !ActionState.RewardsNotGivenOnCompletion)
 				{
 					Value1 = m_strGainedXP; // Gained Experience
 					CohesionUnitNames = GetCohesionRewardUnits();

--- a/X2WOTCCommunityHighlander/Src/XComGame/Classes/UICovertActionStaffSlot.uc
+++ b/X2WOTCCommunityHighlander/Src/XComGame/Classes/UICovertActionStaffSlot.uc
@@ -174,6 +174,7 @@ function UpdateData()
 				// Issue #810: Don't display XP and cohesion gain if rewards weren't
 				// given on completion of the covert action (since XP and cohesion are
 				// not granted in that case).
+				/// HL-Docs: ref:CovertAction_PreventGiveRewards; issue:810
 				if (!Unit.bCaptured && !ActionState.RewardsNotGivenOnCompletion)
 				{
 					Value1 = m_strGainedXP; // Gained Experience

--- a/X2WOTCCommunityHighlander/Src/XComGame/Classes/XComGameState_CovertAction.uc
+++ b/X2WOTCCommunityHighlander/Src/XComGame/Classes/XComGameState_CovertAction.uc
@@ -723,9 +723,9 @@ function GiveRewards(XComGameState NewGameState)
 /// on the covert action get no XP or cohesion. The results are saved and are used to adjust UI later.
 ///
 /// ```event
-/// EventID: CovertAction_PreventGiveRewards
-/// EventData: Data: [ inout bool PreventGiveRewards ]
-/// EventSource: XComGameState_CovertAction (CAState)
+/// EventID: CovertAction_PreventGiveRewards,
+/// EventData: Data: [ inout bool PreventGiveRewards ],
+/// EventSource: XComGameState_CovertAction (CAState),
 /// NewGameState: no
 /// ```
 private function bool TriggerPreventGiveRewards()

--- a/X2WOTCCommunityHighlander/Src/XComGame/Classes/XComGameState_CovertAction.uc
+++ b/X2WOTCCommunityHighlander/Src/XComGame/Classes/XComGameState_CovertAction.uc
@@ -716,16 +716,11 @@ function GiveRewards(XComGameState NewGameState)
 }
 
 // Start Issue #438, #810
-//
-// *Note* This is private to avoid potential problems with side effects
-// and non-idempotent listeners if other parts of the code (or mods) attempt
-// to use it themselves.
-//
 /// HL-Docs: feature:CovertAction_PreventGiveRewards; issue:438; tags:strategy
 /// Fires an event that allows listeners to prevent the covert action from
 /// awarding the action's rewards to the player. Note that if the `PreventGiveRewards`
 /// boolean is `true` then not only are the rewards not given, but the soldiers
-/// on the covert action get no XP or cohesion.
+/// on the covert action get no XP or cohesion. The results are saved and are used to adjust UI later.
 ///
 /// ```unrealscript
 /// EventID: CovertAction_PreventGiveRewards
@@ -2285,15 +2280,6 @@ simulated public function ActionRewardPopups()
 	local bool bPromoteReward;
 	local int idx;
 
-	// Start Issue #810
-	if (RewardsNotGivenOnCompletion)
-	{
-		// A mod or some other source prevented this reward from being
-		// given to the player, so don't display the popups.
-		return;
-	}
-	// End Issue #810
-
 	History = `XCOMHISTORY;
 
 	// Popups are triggered in backwards order of how they are presented to the player, since they get pushed onto the UI stack
@@ -2302,6 +2288,16 @@ simulated public function ActionRewardPopups()
 	{
 		TriggerNextCovertActionPopup();
 	}
+
+	// Start Issue #810
+	/// HL-Docs: ref:CovertAction_PreventGiveRewards; issue:810
+	if (RewardsNotGivenOnCompletion)
+	{
+		// A mod or some other source prevented this reward from being
+		// given to the player, so don't display the popups.
+		return;
+	}
+	// End Issue #810
 
 	// Display popups for Cost Slot rewards
 	for (idx = 0; idx < CostSlots.Length; idx++)

--- a/X2WOTCCommunityHighlander/Src/XComGame/Classes/XComGameState_CovertAction.uc
+++ b/X2WOTCCommunityHighlander/Src/XComGame/Classes/XComGameState_CovertAction.uc
@@ -56,7 +56,7 @@ var name									AmbushMissionSource; // The MissionSource of the Ambush for thi
 //
 // Note that this variable has no value until the covert action has been
 // completed.
-var bool									RewardsNotGivenOnCompletion;
+var privatewrite bool RewardsNotGivenOnCompletion;
 // End Issue #810
 
 struct CovertActionStaffSlot

--- a/X2WOTCCommunityHighlander/Src/XComGame/Classes/XComGameState_CovertAction.uc
+++ b/X2WOTCCommunityHighlander/Src/XComGame/Classes/XComGameState_CovertAction.uc
@@ -724,9 +724,9 @@ function GiveRewards(XComGameState NewGameState)
 ///
 /// ```event
 /// EventID: CovertAction_PreventGiveRewards,
-/// EventData: Data: [ inout bool PreventGiveRewards ],
+/// EventData: [ inout bool PreventGiveRewards ],
 /// EventSource: XComGameState_CovertAction (CAState),
-/// NewGameState: no
+/// NewGameState: none
 /// ```
 private function bool TriggerPreventGiveRewards()
 {

--- a/X2WOTCCommunityHighlander/Src/XComGame/Classes/XComGameState_CovertAction.uc
+++ b/X2WOTCCommunityHighlander/Src/XComGame/Classes/XComGameState_CovertAction.uc
@@ -722,12 +722,10 @@ function GiveRewards(XComGameState NewGameState)
 /// boolean is `true` then not only are the rewards not given, but the soldiers
 /// on the covert action get no XP or cohesion. The results are saved and are used to adjust UI later.
 ///
-/// ```unrealscript
+/// ```event
 /// EventID: CovertAction_PreventGiveRewards
-/// EventData: XComLWTuple {
-///     Data: [ inout bool PreventGiveRewards ]
-/// }
-/// EventSource: XComGameState_CovertAction
+/// EventData: Data: [ inout bool PreventGiveRewards ]
+/// EventSource: XComGameState_CovertAction (CAState)
 /// NewGameState: no
 /// ```
 private function bool TriggerPreventGiveRewards()


### PR DESCRIPTION
The covert action report will no longer display soldiers as gaining XP or cohesion if the rewards have been prevented from being given. This is because the reward prevention code also prevents the soldiers from gaining XP and cohesion.

I have also added documentation for the CovertAction_PreventGiveRewards event.

Fixes #810.