### PR TITLE
Fix covert actions not being cleaned up (#819)

### DIFF
--- a/X2WOTCCommunityHighlander/Src/XComGame/Classes/XComGameState_ResistanceFaction.uc
+++ b/X2WOTCCommunityHighlander/Src/XComGame/Classes/XComGameState_ResistanceFaction.uc
@@ -962,9 +962,9 @@ function RemoveCovertAction(StateObjectReference ActionRef)
 function CleanUpFactionCovertActions(XComGameState NewGameState)
 {
 	local XComGameStateHistory History;
+	local int idx;
 	// Issue #435 Start
 	local XComGameState_CovertAction ActionState;
-	local StateObjectReference ActionRef;
 	local XComLWTuple Tuple;
 
 	Tuple = new class'XComLWTuple';
@@ -976,10 +976,13 @@ function CleanUpFactionCovertActions(XComGameState NewGameState)
 	
 	History = `XCOMHISTORY;
 
-	foreach CovertActions(ActionRef) // Issue #435 Changed Loop type
+	// Issue #819: Replaced the `foreach` with a reverse traversal loop which won't
+	// be affected by elements being removed during the iteration. Also removed the
+	// `ActionRef` local variable.
+	for (idx = CovertActions.Length - 1; idx >= 0; idx--)
 	{
 		// Issue #435 Start
-		ActionState = XComGameState_CovertAction(History.GetGameStateForObjectID(ActionRef.ObjectID));
+		ActionState = XComGameState_CovertAction(History.GetGameStateForObjectID(CovertActions[idx].ObjectID));
 
 		if (ActionState == none)
 		{

--- a/X2WOTCCommunityHighlander/Src/XComGame/Classes/XComGameState_ResistanceFaction.uc
+++ b/X2WOTCCommunityHighlander/Src/XComGame/Classes/XComGameState_ResistanceFaction.uc
@@ -978,7 +978,7 @@ function CleanUpFactionCovertActions(XComGameState NewGameState)
 
 	// Issue #819: Replaced the `foreach` with a reverse traversal loop which won't
 	// be affected by elements being removed during the iteration. Also removed the
-	// `ActionRef` local variable.
+	// `ActionRef` local variable (introduced in #435).
 	for (idx = CovertActions.Length - 1; idx >= 0; idx--)
 	{
 		// Issue #435 Start


### PR DESCRIPTION
Issue #435 removed the unconditional clearing of a resistance faction's covert actions when new ones were generated. This led to the manifestation of an existing bug in a loop in `CleanupFactionCovertActions()`, which meant that not all of the existing covert actions were being removed.

This change simply replaces the loop with a reverse-traversal one that can handle elements of the `CovertActions` array being removed during iteration over that array.

Fixes #819.