### PR TITLE
Unhide the weapon pattern customization screen

### DIFF
--- a/X2WOTCCommunityHighlander/Src/XComGame/Classes/UIArmory_WeaponTrait.uc
+++ b/X2WOTCCommunityHighlander/Src/XComGame/Classes/UIArmory_WeaponTrait.uc
@@ -1,0 +1,158 @@
+//---------------------------------------------------------------------------------------
+//  FILE:    UIArmory_WeaponTrait.uc
+//  AUTHOR:  Sam Batista --  11/4/2015
+//  PURPOSE: Copy of UICustomize_Trait, for use in Weapon Upgrade screen
+//---------------------------------------------------------------------------------------
+//  Copyright (c) 2016 Firaxis Games, Inc. All rights reserved.
+//---------------------------------------------------------------------------------------
+
+class UIArmory_WeaponTrait extends UIArmory_WeaponUpgrade
+	dependson(UICustomize);
+
+//----------------------------------------------------------------------------
+// MEMBERS
+
+// UI
+var array<string> Data; 
+var public string Title;
+var public string Subtitle;
+var public int StartingIndex;
+var bool bAllowedToCycleSoldiers; 
+
+var delegate<OnItemSelectedCallback> OnSelectionChanged;
+var delegate<OnItemSelectedCallback> OnItemClicked;
+var delegate<OnItemSelectedCallback> OnConfirmButtonClicked;
+
+delegate OnItemSelectedCallback(UIList _list, int itemIndex);
+
+//----------------------------------------------------------------------------
+// FUNCTIONS
+
+simulated function InitScreen(XComPlayerController InitController, UIMovie InitMovie, optional name InitName)
+{
+	super.InitScreen(InitController, InitMovie, InitName);
+
+	if(`ScreenStack.IsInStack(class'UIArmory_WeaponUpgrade'))
+		`ScreenStack.GetScreen(class'UIArmory_WeaponUpgrade').Hide();
+}
+
+simulated function OnRemoved()
+{
+	if(`ScreenStack.IsInStack(class'UIArmory_WeaponUpgrade'))
+		`ScreenStack.GetScreen(class'UIArmory_WeaponUpgrade').Show();
+}
+
+simulated function UpdateSlots()
+{
+	//do nothing
+}
+
+simulated function InterpolateWeapon()
+{
+	// do nothing
+}
+
+simulated function UpdateCustomization(UIPanel DummyParam)
+{
+	//do nothing
+}
+
+simulated function CreateWeaponPawn(XComGameState_Item Weapon, optional Rotator DesiredRotation)
+{
+	if(`ScreenStack.IsInStack(class'UIArmory_WeaponUpgrade'))
+		ActorPawn = UIArmory_WeaponUpgrade(`ScreenStack.GetScreen(class'UIArmory_WeaponUpgrade')).ActorPawn;
+}
+
+simulated function UpdateTrait( string _Title, 
+							  array<string> _Data, 
+							  delegate<OnItemSelectedCallback> _onSelectionChanged,
+							  delegate<OnItemSelectedCallback> _onItemClicked,
+							  optional delegate<UICustomize.IsSoldierEligible> _checkSoldierEligibility,
+							  optional int _startingIndex = -1, 
+							  optional string _ConfirmButtonLabel,
+							  optional delegate<OnItemSelectedCallback> _onConfirmButtonClicked)
+{
+	local int i;
+	local UIListItemString ListItemString;
+
+	Data = _Data;
+	SetSlotsListTitle(Caps(_Title));
+	SlotsList.bAutosizeItems = true;
+	SlotsList.OnSelectionChanged = _onSelectionChanged;
+	SlotsList.OnItemClicked = OnClickLocal;
+	SlotsList.OnItemDoubleClicked = OnDoubleClickLocal;
+	SlotsList.ItemPadding = 0; // SlotsList item height already accounts for padding
+	SlotsListContainer.GetChildByName('BG').ProcessMouseEvents(SlotsList.OnChildMouseEvent);
+	OnItemClicked = _onItemClicked;
+	IsSoldierEligible = _checkSoldierEligibility;
+	StartingIndex = _startingIndex;
+	OnConfirmButtonClicked = _onConfirmButtonClicked;
+	
+	if(SlotsList.itemCount > Data.length)
+		SlotsList.ClearItems();
+
+	while(SlotsList.itemCount < Data.length)
+		Spawn(class'UIListItemString', SlotsList.itemContainer).InitListItem();
+	
+	SlotsList.SetSelectedIndex(StartingIndex);
+
+	SlotsList.bLoopSelection = true;
+	SlotsList.Navigator.LoopSelection = true;
+	CustomizeList.DisableNavigation(); 
+	for( i = 0; i < Data.Length; i++ )
+	{
+		ListItemString = UIListItemString(SlotsList.GetItem(i));
+		if(ListItemString != none)
+		{
+			ListItemString.SetText(Data[i]);
+			if(_ConfirmButtonLabel != "")
+				ListItemString.SetConfirmButtonStyle(eUIConfirmButtonStyle_Default, _ConfirmButtonLabel,,, ConfirmButtonClicked);
+		}
+	}
+}
+
+simulated function ConfirmButtonClicked(UIButton Button)
+{
+	if(SlotsList.SelectedIndex != -1 && OnConfirmButtonClicked != none)
+		OnConfirmButtonClicked(SlotsList, SlotsList.SelectedIndex);
+}
+
+simulated function OnCancel()
+{
+	if(StartingIndex != -1 && OnItemClicked != none)
+		OnItemClicked(SlotsList, StartingIndex);
+	CloseScreen();
+}
+
+simulated function OnClickLocal(UIList _list, int itemIndex)
+{
+	OnItemClicked(_list, itemIndex);
+	CloseScreen();
+}
+
+simulated function OnDoubleClickLocal(UIList _list, int itemIndex)
+{
+	OnItemClicked(_list, itemIndex);
+	CloseScreen();
+}
+
+simulated function bool IsAllowedToCycleSoldiers()
+{
+	return bAllowedToCycleSoldiers;
+}
+
+simulated function OnAccept()
+{
+	//Because of UScript inheritance rules, we need to call OnItemClicked from within UIArmory_WeaponTrait (it's a delegate here, and not in the parent)
+	if(SlotsList.SelectedIndex != -1 && OnItemClicked != none)
+		OnItemClicked(SlotsList, SlotsList.SelectedIndex);
+
+	CloseScreen();
+}
+//==============================================================================
+
+defaultproperties
+{
+	bAllowedToCycleSoldiers = true;
+	bConsumeMouseEvents = false;
+}

--- a/X2WOTCCommunityHighlander/Src/XComGame/Classes/UIArmory_WeaponTrait.uc
+++ b/X2WOTCCommunityHighlander/Src/XComGame/Classes/UIArmory_WeaponTrait.uc
@@ -30,16 +30,31 @@ delegate OnItemSelectedCallback(UIList _list, int itemIndex);
 
 simulated function InitScreen(XComPlayerController InitController, UIMovie InitMovie, optional name InitName)
 {
+	// Issue #877 Variable
+	local UIArmory_WeaponUpgrade WeaponUpgradeScreen;
+
 	super.InitScreen(InitController, InitMovie, InitName);
 
-	if(`ScreenStack.IsInStack(class'UIArmory_WeaponUpgrade'))
-		`ScreenStack.GetScreen(class'UIArmory_WeaponUpgrade').Hide();
+	// Issue #877 Start -- make sure this screen doesn't hide itself with the changes to UIScreenStack (#290)
+	WeaponUpgradeScreen = UIArmory_WeaponUpgrade(`ScreenStack.GetScreen_CH(class'UIArmory_WeaponUpgrade', false));
+	if (WeaponUpgradeScreen != none)
+	{
+		WeaponUpgradeScreen.Hide();
+	}
+	// Issue #877 End
 }
 
 simulated function OnRemoved()
 {
-	if(`ScreenStack.IsInStack(class'UIArmory_WeaponUpgrade'))
-		`ScreenStack.GetScreen(class'UIArmory_WeaponUpgrade').Show();
+	// Issue #877 Start -- make sure this screen doesn't hide itself with the changes to UIScreenStack (#290)
+	local UIArmory_WeaponUpgrade WeaponUpgradeScreen;
+
+	WeaponUpgradeScreen = UIArmory_WeaponUpgrade(`ScreenStack.GetScreen_CH(class'UIArmory_WeaponUpgrade', false));
+	if (WeaponUpgradeScreen != none)
+	{
+		WeaponUpgradeScreen.Show();
+	}
+	// Issue #877 End
 }
 
 simulated function UpdateSlots()
@@ -59,8 +74,15 @@ simulated function UpdateCustomization(UIPanel DummyParam)
 
 simulated function CreateWeaponPawn(XComGameState_Item Weapon, optional Rotator DesiredRotation)
 {
-	if(`ScreenStack.IsInStack(class'UIArmory_WeaponUpgrade'))
-		ActorPawn = UIArmory_WeaponUpgrade(`ScreenStack.GetScreen(class'UIArmory_WeaponUpgrade')).ActorPawn;
+	// Issue #877 Start -- make sure this screen doesn't hide itself with the changes to UIScreenStack (#290)
+	local UIArmory_WeaponUpgrade WeaponUpgradeScreen;
+	
+	WeaponUpgradeScreen = UIArmory_WeaponUpgrade(`ScreenStack.GetScreen_CH(class'UIArmory_WeaponUpgrade', false));
+	if (WeaponUpgradeScreen != none)
+	{
+		ActorPawn = WeaponUpgradeScreen.ActorPawn;
+	}
+	// Issue #877 End
 }
 
 simulated function UpdateTrait( string _Title, 

--- a/X2WOTCCommunityHighlander/X2WOTCCommunityHighlander.x2proj
+++ b/X2WOTCCommunityHighlander/X2WOTCCommunityHighlander.x2proj
@@ -166,6 +166,9 @@
     <Content Include="Src\XComGame\Classes\UIArmory_PromotionPsiOp.uc">
       <SubType>Content</SubType>
     </Content>
+    <Content Include="Src\XComGame\Classes\UIArmory_WeaponTrait.uc">
+      <SubType>Content</SubType>
+    </Content>
     <Content Include="Src\XComGame\Classes\UIArmory_WeaponUpgrade.uc">
       <SubType>Content</SubType>
     </Content>


### PR DESCRIPTION
Fixes #877.

`@kdm2k6` had uncovered fallout from the #290 ScreenStack change and offered a solution. This is just that solution.