### PR TITLE
Fix docs build

### DIFF
--- a/.scripts/make_docs.py
+++ b/.scripts/make_docs.py
@@ -22,10 +22,10 @@ exit_code = 0
 
 def err(msg: str, fatal: bool):
     global exit_code
+    print("error: %s" % (msg))
     if fatal:
         sys.exit(1)
     exit_code = 1
-    print("error: %s" % (msg))
 
 
 def parse_args() -> (List[str], str, str):

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -123,7 +123,6 @@ RunPriorityGroup=RUN_STANDARD
   is shown on the end-of-month report or not (#663)
 - Triggers the event `OverrideNextRetaliationDisplay` to allow mods to customize and/or enable/disable "next retaliation"
   display in `UIAdventOperations` (#667)
-- Triggers the event `OnBestGearLoadoutApplied` at the end of `XCGS_Unit::ApplyBestGearLoadout()` to allow mods to make changes to the Unit State. (#676)
 - Triggers the event `ItemAddedToSlot` & `ItemRemovedFromSlot` to allow mods to change Items that have been Equipped/Unequipped during runtime(#694)
 - Triggers the event `CovertAction_AllowResActivityRecord` to allow mods to enable/disable "covert action completed"
   record for the monthly resistance report (#696)
@@ -146,7 +145,6 @@ RunPriorityGroup=RUN_STANDARD
   (#82)
 - bDontUnequipCovertOps prevents soldiers gear gets stripped when sending on covert op with no ambush risk (#153)
 - bDontUnequipWhenWounded prevents soldiers gear gets stripped when getting wounded (#310)
-- iDefaultWeaponTint allows to configure the default weappon tint for randomly generated soldiers (#397)
 - AdditionalAmbushRiskTemplates array represents risk templates that the game will consider at risk to ambush (#485)
 - bSkipCampaignIntroMovies skips the intro movies on campaign start (#543)
 
@@ -214,7 +212,6 @@ RunPriorityGroup=RUN_STANDARD
   the Skulljack / ADVENT screen arbitrarily (#330)
 - `OverrideClipSize` to allow effects to modify weapon clip size (#393)
 - `PostMissionObjectivesSpawned` to allow for map manipulation before units are spawned  (#405)
-- 'PostAliensSpawned' to allow changes to StartState (#457)
 - Allow mods to override the number of objectives spawned for a mission via the new event
   `OverrideObjectiveSpawnCount`, which is triggered as the objective spawns are being
   selected by `XComTacticalMissionManager`. (#463)
@@ -303,7 +300,6 @@ RunPriorityGroup=RUN_STANDARD
 - `UpdateWeaponAttachments` added to allow manipulation weapon attachments at runtime (#239)
 - `WeaponInitialized` added to conditionally change the weapon archetype on initialization (#245)
 - `UpdateWeaponMaterial` added to conditionally change the weapon materials(#246)
-- `DLCAppendWeaponSockets` allows adding new sockets to weapons(#281)
 - `OnPreCreateTemplates` allows mods to modify properties of X2DataSet(s) before they are invoked (#412)
 - `UpdateTransitionMap` allows overriding the transition map -- dropship interior by default (#388)
 - `UseAlternateMissionIntroDefinition` allows overriding the mission intro (#395)
@@ -344,8 +340,6 @@ RunPriorityGroup=RUN_STANDARD
 
 ### Improvements
 - Create a mod friendly way to manipulate loot tables (#8)
-- Allow to specify EventListenerDeferral Priority for EventListeners registered
-  X2EventListenerTemplates. Also allow to remove registered Listeners. (#4)
 - Allow enemies with assigned names to have them appear as their name, rather
   than a generic label. (#52)
 - Change UIUtilities_Colors.GetColorForFaction to use Faction template color as

--- a/X2WOTCCommunityHighlander/Src/XComGame/Classes/X2DownloadableContentInfo.uc
+++ b/X2WOTCCommunityHighlander/Src/XComGame/Classes/X2DownloadableContentInfo.uc
@@ -550,9 +550,6 @@ static function bool CanWeaponApplyUpgrade(XComGameState_Item WeaponState, X2Wea
 /// NOTE: To create new sockets from script you need to unconst SocketName and BoneName in SkeletalMeshSocket
 /// </summary>
 /// HL-Docs: feature:DLCAppendWeaponSockets; issue:281; tags:pawns
-/// Allows mods to add, move and rescale sockets on the skeletal mesh of any weapon, which can be used to position visual weapon attachments.
-///	Duplicate sockets are not allowed. If you try to add a socket that already exists, the older socket will be removed.
-/// HL-Docs: feature:DLCAppendWeaponSockets; issue:281; tags:pawns
 /// Allows mods to add sockets to the skeletal mesh of any weapon, which can be used to position visual weapon attachments,
 /// using different position/scale of the same attachment's skeletal mesh for different weapons. Example use:
 /// ```unrealscript

--- a/X2WOTCCommunityHighlander/Src/XComGame/Classes/X2DownloadableContentInfo.uc
+++ b/X2WOTCCommunityHighlander/Src/XComGame/Classes/X2DownloadableContentInfo.uc
@@ -550,7 +550,7 @@ static function bool CanWeaponApplyUpgrade(XComGameState_Item WeaponState, X2Wea
 /// NOTE: To create new sockets from script you need to unconst SocketName and BoneName in SkeletalMeshSocket
 /// </summary>
 /// HL-Docs: feature:DLCAppendWeaponSockets; issue:281; tags:pawns
-/// Allows mods to add sockets to the skeletal mesh of any weapon, which can be used to position visual weapon attachments,
+/// Allows mods to add, move and rescale sockets on the skeletal mesh of any weapon, which can be used to position visual weapon attachments,
 /// using different position/scale of the same attachment's skeletal mesh for different weapons. Example use:
 /// ```unrealscript
 /// static function DLCAppendWeaponSockets(out array<SkeletalMeshSocket> NewSockets, XComWeapon Weapon, XComGameState_Item ItemState)
@@ -590,6 +590,9 @@ static function bool CanWeaponApplyUpgrade(XComGameState_Item WeaponState, X2Wea
 /// 	}
 /// }
 /// ```
+///
+/// Sockets that have the name of an existing socket will replace the original socket. This can be used to move, rotate,
+/// and rescale existing sockets.
 static function DLCAppendWeaponSockets(out array<SkeletalMeshSocket> NewSockets, XComWeapon Weapon, XComGameState_Item ItemState)
 {
 	return;

--- a/X2WOTCCommunityHighlander/Src/XComGame/Classes/XComGameState_Unit.uc
+++ b/X2WOTCCommunityHighlander/Src/XComGame/Classes/XComGameState_Unit.uc
@@ -6229,7 +6229,7 @@ event TakeDamage( XComGameState NewGameState, const int DamageAmount, const int 
 	DamageAbsorbedByShield = 0;
 
 	// Begin Issue #743
-	/// HL-Docs: feature:DamageCalc_ArmorBeforeShield; issue:743; tags:tactical,balance,damage-calc
+	/// HL-Docs: feature:DamageCalc_ArmorBeforeShield; issue:743; tags:tactical
 	/// By default, shields are damaged before any damage is mitigated by armor.
 	/// This is fine in vanilla when shields are rare, but becomes an issue in
 	/// modded campaigns where 'shields' are turned into 'ablative' hit points


### PR DESCRIPTION
#747 used an unknown tag, but there was no CI check because the PR was based on a commit that didn't have CI set up. This broke the master docs build.

#745 erronously had two `HL-Docs` in one block, which caused the script to emit an error but not terminate with a non-zero exit code, causing the check to succeed. All caught errors now (either deferredly or immediately) terminate the script with exit code 1.