### PR TITLE
Add error reporting for missing 'tags' docs key

### DIFF
--- a/.scripts/make_docs.py
+++ b/.scripts/make_docs.py
@@ -253,6 +253,10 @@ def render_bugfix_page(item: dict, outdir: str):
 
 
 def render_full_feature_page(item: dict, outdir: str):
+    if not "tags" in item:
+        err("Feature '%s' does not have a 'tags' key/annotation" % (item["feature"]), False)
+        return
+
     if "strategy" in item["tags"] and not "tactical" in item["tags"]:
         folder = "strategy"
     elif "tactical" in item["tags"] and not "strategy" in item["tags"]:


### PR DESCRIPTION
I sometimes forget to add the 'tags' key to a HL-Docs feature line, but the existing error reporting gives no indication which feature is at fault. This adds a simple check and error message for that case.