### PR TITLE
Use GITHUB_TOKEN for docs deployment

### DIFF
--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -34,10 +34,9 @@ jobs:
         name: docs-html
         path: target
     - name: Deploy
-      uses: crazy-max/ghaction-github-pages@v1
+      uses: crazy-max/ghaction-github-pages@v2
       with:
         target_branch: gh-pages
         build_dir: target # The folder the action should deploy.
-        committer_name: X2CommunityCore-Docs-Bot
       env:
-        GITHUB_PAT: ${{ secrets.ACCESS_TOKEN }}
+        GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}


### PR DESCRIPTION
Noticed a bunch of deprecation warnings in my DD save editor CI runs: https://github.com/robojumper/DarkestDungeonSaveEditor/actions/runs/129776896

Also present here: https://github.com/X2CommunityCore/X2WOTCCommunityHighlander/actions/runs/121703029

This makes @X2CommunityCore-Docs-Bot useless
![grafik](https://user-images.githubusercontent.com/14299449/84154220-1e01a880-aa67-11ea-8368-367681dbb035.png)
