### PR TITLE
Added four Inventory Slots for Sparks (Issues #118 and #137)

### DIFF
--- a/X2WOTCCommunityHighlander/Src/XComGame/Classes/X2TacticalGameRulesetDataStructures.uc
+++ b/X2WOTCCommunityHighlander/Src/XComGame/Classes/X2TacticalGameRulesetDataStructures.uc
@@ -104,10 +104,8 @@ enum EInventorySlot
 	eInvSlot_Pistol,
 	eInvSlot_Wings,
 	eInvSlot_ExtraBackpack,
-	eInvSlot_SparkRocket1,
-	eInvSlot_SparkRocket2,
-	eInvSlot_SparkRocket3,
-	eInvSlot_SparkRocket4,
+	eInvSlot_SparkGrenadePocket,
+	eInvSlot_AuxiliaryWeapon,
 
 	// Marker slot, don't use
 	eInvSlot_END_TEMPLATED_SLOTS,

--- a/X2WOTCCommunityHighlander/Src/XComGame/Classes/X2TacticalGameRulesetDataStructures.uc
+++ b/X2WOTCCommunityHighlander/Src/XComGame/Classes/X2TacticalGameRulesetDataStructures.uc
@@ -104,6 +104,10 @@ enum EInventorySlot
 	eInvSlot_Pistol,
 	eInvSlot_Wings,
 	eInvSlot_ExtraBackpack,
+	eInvSlot_SparkRocket1,
+	eInvSlot_SparkRocket2,
+	eInvSlot_SparkRocket3,
+	eInvSlot_SparkRocket4,
 
 	// Marker slot, don't use
 	eInvSlot_END_TEMPLATED_SLOTS,


### PR DESCRIPTION
Added inventory slots:

```
eInvSlot_SparkRocket1
eInvSlot_SparkRocket2
eInvSlot_SparkRocket3
eInvSlot_SparkRocket4
```

They will be used by my upcoming SPARK Weapons mod. The slots will be templated and added to the SPARKs and MEC Troopers when an Ordnance Launcher is equipped. I could potentially just add utility slots and control what goes into them via CanAddItemToInventory, but templated slots offer more control and are more compatible with mods that would want SPARKs to have Utility slots for things like SPARK Launcher by RM or ammo.