### PR TITLE
Deprivatise functions related to soldier AP (#915)

### DIFF
--- a/X2WOTCCommunityHighlander/Src/XComGame/Classes/XComGameState_Unit.uc
+++ b/X2WOTCCommunityHighlander/Src/XComGame/Classes/XComGameState_Unit.uc
@@ -2993,7 +2993,9 @@ function ImproveCombatIntelligence()
 	AbilityPoints += Round(APIncrease);
 }
 
-private function int GetResistanceHeroAPAmount(int SoldierRank, ECombatIntelligence eComInt)
+// Issue #915: Deprivatized this function as it has no side effects, i.e. it
+// doesn't change any state.
+function int GetResistanceHeroAPAmount(int SoldierRank, ECombatIntelligence eComInt)
 {
 	local XComGameStateHistory History;
 	local XComGameState_HeadquartersResistance ResHQ;
@@ -3029,7 +3031,9 @@ private function int GetResistanceHeroAPAmount(int SoldierRank, ECombatIntellige
 	return APReward;
 }
 
-private function int GetBaseSoldierAPAmount(ECombatIntelligence eComInt)
+// Issue #915: Deprivatized this function as it has no side effects, i.e. it
+// doesn't change any state.
+function int GetBaseSoldierAPAmount(ECombatIntelligence eComInt)
 {
 	local XComGameStateHistory History;
 	local XComGameState_HeadquartersResistance ResHQ;


### PR DESCRIPTION
This change deprivatises the functions:

 * `XComGameState_Unit.GetResistanceHeroAPAmount()`
 * `XComGameState_Unit.GetBaseSoldierAPAmount()`

These two functions have no side effects -- they don't change any state -- and they provide useful data to mods, particularly those that want to reconstruct soldier AP amounts after changes to combat intelligence for example.

Resolves #915.