### PR TITLE
Fix weapon models not rotating when previewing weapon upgrades (Issue #39)

### DIFF
--- a/X2WOTCCommunityHighlander/Src/XComGame/Classes/UIArmory_WeaponUpgrade.uc
+++ b/X2WOTCCommunityHighlander/Src/XComGame/Classes/UIArmory_WeaponUpgrade.uc
@@ -540,6 +540,15 @@ simulated function PreviewUpgrade(UIList ContainerList, int ItemIndex)
 	{
 		Weapon.ApplyWeaponUpgradeTemplate(UpgradeTemplate, SlotIndex);
 
+		//	Start Issue #39
+		/// HL-Docs: ref:Bugfixes; issue:39
+		/// Create weapon pawn before setting PawnLocationTag so that the weapon can rotate when previewing weapon upgrades.
+		PreviousLocation = ActorPawn.Location;
+		CreateWeaponPawn(Weapon, ActorPawn.Rotation);
+		ActorPawn.SetLocation(PreviousLocation);
+		MouseGuard.SetActorPawn(ActorPawn, ActorPawn.Rotation);
+		//	End Issue #39
+
 		//Formulate the attachment specific location tag from the attach socket
 		WeaponTemplateName = Weapon.GetMyTemplateName();
 		for( WeaponAttachIndex = 0; WeaponAttachIndex < UpgradeTemplate.UpgradeAttachments.Length; ++WeaponAttachIndex )
@@ -565,12 +574,12 @@ simulated function PreviewUpgrade(UIList ContainerList, int ItemIndex)
 	{
 		MouseGuard.SetActorPawn(None); //Otherwise, grab the rotation to show them the upgrade as they select it
 	}
-
-	PreviousLocation = ActorPawn.Location;
-	CreateWeaponPawn(Weapon, ActorPawn.Rotation);
-	ActorPawn.SetLocation(PreviousLocation);
-	MouseGuard.SetActorPawn(ActorPawn, ActorPawn.Rotation);
-
+	//	Start Issue #39
+	//PreviousLocation = ActorPawn.Location;
+	//CreateWeaponPawn(Weapon, ActorPawn.Rotation);
+	//ActorPawn.SetLocation(PreviousLocation);
+	//MouseGuard.SetActorPawn(ActorPawn, ActorPawn.Rotation);
+	//	End Issue #39
 	`XCOMHISTORY.CleanupPendingGameState(ChangeState);
 }
 

--- a/X2WOTCCommunityHighlander/Src/XComGame/Classes/UIArmory_WeaponUpgrade.uc
+++ b/X2WOTCCommunityHighlander/Src/XComGame/Classes/UIArmory_WeaponUpgrade.uc
@@ -540,14 +540,14 @@ simulated function PreviewUpgrade(UIList ContainerList, int ItemIndex)
 	{
 		Weapon.ApplyWeaponUpgradeTemplate(UpgradeTemplate, SlotIndex);
 
-		//	Start Issue #39
+		// Start Issue #39
 		/// HL-Docs: ref:Bugfixes; issue:39
 		/// Create weapon pawn before setting PawnLocationTag so that the weapon can rotate when previewing weapon upgrades.
 		PreviousLocation = ActorPawn.Location;
 		CreateWeaponPawn(Weapon, ActorPawn.Rotation);
 		ActorPawn.SetLocation(PreviousLocation);
 		MouseGuard.SetActorPawn(ActorPawn, ActorPawn.Rotation);
-		//	End Issue #39
+		// End Issue #39
 
 		//Formulate the attachment specific location tag from the attach socket
 		WeaponTemplateName = Weapon.GetMyTemplateName();
@@ -574,12 +574,17 @@ simulated function PreviewUpgrade(UIList ContainerList, int ItemIndex)
 	{
 		MouseGuard.SetActorPawn(None); //Otherwise, grab the rotation to show them the upgrade as they select it
 	}
-	//	Start Issue #39
-	//PreviousLocation = ActorPawn.Location;
-	//CreateWeaponPawn(Weapon, ActorPawn.Rotation);
-	//ActorPawn.SetLocation(PreviousLocation);
-	//MouseGuard.SetActorPawn(ActorPawn, ActorPawn.Rotation);
-	//	End Issue #39
+	// Start Issue #39
+	// Create weapon pawn if the upgrade template does not exist to preserve the vanilla WOTC behavior
+	// in case something goes wrong.
+	if (UpgradeTemplate == none)
+	{
+		PreviousLocation = ActorPawn.Location;
+		CreateWeaponPawn(Weapon, ActorPawn.Rotation);
+		ActorPawn.SetLocation(PreviousLocation);
+		MouseGuard.SetActorPawn(ActorPawn, ActorPawn.Rotation);
+	}
+	// End Issue #39
 	`XCOMHISTORY.CleanupPendingGameState(ChangeState);
 }
 


### PR DESCRIPTION
Fixes #39 

I'm not very comfortable with how I addressed the issue. The original `PreviewUpgrade()` function from pre-WOTC XCOM 2 can be seen below. You can clearly see how `CreateWeaponPawn()` is called after applying the weapon upgrade template, and before assigning the `PawnLocationTag`. 

It seems that in WOTC Firaxis has refactored this function somewhat, not sure to what end, but now it calls `CreateWeaponPawn()` after assigning the `PawnLocationTag`, which will reset that field, preventing the weapon from moving. Another important difference of the WOTC function is that now there's a none check for the `UpgradeTemplate` var. To fix the issue, I have moved the `CreateWeaponPawn()` block after the upgrade template is assigned to the weapon, just as it was positioned in vanilla.

But now it is inside a none check, and I'm not entirely comfortable with that, because now it's possible the pawn will not be created if the template is none. 

I'm not sure if there could be negative consequences to this, so I humbly request review to put me on the right path here. 
The code in this PR has been tested with vanilla and a few mod-added weapons and I did not experience any issues.
```
simulated function PreviewUpgrade(UIList ContainerList, int ItemIndex)
{
	local XComGameState_Item Weapon;
	local XComGameState ChangeState;
	local X2WeaponUpgradeTemplate UpgradeTemplate;
	local Vector PreviousLocation;
	local int WeaponAttachIndex, SlotIndex;
	local Name WeaponTemplateName;

	if(ItemIndex == INDEX_NONE)
	{
		SetUpgradeText();
		return;
	}

	`XSTRATEGYSOUNDMGR.PlaySoundEvent("Weapon_Attachement_Upgrade");
	ChangeState = class'XComGameStateContext_ChangeContainer'.static.CreateChangeState("Visualize Weapon Upgrade");

	Weapon = XComGameState_Item(ChangeState.CreateStateObject(class'XComGameState_Item', WeaponRef.ObjectID));
	ChangeState.AddStateObject(Weapon);

	UpgradeTemplate = UIArmory_WeaponUpgradeItem(ContainerList.GetItem(ItemIndex)).UpgradeTemplate;
	SlotIndex = UIArmory_WeaponUpgradeItem(SlotsList.GetSelectedItem()).SlotIndex;

	Weapon.DeleteWeaponUpgradeTemplate(SlotIndex);
	Weapon.ApplyWeaponUpgradeTemplate(UpgradeTemplate, SlotIndex);

	PreviousLocation = ActorPawn.Location;
	CreateWeaponPawn(Weapon, ActorPawn.Rotation);
	ActorPawn.SetLocation(PreviousLocation);

	//Formulate the attachment specific location tag from the attach socket
	WeaponTemplateName = Weapon.GetMyTemplateName();
	for( WeaponAttachIndex = 0; WeaponAttachIndex < UpgradeTemplate.UpgradeAttachments.Length; ++WeaponAttachIndex )
	{
		if( UpgradeTemplate.UpgradeAttachments[WeaponAttachIndex].ApplyToWeaponTemplate == WeaponTemplateName &&
		    UpgradeTemplate.UpgradeAttachments[WeaponAttachIndex].UIArmoryCameraPointTag != '' )
		{
			PawnLocationTag = UpgradeTemplate.UpgradeAttachments[WeaponAttachIndex].UIArmoryCameraPointTag;
			break;
		}
	}
	if(ActiveList != UpgradesList)
	{
		MouseGuard.SetActorPawn(ActorPawn); //When we're not selecting an upgrade, let the user spin the weapon around
		RestoreWeaponLocation();
	}
	else
	{
		MouseGuard.SetActorPawn(None); //Otherwise, grab the rotation to show them the upgrade as they select it
	}

	SetUpgradeText(UpgradeTemplate.GetItemFriendlyName(), UpgradeTemplate.GetItemBriefSummary());

	WeaponStats.PopulateData(Weapon, UpgradeTemplate);

	`XCOMHISTORY.CleanupPendingGameState(ChangeState);
}
```