### PR TITLE
Override camera rotation angle

### DIFF
--- a/X2WOTCCommunityHighlander/Src/XComGame/Classes/CHHelpers.uc
+++ b/X2WOTCCommunityHighlander/Src/XComGame/Classes/CHHelpers.uc
@@ -178,6 +178,9 @@ var config array<name> ClassesAllowPsiPCS;
 // Variable for Issue #724
 var config array<name> ValidReserveAPForUnitFlag;
 
+// Variable for Issue #854
+var config float CameraRotationAngle;
+
 // Start Issue #885
 enum EHLDelegateReturn
 {

--- a/X2WOTCCommunityHighlander/Src/XComGame/Classes/UITacticalHUD_AbilityContainer.uc
+++ b/X2WOTCCommunityHighlander/Src/XComGame/Classes/UITacticalHUD_AbilityContainer.uc
@@ -280,12 +280,12 @@ simulated function bool OnUnrealCommand(int ucmd, int arg)
 				break;
 			case (class'UIUtilities_Input'.const.FXS_DPAD_LEFT):
 			case (class'UIUtilities_Input'.const.FXS_ARROW_LEFT):
-				XComTacticalController(PC).YawCamera(90.0);
+				XComTacticalController(PC).YawCamera(class'XComTacticalInput'.static.GetCameraRotationAngle(arg));  // Issue #854
 				bHandled = true;
 				break;
 			case (class'UIUtilities_Input'.const.FXS_DPAD_RIGHT):
 			case (class'UIUtilities_Input'.const.FXS_ARROW_RIGHT):
-				XComTacticalController(PC).YawCamera(-90.0);
+				XComTacticalController(PC).YawCamera(-1 * class'XComTacticalInput'.static.GetCameraRotationAngle(arg));  // Issue #854
 				bHandled = true;
 				break;
 			case (class'UIUtilities_Input'.const.FXS_DPAD_UP):

--- a/X2WOTCCommunityHighlander/Src/XComGame/Classes/XComTacticalInput.uc
+++ b/X2WOTCCommunityHighlander/Src/XComGame/Classes/XComTacticalInput.uc
@@ -636,26 +636,26 @@ state InReplayPlayback
 	function bool Key_Q( int ActionMask )
 	{
 		if (( ActionMask & class'UIUtilities_Input'.const.FXS_ACTION_RELEASE) != 0)
-			XComTacticalController(Outer).YawCamera(90.0);
+			XComTacticalController(Outer).YawCamera(GetCameraRotationAngle(ActionMask));  // Issue #854
 		return false;
 	}
 	function bool Key_E( int ActionMask )
 	{
 		if (( ActionMask & class'UIUtilities_Input'.const.FXS_ACTION_RELEASE) != 0)
-			XComTacticalController(Outer).YawCamera(-90.0);
+			XComTacticalController(Outer).YawCamera(-1 * GetCameraRotationAngle(ActionMask));  // Issue #854
 		return false;
 	}
 
 	function bool DPad_Right( int ActionMask )
 	{
 		if (( ActionMask & class'UIUtilities_Input'.const.FXS_ACTION_RELEASE) != 0)
-			XComTacticalController(Outer).YawCamera(-90.0);
+			XComTacticalController(Outer).YawCamera(-1 * GetCameraRotationAngle(ActionMask));  // Issue #854
 		return false;
 	}
 	function bool DPad_Left( int ActionMask )
 	{
 		if (( ActionMask & class'UIUtilities_Input'.const.FXS_ACTION_RELEASE) != 0)
-			XComTacticalController(Outer).YawCamera(90.0);
+			XComTacticalController(Outer).YawCamera(GetCameraRotationAngle(ActionMask));  // Issue #854
 		return false;
 	}
 	function bool DPad_Up( int ActionMask )
@@ -886,6 +886,51 @@ state InReplayPlayback
 Begin: 
 }
 
