### PR TITLE
Fix Stocks and Laser Sights not benefitting from empowered upgrades (Issue #896)

### DIFF
--- a/X2WOTCCommunityHighlander/Src/XComGame/Classes/X2Effect_ApplyWeaponDamage.uc
+++ b/X2WOTCCommunityHighlander/Src/XComGame/Classes/X2Effect_ApplyWeaponDamage.uc
@@ -467,7 +467,19 @@ simulated function GetDamagePreview(StateObjectReference TargetRef, XComGameStat
 
 					ModifyDamageValue(UpgradeTemplateBonusDamage, TargetUnit, AppliedDamageTypes);
 
-					UpgradeDamageValue.Damage += UpgradeTemplateBonusDamage.Damage;
+					//	Start Issue #896
+					/// HL-Docs: ref:Bugfixes; issue:896
+					///	Call the (hopefully) relevant delegate, if this weapon upgrade has it.
+					/// This makes the guaranteed damage on missed shots added by Stocks properly benefit from Insider Knowledge
+					if (WeaponUpgradeTemplate.GetBonusAmountFn != none)
+					{
+						UpgradeDamageValue.Damage += WeaponUpgradeTemplate.GetBonusAmountFn(WeaponUpgradeTemplate);
+					}
+					else
+					{
+						UpgradeDamageValue.Damage += UpgradeTemplateBonusDamage.Damage;
+					}
+					//	End Issue #896
 					UpgradeDamageValue.Spread += UpgradeTemplateBonusDamage.Spread;
 					UpgradeDamageValue.Crit += UpgradeTemplateBonusDamage.Crit;
 					UpgradeDamageValue.Pierce += UpgradeTemplateBonusDamage.Pierce;
@@ -804,7 +816,19 @@ simulated function int CalculateDamageAmount(const out EffectAppliedData ApplyEf
 					if (UpgradeTemplateBonusDamage.Damage > 0) bHadAnyDamage = true;
 					bWasImmune = bWasImmune && ModifyDamageValue(UpgradeTemplateBonusDamage, kTarget, AppliedDamageTypes);
 
-					UpgradeDamageValue.Damage += UpgradeTemplateBonusDamage.Damage;
+					//	Start Issue #896
+					/// HL-Docs: ref:Bugfixes; issue:896
+					///	Call the (hopefully) relevant delegate, if this weapon upgrade has it.
+					/// This makes the guaranteed damage on missed shots added by Stocks properly benefit from Insider Knowledge
+					if (WeaponUpgradeTemplate.GetBonusAmountFn != none)
+					{
+						UpgradeDamageValue.Damage += WeaponUpgradeTemplate.GetBonusAmountFn(WeaponUpgradeTemplate);
+					}
+					else
+					{
+						UpgradeDamageValue.Damage += UpgradeTemplateBonusDamage.Damage;
+					}
+					//	End Issue #896
 					UpgradeDamageValue.Spread += UpgradeTemplateBonusDamage.Spread;
 					UpgradeDamageValue.Crit += UpgradeTemplateBonusDamage.Crit;
 					UpgradeDamageValue.Pierce += UpgradeTemplateBonusDamage.Pierce;

--- a/X2WOTCCommunityHighlander/Src/XComGame/Classes/X2Effect_LaserSight.uc
+++ b/X2WOTCCommunityHighlander/Src/XComGame/Classes/X2Effect_LaserSight.uc
@@ -1,0 +1,37 @@
+class X2Effect_LaserSight extends X2Effect_Persistent config(GameData_SoldierSkills);
+
+var config array<int> CritBoostArray;
+
+var int CritBonus;
+
+function GetToHitModifiers(XComGameState_Effect EffectState, XComGameState_Unit Attacker, XComGameState_Unit Target, XComGameState_Ability AbilityState, class<X2AbilityToHitCalc> ToHitType, bool bMelee, bool bFlanking, bool bIndirectFire, out array<ShotModifierInfo> ShotModifiers)
+{
+	local int Tiles;
+	local XComGameState_Item SourceWeapon;
+	local ShotModifierInfo ShotInfo;
+
+	SourceWeapon = AbilityState.GetSourceWeapon();
+	if (SourceWeapon != none && SourceWeapon.ObjectID == EffectState.ApplyEffectParameters.ItemStateObjectRef.ObjectID)
+	{
+		Tiles = Attacker.TileDistanceBetween(Target);
+		if (CritBoostArray.Length > 0)
+		{
+			if (Tiles < CritBoostArray.Length)
+				ShotInfo.Value = CritBoostArray[Tiles];
+			else  //  if this tile is not configured, use the last configured tile	
+				ShotInfo.Value = CritBoostArray[CritBoostArray.Length - 1];
+
+			ShotInfo.Value += CritBonus;
+
+			ShotInfo.ModType = eHit_Crit;
+			ShotInfo.Reason = FriendlyName;
+			ShotModifiers.AddItem(ShotInfo);
+		}
+	}
+}
+
+DefaultProperties
+{
+	DuplicateResponse = eDupe_Ignore
+	EffectName = "LaserSight"
+}

--- a/X2WOTCCommunityHighlander/Src/XComGame/Classes/X2Effect_LaserSight.uc
+++ b/X2WOTCCommunityHighlander/Src/XComGame/Classes/X2Effect_LaserSight.uc
@@ -1,6 +1,7 @@
 class X2Effect_LaserSight extends X2Effect_Persistent config(GameData_SoldierSkills);
 
 var config array<int> CritBoostArray;
+var bool bBenefitFromEmpoweredUpgrades; // Issue #896 - if "true", crit chance bonus will be increased if XCOM has empowered weapon upgrades.
 
 var int CritBonus;
 
@@ -23,6 +24,15 @@ function GetToHitModifiers(XComGameState_Effect EffectState, XComGameState_Unit 
 
 			ShotInfo.Value += CritBonus;
 
+			// Start Issue #896
+			/// HL-Docs: ref:Bugfixes; issue:896
+			///	Add bonus crit if Insider Knowledge is present.
+			if (bBenefitFromEmpoweredUpgrades && `XCOMHQ.bEmpoweredUpgrades)
+			{
+				ShotInfo.Value += class'X2Item_DefaultUpgrades'.default.CRIT_UPGRADE_EMPOWER_BONUS;
+			}
+			// End Issue #896
+
 			ShotInfo.ModType = eHit_Crit;
 			ShotInfo.Reason = FriendlyName;
 			ShotModifiers.AddItem(ShotInfo);
@@ -32,6 +42,7 @@ function GetToHitModifiers(XComGameState_Effect EffectState, XComGameState_Unit 
 
 DefaultProperties
 {
+	bBenefitFromEmpoweredUpgrades = true // Issue #896 - we assume this effect is normally used for Laser Sight weapon upgrade.
 	DuplicateResponse = eDupe_Ignore
 	EffectName = "LaserSight"
 }

--- a/X2WOTCCommunityHighlander/X2WOTCCommunityHighlander.x2proj
+++ b/X2WOTCCommunityHighlander/X2WOTCCommunityHighlander.x2proj
@@ -430,6 +430,9 @@
     <Content Include="Src\XComGame\Classes\X2Effect_Burning.uc">
       <SubType>Content</SubType>
     </Content>
+    <Content Include="Src\XComGame\Classes\X2Effect_LaserSight.uc">
+      <SubType>Content</SubType>
+    </Content>
     <Content Include="Src\XComGame\Classes\X2EncyclopediaTemplate.uc">
       <SubType>Content</SubType>
     </Content>


### PR DESCRIPTION
Fixes Issue #896

`X2Effect_ApplyWeaponDamage` now calls `WeaponUpgradeTemplate.GetBonusAmountFn()`, if it exists, rather than accessing `WeaponUpgradeTemplate.BonusDamage` directly. 

`X2Effect_LaserSight` now adds `class'X2Item_DefaultUpgrades'.default.CRIT_UPGRADE_EMPOWER_BONUS` to the bonus crit chance amount if empowered upgrades are available. 

Both of these implementations fix the bug, as I confirmed with testing, but in both cases it might potentially change the behavior of some obscure mods that have been relying on the things working as they did. So I would appreciate some input here. Feel free to check the associated issue for more context.

Note that this bug is successfully fixed by this mod: 
Insider Knowledge Fix
https://steamcommunity.com/sharedfiles/filedetails/?id=1124909099