+// Start Issue #854
+/// HL-Docs: feature:OverrideCameraRotationAngle; issue:854; tags:tactical,compatibility
+/// The 'OverrideCameraRotationAngle' event allows mods to override the angle
+/// the camera rotates when using the controller or the Q and E buttons. The
+/// event takes the following form, with mods changing the first value of the
+/// tuple if they want to change the angle:
+///
+/// ```unrealscript
+/// EventID: OverrideCameraRotationAngle
+/// EventData: [ inout float RotationAngle, in int ActionMask ]
+/// EventSource: none
+/// NewGameState: none
+/// ```
+///
+/// ## Compatibility
+///
+/// Several mods, typically ones that modify the behavior of the camera,
+/// override `XComTacticalInput`, thus breaking this highlander change.
+/// Since those camera mods mostly seem to override the camera rotation
+/// behavior, that's usually not a problem. Just be aware that overriding
+/// `XComTacticalInput` without including this highlander event may break
+/// other mods that rely on it.
+
+static function float GetCameraRotationAngle(int ActionMask)
+{
+	local XComLWTuple Tuple;
+	local float CameraRotationAngle;
+
+	CameraRotationAngle = class'CHHelpers'.default.CameraRotationAngle == 0.0 ? 90.0 : class'CHHelpers'.default.CameraRotationAngle;
+
+	// Allow mods to override this default angle via an event
+	Tuple = new class'XComLWTuple';
+	Tuple.Id = 'OverrideCameraRotationAngle';
+	Tuple.Data.Add(2);
+	Tuple.Data[0].Kind = XComLWTVFloat;
+	Tuple.Data[0].f = CameraRotationAngle;
+	Tuple.Data[1].Kind = XComLWTVInt;
+	Tuple.Data[1].i = ActionMask;
+
+	`XEVENTMGR.TriggerEvent(Tuple.Id, Tuple);
+
+	return Tuple.Data[0].f;
+}
+// End Issue #854
+
 // This state is exactly the same as state "UsingTargetingMethod" except that I brought back camera rotation
 // and I removed the ability to press the Y button for Overwatch shortcut.
 state UsingSecondaryTargetingMethod
@@ -980,7 +1025,7 @@ state UsingSecondaryTargetingMethod
 	{
 		if (( ActionMask & class'UIUtilities_Input'.const.FXS_ACTION_PRESS) != 0)
 		{
-			XComTacticalController(Outer).YawCamera(-90.0);
+			XComTacticalController(Outer).YawCamera(-1 * GetCameraRotationAngle(Actionmask));  // Issue #854
 		}
 		return true;
 	}
@@ -989,7 +1034,7 @@ state UsingSecondaryTargetingMethod
 	{
 		if (( ActionMask & class'UIUtilities_Input'.const.FXS_ACTION_PRESS) != 0)
 		{
-			XComTacticalController(Outer).YawCamera(90.0);
+			XComTacticalController(Outer).YawCamera(GetCameraRotationAngle(Actionmask));  // Issue #854
 		}
 		return true;
 	}
@@ -1244,7 +1289,7 @@ state UsingTargetingMethod
 	{
 		if (( ActionMask & class'UIUtilities_Input'.const.FXS_ACTION_PRESS) != 0)
 		{
-			XComTacticalController(Outer).YawCamera(-90.0);
+			XComTacticalController(Outer).YawCamera(-1 * GetCameraRotationAngle(Actionmask));  // Issue #854
 		}
 		return true;
 	}
@@ -1253,7 +1298,7 @@ state UsingTargetingMethod
 	{
 		if (( ActionMask & class'UIUtilities_Input'.const.FXS_ACTION_PRESS) != 0)
 		{
-			XComTacticalController(Outer).YawCamera(90.0);
+			XComTacticalController(Outer).YawCamera(GetCameraRotationAngle(Actionmask));  // Issue #854
 		}
 		return true;
 	}
@@ -1480,26 +1525,26 @@ state Multiplayer_Inactive
 	function bool Key_E( int ActionMask )
 	{
 		if (( ActionMask & class'UIUtilities_Input'.const.FXS_ACTION_RELEASE) != 0)
-			XComTacticalController(Outer).YawCamera(-90.0);
+			XComTacticalController(Outer).YawCamera(-1 * GetCameraRotationAngle(Actionmask));  // Issue #854
 		return false;
 	}
 	function bool Key_Q( int ActionMask )
 	{
 		if (( ActionMask & class'UIUtilities_Input'.const.FXS_ACTION_RELEASE) != 0)
-			XComTacticalController(Outer).YawCamera(90.0);
+			XComTacticalController(Outer).YawCamera(GetCameraRotationAngle(Actionmask));  // Issue #854
 		return false;
 	}
 
 	function bool DPad_Right( int ActionMask )
 	{
 		if (( ActionMask & class'UIUtilities_Input'.const.FXS_ACTION_RELEASE) != 0)
-			XComTacticalController(Outer).YawCamera(-90.0);
+			XComTacticalController(Outer).YawCamera(-1 * GetCameraRotationAngle(Actionmask));  // Issue #854
 		return false;
 	}
 	function bool DPad_Left( int ActionMask )
 	{
 		if (( ActionMask & class'UIUtilities_Input'.const.FXS_ACTION_RELEASE) != 0)
-			XComTacticalController(Outer).YawCamera(90.0);
+			XComTacticalController(Outer).YawCamera(GetCameraRotationAngle(Actionmask));  // Issue #854
 		return false;
 	}
 	function bool DPad_Up( int ActionMask )
@@ -2373,13 +2418,13 @@ state ActiveUnit_Moving
 	function bool Key_E( int ActionMask )
 	{
 		if (( ActionMask & class'UIUtilities_Input'.const.FXS_ACTION_RELEASE) != 0)
-			XComTacticalController(Outer).YawCamera(-90.0);
+			XComTacticalController(Outer).YawCamera(-1 * GetCameraRotationAngle(Actionmask));  // Issue #854
 		return false;
 	}
 	function bool Key_Q( int ActionMask )
 	{
 		if (( ActionMask & class'UIUtilities_Input'.const.FXS_ACTION_RELEASE) != 0)
-			XComTacticalController(Outer).YawCamera(90.0);
+			XComTacticalController(Outer).YawCamera(GetCameraRotationAngle(Actionmask));  // Issue #854
 		return false;
 	}
 	function bool DPad_Up( int ActionMask )


### PR DESCRIPTION
Depends on #853. Adds both an event and a configuration variable that allows mods and/or players to override the default camera rotation angle of 90°.

Note that this passes the ActionMask to the listeners, but that may not be particularly useful when simply overriding the rotation angle. Another approach would be to override the key press/key release behaviour as well. Not sure which is better at this point.

Resolves #854 