### PR TITLE
Add extra damage modifier hooks for effects (#923)

### DIFF
--- a/X2WOTCCommunityHighlander/Src/XComGame/Classes/X2Effect_ApplyWeaponDamage.uc
+++ b/X2WOTCCommunityHighlander/Src/XComGame/Classes/X2Effect_ApplyWeaponDamage.uc
@@ -1171,7 +1171,7 @@ simulated private function int ApplyPreDefaultDamageModifierEffects(
 
 			EffectState = XComGameState_Effect(History.GetGameStateForObjectID(EffectRef.ObjectID));
 			EffectTemplate = EffectState.GetX2Effect();
-			CurrDamage += EffectTemplate.GetPreDefaultAttackingDamageModifier_CH(EffectState, SourceUnit, Target, AbilityState, ApplyEffectParameters, CurrDamage, NewGameState);
+			CurrDamage += EffectTemplate.GetPreDefaultAttackingDamageModifier_CH(EffectState, SourceUnit, Target, AbilityState, ApplyEffectParameters, CurrDamage, self, NewGameState);
 			EffectDmg = Round(CurrDamage) - Round(OldDamage);
 			if (EffectDmg != 0)
 			{
@@ -1199,7 +1199,7 @@ simulated private function int ApplyPreDefaultDamageModifierEffects(
 
 			EffectState = XComGameState_Effect(History.GetGameStateForObjectID(EffectRef.ObjectID));
 			EffectTemplate = EffectState.GetX2Effect();
-			CurrDamage += EffectTemplate.GetPreDefaultDefendingDamageModifier_CH(EffectState, SourceUnit, TargetUnit, AbilityState, ApplyEffectParameters, CurrDamage, NewGameState);
+			CurrDamage += EffectTemplate.GetPreDefaultDefendingDamageModifier_CH(EffectState, SourceUnit, TargetUnit, AbilityState, ApplyEffectParameters, CurrDamage, self, NewGameState);
 			EffectDmg = Round(CurrDamage) - Round(OldDamage);
 			if (EffectDmg != 0)
 			{
@@ -1254,7 +1254,7 @@ simulated private function int ApplyPostDefaultDamageModifierEffects(
 
 			EffectState = XComGameState_Effect(History.GetGameStateForObjectID(EffectRef.ObjectID));
 			EffectTemplate = EffectState.GetX2Effect();
-			CurrDamage += EffectTemplate.GetPostDefaultAttackingDamageModifier_CH(EffectState, SourceUnit, Target, AbilityState, ApplyEffectParameters, CurrDamage, NewGameState);
+			CurrDamage += EffectTemplate.GetPostDefaultAttackingDamageModifier_CH(EffectState, SourceUnit, Target, AbilityState, ApplyEffectParameters, CurrDamage, self, NewGameState);
 			EffectDmg = Round(CurrDamage) - Round(OldDamage);
 			if (EffectDmg != 0)
 			{
@@ -1282,7 +1282,7 @@ simulated private function int ApplyPostDefaultDamageModifierEffects(
 
 			EffectState = XComGameState_Effect(History.GetGameStateForObjectID(EffectRef.ObjectID));
 			EffectTemplate = EffectState.GetX2Effect();
-			CurrDamage += EffectTemplate.GetPostDefaultDefendingDamageModifier_CH(EffectState, SourceUnit, TargetUnit, AbilityState, ApplyEffectParameters, CurrDamage, NewGameState);
+			CurrDamage += EffectTemplate.GetPostDefaultDefendingDamageModifier_CH(EffectState, SourceUnit, TargetUnit, AbilityState, ApplyEffectParameters, CurrDamage, self, NewGameState);
 			EffectDmg = Round(CurrDamage) - Round(OldDamage);
 			if (EffectDmg != 0)
 			{

--- a/X2WOTCCommunityHighlander/Src/XComGame/Classes/X2Effect_ApplyWeaponDamage.uc
+++ b/X2WOTCCommunityHighlander/Src/XComGame/Classes/X2Effect_ApplyWeaponDamage.uc
@@ -384,6 +384,7 @@ simulated function GetDamagePreview(StateObjectReference TargetRef, XComGameStat
 	local array<Name> AppliedDamageTypes;
 	local bool bDoesDamageIgnoreShields;
 	local DamageModifierInfo DamageModInfo;
+	local array<DamageModifierInfo> DamageMods; // Issue #923
 
 	MinDamagePreview = UpgradeTemplateBonusDamage;
 	MaxDamagePreview = UpgradeTemplateBonusDamage;
@@ -536,6 +537,13 @@ simulated function GetDamagePreview(StateObjectReference TargetRef, XComGameStat
 	if (bAsPrimaryTarget)
 		TestEffectParams.AbilityInputContext.PrimaryTarget = TargetRef;
 
+	// Start Issue #923
+	MinDamagePreview.Damage = ApplyPreDefaultDamageModifierEffects(History, SourceUnit, TargetUnit, AbilityState, TestEffectParams, MinDamagePreview.Damage, DamageMods, false);
+	MoveDamageModItems(MinDamagePreview.BonusDamageInfo, DamageMods);
+	MaxDamagePreview.Damage = ApplyPreDefaultDamageModifierEffects(History, SourceUnit, TargetUnit, AbilityState, TestEffectParams, MaxDamagePreview.Damage, DamageMods, false);
+	MoveDamageModItems(MaxDamagePreview.BonusDamageInfo, DamageMods);
+	// End Issue #923
+
 	if (TargetUnit != none)
 	{
 		foreach TargetUnit.AffectedByEffects(EffectRef)
@@ -627,9 +635,17 @@ simulated function GetDamagePreview(StateObjectReference TargetRef, XComGameStat
 				DamageModInfo.SourceEffectRef = EffectState.ApplyEffectParameters.EffectRef;
 				DamageModInfo.Value = EffectDmg;
 				MaxDamagePreview.BonusDamageInfo.AddItem(DamageModInfo);
-			}
+			}	
 		}
 	}
+
+	// Start Issue #923
+	MinDamagePreview.Damage = ApplyPostDefaultDamageModifierEffects(History, SourceUnit, TargetUnit, AbilityState, TestEffectParams, MinDamagePreview.Damage, DamageMods, false);
+	MoveDamageModItems(MinDamagePreview.BonusDamageInfo, DamageMods);
+	MaxDamagePreview.Damage = ApplyPostDefaultDamageModifierEffects(History, SourceUnit, TargetUnit, AbilityState, TestEffectParams, MaxDamagePreview.Damage, DamageMods, false);
+	MoveDamageModItems(MaxDamagePreview.BonusDamageInfo, DamageMods);
+	// End Issue #923
+
 	if (!bDoesDamageIgnoreShields)
 		AllowsShield += MaxDamagePreview.Damage;
 }
@@ -910,6 +926,10 @@ simulated function int CalculateDamageAmount(const out EffectAppliedData ApplyEf
 
 	if( kSourceUnit != none)
 	{
+		// Start Issue #923
+		WeaponDamage = ApplyPreDefaultDamageModifierEffects(History, kSourceUnit, kTarget, kAbility, ApplyEffectParameters, WeaponDamage, SpecialDamageMessages,, NewGameState);
+		// End Issue #923
+
 		//  allow target effects that modify only the base damage
 		TargetUnit = XComGameState_Unit(kTarget);
 		if (TargetUnit != none)
@@ -1030,6 +1050,10 @@ simulated function int CalculateDamageAmount(const out EffectAppliedData ApplyEf
 			}
 		}
 
+		// Start Issue #923
+		WeaponDamage = ApplyPostDefaultDamageModifierEffects(History, kSourceUnit, kTarget, kAbility, ApplyEffectParameters, WeaponDamage, SpecialDamageMessages,, NewGameState);
+		// End Issue #923
+
 		if (kTarget != none && !bIgnoreArmor)
 		{
 			ArmorMitigation = kTarget.GetArmorMitigation(ApplyEffectParameters.AbilityResultContext.ArmorMitigation);
@@ -1115,6 +1139,186 @@ simulated function bool IsExplosiveDamage()
 { 
 	return bExplosiveDamage; 
 }
+
+// Start Issue #923
+simulated private function int ApplyPreDefaultDamageModifierEffects(
+	XComGameStateHistory History,
+	XComGameState_Unit SourceUnit,
+	Damageable Target,
+	XComGameState_Ability AbilityState,
+	const out EffectAppliedData ApplyEffectParameters,
+	int WeaponDamage,
+	out array<DamageModifierInfo> DamageMods,
+	optional bool CheckSpecialMessagesProperty = true,
+	optional XComGameState NewGameState)
+{
+	local XComGameState_Unit TargetUnit;
+	local XComGameState_Effect EffectState;
+	local X2Effect_Persistent EffectTemplate;
+	local StateObjectReference EffectRef;
+	local DamageModifierInfo ModifierInfo;
+	local float OldDamage, CurrDamage;
+	local int EffectDmg;
+
+	CurrDamage = WeaponDamage;
+
+	if (SourceUnit != none)
+	{
+		foreach SourceUnit.AffectedByEffects(EffectRef)
+		{
+			ModifierInfo.Value = 0;
+			OldDamage = CurrDamage;
+
+			EffectState = XComGameState_Effect(History.GetGameStateForObjectID(EffectRef.ObjectID));
+			EffectTemplate = EffectState.GetX2Effect();
+			CurrDamage += EffectTemplate.GetPreDefaultAttackingDamageModifier_CH(EffectState, SourceUnit, Target, AbilityState, ApplyEffectParameters, CurrDamage, NewGameState);
+			EffectDmg = Round(CurrDamage) - Round(OldDamage);
+			if (EffectDmg != 0)
+			{
+				`log("[CHL] Attacker effect" @ EffectTemplate.EffectName @ "adjusting damage by" @ (CurrDamage - OldDamage) $ ", new damage:" @ CurrDamage, true, 'XCom_HitRolls');
+
+				ModifierInfo.Value = EffectDmg;
+			}
+
+			if (ModifierInfo.Value != 0 && (!CheckSpecialMessagesProperty || EffectTemplate.bDisplayInSpecialDamageMessageUI))
+			{
+				ModifierInfo.SourceEffectRef = EffectState.ApplyEffectParameters.EffectRef;
+				ModifierInfo.SourceID = EffectRef.ObjectID;
+				DamageMods.AddItem(ModifierInfo);
+			}
+		}
+	}
+
+	TargetUnit = XComGameState_Unit(Target);
+	if (TargetUnit != none)
+	{
+		foreach TargetUnit.AffectedByEffects(EffectRef)
+		{
+			ModifierInfo.Value = 0;
+			OldDamage = CurrDamage;
+
+			EffectState = XComGameState_Effect(History.GetGameStateForObjectID(EffectRef.ObjectID));
+			EffectTemplate = EffectState.GetX2Effect();
+			CurrDamage += EffectTemplate.GetPreDefaultDefendingDamageModifier_CH(EffectState, SourceUnit, TargetUnit, AbilityState, ApplyEffectParameters, CurrDamage, NewGameState);
+			EffectDmg = Round(CurrDamage) - Round(OldDamage);
+			if (EffectDmg != 0)
+			{
+				`log("[CHL] Defender effect" @ EffectTemplate.EffectName @ "adjusting damage by" @ (CurrDamage - OldDamage) $ ", new damage:" @ CurrDamage, true, 'XCom_HitRolls');
+
+				ModifierInfo.Value = EffectDmg;
+			}
+
+			if (ModifierInfo.Value != 0 && (!CheckSpecialMessagesProperty || EffectTemplate.bDisplayInSpecialDamageMessageUI))
+			{
+				ModifierInfo.SourceEffectRef = EffectState.ApplyEffectParameters.EffectRef;
+				ModifierInfo.SourceID = EffectRef.ObjectID;
+				DamageMods.AddItem(ModifierInfo);
+			}
+		}
+	}
+
+	// Truncate rather than use `Round()` for consistency with how XCOM 2
+	// handles float -> int conversion in most cases. Note that this may
+	// result in the sum of the shot modifiers not adding up to the overall
+	// damage modifier, but damage is generally shown as a range anyway.
+	return CurrDamage;
+}
+
+simulated private function int ApplyPostDefaultDamageModifierEffects(
+	XComGameStateHistory History,
+	XComGameState_Unit SourceUnit,
+	Damageable Target,
+	XComGameState_Ability AbilityState,
+	const out EffectAppliedData ApplyEffectParameters,
+	int WeaponDamage,
+	out array<DamageModifierInfo> DamageMods,
+	optional bool CheckSpecialMessagesProperty = true,
+	optional XComGameState NewGameState)
+{
+	local XComGameState_Unit TargetUnit;
+	local XComGameState_Effect EffectState;
+	local X2Effect_Persistent EffectTemplate;
+	local StateObjectReference EffectRef;
+	local DamageModifierInfo ModifierInfo;
+	local float OldDamage, CurrDamage;
+	local int EffectDmg;
+
+	CurrDamage = WeaponDamage;
+
+	if (SourceUnit != none)
+	{
+		foreach SourceUnit.AffectedByEffects(EffectRef)
+		{
+			ModifierInfo.Value = 0;
+			OldDamage = CurrDamage;
+
+			EffectState = XComGameState_Effect(History.GetGameStateForObjectID(EffectRef.ObjectID));
+			EffectTemplate = EffectState.GetX2Effect();
+			CurrDamage += EffectTemplate.GetPostDefaultAttackingDamageModifier_CH(EffectState, SourceUnit, Target, AbilityState, ApplyEffectParameters, CurrDamage, NewGameState);
+			EffectDmg = Round(CurrDamage) - Round(OldDamage);
+			if (EffectDmg != 0)
+			{
+				`log("[CHL] Attacker effect" @ EffectTemplate.EffectName @ "adjusting damage by" @ (CurrDamage - OldDamage) $ ", new damage:" @ CurrDamage, true, 'XCom_HitRolls');
+
+				ModifierInfo.Value = EffectDmg;
+			}
+
+			if (ModifierInfo.Value != 0 && (!CheckSpecialMessagesProperty || EffectTemplate.bDisplayInSpecialDamageMessageUI))
+			{
+				ModifierInfo.SourceEffectRef = EffectState.ApplyEffectParameters.EffectRef;
+				ModifierInfo.SourceID = EffectRef.ObjectID;
+				DamageMods.AddItem(ModifierInfo);
+			}
+		}
+	}
+
+	TargetUnit = XComGameState_Unit(Target);
+	if (TargetUnit != none)
+	{
+		foreach TargetUnit.AffectedByEffects(EffectRef)
+		{
+			ModifierInfo.Value = 0;
+			OldDamage = CurrDamage;
+
+			EffectState = XComGameState_Effect(History.GetGameStateForObjectID(EffectRef.ObjectID));
+			EffectTemplate = EffectState.GetX2Effect();
+			CurrDamage += EffectTemplate.GetPostDefaultDefendingDamageModifier_CH(EffectState, SourceUnit, TargetUnit, AbilityState, ApplyEffectParameters, CurrDamage, NewGameState);
+			EffectDmg = Round(CurrDamage) - Round(OldDamage);
+			if (EffectDmg != 0)
+			{
+				`log("[CHL] Defender effect" @ EffectTemplate.EffectName @ "adjusting damage by" @ (CurrDamage - OldDamage) $ ", new damage:" @ CurrDamage, true, 'XCom_HitRolls');
+
+				ModifierInfo.Value = EffectDmg;
+			}
+
+			if (ModifierInfo.Value != 0 && (!CheckSpecialMessagesProperty || EffectTemplate.bDisplayInSpecialDamageMessageUI))
+			{
+				ModifierInfo.SourceEffectRef = EffectState.ApplyEffectParameters.EffectRef;
+				ModifierInfo.SourceID = EffectRef.ObjectID;
+				DamageMods.AddItem(ModifierInfo);
+			}
+		}
+	}
+
+
+	// Truncate rather than use `Round()` for consistency with how XCOM 2
+	// handles float -> int conversion in most cases. Note that this may
+	// result in the sum of the shot modifiers not adding up to the overall
+	// damage modifier, but damage is generally shown as a range anyway.
+	return CurrDamage;
+}
+
+static private function MoveDamageModItems(out array<DamageModifierInfo> ToArray, out array<DamageModifierInfo> FromArray)
+{
+	local DamageModifierInfo DamageModInfo;
+
+	foreach FromArray(DamageModInfo)
+	{
+		ToArray.AddItem(DamageModInfo);
+	}
+	FromArray.Length = 0;
+}
+// End Issue #923
 
 simulated function AddX2ActionsForVisualization(XComGameState VisualizeGameState, out VisualizationActionMetadata ActionMetadata, name EffectApplyResult)
 {

--- a/X2WOTCCommunityHighlander/Src/XComGame/Classes/X2Effect_ApplyWeaponDamage.uc
+++ b/X2WOTCCommunityHighlander/Src/XComGame/Classes/X2Effect_ApplyWeaponDamage.uc
@@ -1141,7 +1141,7 @@ simulated function bool IsExplosiveDamage()
 }
 
 // Start Issue #923
-simulated private function int ApplyPreDefaultDamageModifierEffects(
+simulated protected function int ApplyPreDefaultDamageModifierEffects(
 	XComGameStateHistory History,
 	XComGameState_Unit SourceUnit,
 	Damageable Target,
@@ -1224,7 +1224,7 @@ simulated private function int ApplyPreDefaultDamageModifierEffects(
 	return CurrDamage;
 }
 
-simulated private function int ApplyPostDefaultDamageModifierEffects(
+simulated protected function int ApplyPostDefaultDamageModifierEffects(
 	XComGameStateHistory History,
 	XComGameState_Unit SourceUnit,
 	Damageable Target,

--- a/X2WOTCCommunityHighlander/Src/XComGame/Classes/X2Effect_Persistent.uc
+++ b/X2WOTCCommunityHighlander/Src/XComGame/Classes/X2Effect_Persistent.uc
@@ -794,7 +794,20 @@ event string GetSpecialDamageMessageName() { return FriendlyName; }
 /// your effect has, so if you want your effects to work with older versions
 /// of the Community Highlander and setups without any Community Highlander at
 /// all, then you should guard the old damage modifier functions with a
-/// [check for Community Highlander version](../../misc/ComponentVersions/).
+/// check for these new functions, e.g.
+/// ```unrealscript
+/// function int GetAttackingDamageModifier(...)
+/// {
+///     if (Function'XComGame.X2Effect_Persistent.GetPreDefaultAttackingDamageModifier_CH' != none)
+///     {
+///         // Using the new hooks, so skip the old implementation
+///         return;
+///     }
+///
+///     // Continue with old implementation here
+///     ...
+/// }
+/// ```
 function float GetPreDefaultAttackingDamageModifier_CH(XComGameState_Effect EffectState, XComGameState_Unit SourceUnit, Damageable Target, XComGameState_Ability AbilityState, const out EffectAppliedData ApplyEffectParameters, float WeaponDamage, XComGameState NewGameState) { return 0.0; }
 function float GetPreDefaultDefendingDamageModifier_CH(XComGameState_Effect EffectState, XComGameState_Unit SourceUnit, XComGameState_Unit TargetUnit, XComGameState_Ability AbilityState, const out EffectAppliedData ApplyEffectParameters, float WeaponDamage, XComGameState NewGameState) { return 0.0; }
 function float GetPostDefaultAttackingDamageModifier_CH(XComGameState_Effect EffectState, XComGameState_Unit SourceUnit, Damageable Target, XComGameState_Ability AbilityState, const out EffectAppliedData ApplyEffectParameters, float WeaponDamage, XComGameState NewGameState) { return 0.0; }

--- a/X2WOTCCommunityHighlander/Src/XComGame/Classes/X2Effect_Persistent.uc
+++ b/X2WOTCCommunityHighlander/Src/XComGame/Classes/X2Effect_Persistent.uc
@@ -808,10 +808,10 @@ event string GetSpecialDamageMessageName() { return FriendlyName; }
 ///     ...
 /// }
 /// ```
-function float GetPreDefaultAttackingDamageModifier_CH(XComGameState_Effect EffectState, XComGameState_Unit SourceUnit, Damageable Target, XComGameState_Ability AbilityState, const out EffectAppliedData ApplyEffectParameters, float WeaponDamage, XComGameState NewGameState) { return 0.0; }
-function float GetPreDefaultDefendingDamageModifier_CH(XComGameState_Effect EffectState, XComGameState_Unit SourceUnit, XComGameState_Unit TargetUnit, XComGameState_Ability AbilityState, const out EffectAppliedData ApplyEffectParameters, float WeaponDamage, XComGameState NewGameState) { return 0.0; }
-function float GetPostDefaultAttackingDamageModifier_CH(XComGameState_Effect EffectState, XComGameState_Unit SourceUnit, Damageable Target, XComGameState_Ability AbilityState, const out EffectAppliedData ApplyEffectParameters, float WeaponDamage, XComGameState NewGameState) { return 0.0; }
-function float GetPostDefaultDefendingDamageModifier_CH(XComGameState_Effect EffectState, XComGameState_Unit SourceUnit, XComGameState_Unit TargetUnit, XComGameState_Ability AbilityState, const out EffectAppliedData ApplyEffectParameters, float WeaponDamage, XComGameState NewGameState) { return 0.0; }
+function float GetPreDefaultAttackingDamageModifier_CH(XComGameState_Effect EffectState, XComGameState_Unit SourceUnit, Damageable Target, XComGameState_Ability AbilityState, const out EffectAppliedData ApplyEffectParameters, float WeaponDamage, X2Effect_ApplyWeaponDamage WeaponDamageEffect, XComGameState NewGameState) { return 0.0; }
+function float GetPreDefaultDefendingDamageModifier_CH(XComGameState_Effect EffectState, XComGameState_Unit SourceUnit, XComGameState_Unit TargetUnit, XComGameState_Ability AbilityState, const out EffectAppliedData ApplyEffectParameters, float WeaponDamage, X2Effect_ApplyWeaponDamage WeaponDamageEffect, XComGameState NewGameState) { return 0.0; }
+function float GetPostDefaultAttackingDamageModifier_CH(XComGameState_Effect EffectState, XComGameState_Unit SourceUnit, Damageable Target, XComGameState_Ability AbilityState, const out EffectAppliedData ApplyEffectParameters, float WeaponDamage, X2Effect_ApplyWeaponDamage WeaponDamageEffect, XComGameState NewGameState) { return 0.0; }
+function float GetPostDefaultDefendingDamageModifier_CH(XComGameState_Effect EffectState, XComGameState_Unit SourceUnit, XComGameState_Unit TargetUnit, XComGameState_Ability AbilityState, const out EffectAppliedData ApplyEffectParameters, float WeaponDamage, X2Effect_ApplyWeaponDamage WeaponDamageEffect, XComGameState NewGameState) { return 0.0; }
 // End Issue #923
 
 final event int CallModifyDamageFromDestructible(XComGameState_Destructible DestructibleState, int IncomingDamage, XComGameState_Unit TargetUnit, XComGameState_Effect EffectState)

--- a/X2WOTCCommunityHighlander/Src/XComGame/Classes/X2Effect_Persistent.uc
+++ b/X2WOTCCommunityHighlander/Src/XComGame/Classes/X2Effect_Persistent.uc
@@ -707,9 +707,19 @@ event string GetSpecialDamageMessageName() { return FriendlyName; }
 /// final damage result will be independent of the order in which effects
 /// are applied.
 ///
+/// In summary: use these hooks to apply multiplicative damage modifiers
+/// such as percent-based increases and reductions. The pre-default hooks
+/// are for multipliers that should apply to just the calculated base
+/// damage, while the post-default hooks apply modifiers to the calculated
+/// damage after all the additive modifiers have been applied.
+///
+/// **Important** Your implementations of these functions should return the
+/// amount of damage your effect is adding or subtracting, **not** the overall
+/// damage. The value you return will be added to `CurrentDamage`.
+///
 /// ## Pre-default hooks
-/// The first step of the damage calculation involves working out the
-/// base damage. Once that's done, the "pre-default" hooks are applied.
+/// The "pre-default" hooks are applied immediately after the base damage
+/// has been calculated.
 /// This allows mods to apply damage modifiers based on the base damage
 /// before any flat damage modifiers are applied.
 ///
@@ -722,7 +732,7 @@ event string GetSpecialDamageMessageName() { return FriendlyName; }
 ///         Damageable Target,
 ///         XComGameState_Ability AbilityState,
 ///         const out EffectAppliedData ApplyEffectParameters,
-///         float WeaponDamage,
+///         float CurrentDamage,
 ///         XComGameState NewGameState)
 /// ```
 /// This next one is used for effects that are applied to the target
@@ -734,17 +744,13 @@ event string GetSpecialDamageMessageName() { return FriendlyName; }
 ///         XComGameState_Unit TargetUnit,
 ///         XComGameState_Ability AbilityState,
 ///         const out EffectAppliedData ApplyEffectParameters,
-///         float WeaponDamage,
+///         float CurrentDamage,
 ///         XComGameState NewGameState)
 /// ```
-/// The arguments are largely self explanatory, but note that `WeaponDamage`
-/// is a float, as is the return value. `WeaponDamage` is the current total
+/// The arguments are largely self explanatory, but note that `CurrentDamage`
+/// is a float, as is the return value. `CurrentDamage` is the current total
 /// damage, which is the base damage with any preceding damage modifiers
 /// already applied.
-///
-/// Your implementations of these functions should return the amount of
-/// damage your effect is adding or subtracting, **not** the overall damage.
-/// The value you return will be added to `WeaponDamage`.
 ///
 /// ## Post-default hooks
 /// Once the pre-default modifiers have been applied, the traditional (flat)
@@ -762,7 +768,7 @@ event string GetSpecialDamageMessageName() { return FriendlyName; }
 ///         Damageable Target,
 ///         XComGameState_Ability AbilityState,
 ///         const out EffectAppliedData ApplyEffectParameters,
-///         float WeaponDamage,
+///         float CurrentDamage,
 ///         XComGameState NewGameState)
 /// ```
 /// This next one is used for effects that are applied to the target
@@ -774,16 +780,12 @@ event string GetSpecialDamageMessageName() { return FriendlyName; }
 ///         XComGameState_Unit TargetUnit,
 ///         XComGameState_Ability AbilityState,
 ///         const out EffectAppliedData ApplyEffectParameters,
-///         float WeaponDamage,
+///         float CurrentDamage,
 ///         XComGameState NewGameState)
 /// ```
-/// The arguments are largely self explanatory, but note that `WeaponDamage`
-/// is a float, as is the return value. `WeaponDamage` is the current total
+/// The arguments are largely self explanatory, but note that `CurrentDamage`
+/// is a float, as is the return value. `CurrentDamage` is the current total
 /// damage.
-///
-/// Your implementations of these functions should return the amount of
-/// damage your effect is adding or subtracting, **not** the overall damage.
-/// The value you return will be added to `WeaponDamage`.
 ///
 /// ## Compatibility
 /// If you implement any of these functions in your own effects, they will do
@@ -808,10 +810,10 @@ event string GetSpecialDamageMessageName() { return FriendlyName; }
 ///     ...
 /// }
 /// ```
-function float GetPreDefaultAttackingDamageModifier_CH(XComGameState_Effect EffectState, XComGameState_Unit SourceUnit, Damageable Target, XComGameState_Ability AbilityState, const out EffectAppliedData ApplyEffectParameters, float WeaponDamage, X2Effect_ApplyWeaponDamage WeaponDamageEffect, XComGameState NewGameState) { return 0.0; }
-function float GetPreDefaultDefendingDamageModifier_CH(XComGameState_Effect EffectState, XComGameState_Unit SourceUnit, XComGameState_Unit TargetUnit, XComGameState_Ability AbilityState, const out EffectAppliedData ApplyEffectParameters, float WeaponDamage, X2Effect_ApplyWeaponDamage WeaponDamageEffect, XComGameState NewGameState) { return 0.0; }
-function float GetPostDefaultAttackingDamageModifier_CH(XComGameState_Effect EffectState, XComGameState_Unit SourceUnit, Damageable Target, XComGameState_Ability AbilityState, const out EffectAppliedData ApplyEffectParameters, float WeaponDamage, X2Effect_ApplyWeaponDamage WeaponDamageEffect, XComGameState NewGameState) { return 0.0; }
-function float GetPostDefaultDefendingDamageModifier_CH(XComGameState_Effect EffectState, XComGameState_Unit SourceUnit, XComGameState_Unit TargetUnit, XComGameState_Ability AbilityState, const out EffectAppliedData ApplyEffectParameters, float WeaponDamage, X2Effect_ApplyWeaponDamage WeaponDamageEffect, XComGameState NewGameState) { return 0.0; }
+function float GetPreDefaultAttackingDamageModifier_CH(XComGameState_Effect EffectState, XComGameState_Unit SourceUnit, Damageable Target, XComGameState_Ability AbilityState, const out EffectAppliedData ApplyEffectParameters, float CurrentDamage, X2Effect_ApplyWeaponDamage WeaponDamageEffect, XComGameState NewGameState) { return 0.0; }
+function float GetPreDefaultDefendingDamageModifier_CH(XComGameState_Effect EffectState, XComGameState_Unit SourceUnit, XComGameState_Unit TargetUnit, XComGameState_Ability AbilityState, const out EffectAppliedData ApplyEffectParameters, float CurrentDamage, X2Effect_ApplyWeaponDamage WeaponDamageEffect, XComGameState NewGameState) { return 0.0; }
+function float GetPostDefaultAttackingDamageModifier_CH(XComGameState_Effect EffectState, XComGameState_Unit SourceUnit, Damageable Target, XComGameState_Ability AbilityState, const out EffectAppliedData ApplyEffectParameters, float CurrentDamage, X2Effect_ApplyWeaponDamage WeaponDamageEffect, XComGameState NewGameState) { return 0.0; }
+function float GetPostDefaultDefendingDamageModifier_CH(XComGameState_Effect EffectState, XComGameState_Unit SourceUnit, XComGameState_Unit TargetUnit, XComGameState_Ability AbilityState, const out EffectAppliedData ApplyEffectParameters, float CurrentDamage, X2Effect_ApplyWeaponDamage WeaponDamageEffect, XComGameState NewGameState) { return 0.0; }
 // End Issue #923
 
 final event int CallModifyDamageFromDestructible(XComGameState_Destructible DestructibleState, int IncomingDamage, XComGameState_Unit TargetUnit, XComGameState_Effect EffectState)

--- a/X2WOTCCommunityHighlander/Src/XComGame/Classes/X2Effect_Persistent.uc
+++ b/X2WOTCCommunityHighlander/Src/XComGame/Classes/X2Effect_Persistent.uc
@@ -801,7 +801,7 @@ event string GetSpecialDamageMessageName() { return FriendlyName; }
 ///     if (Function'XComGame.X2Effect_Persistent.GetPreDefaultAttackingDamageModifier_CH' != none)
 ///     {
 ///         // Using the new hooks, so skip the old implementation
-///         return;
+///         return 0;
 ///     }
 ///
 ///     // Continue with old implementation here

--- a/X2WOTCCommunityHighlander/Src/XComGame/Classes/X2Effect_Persistent.uc
+++ b/X2WOTCCommunityHighlander/Src/XComGame/Classes/X2Effect_Persistent.uc
@@ -692,6 +692,115 @@ function bool AreMovesVisible() { return true; }
 function int ModifyDamageFromDestructible(XComGameState_Destructible DestructibleState, int IncomingDamage, XComGameState_Unit TargetUnit, XComGameState_Effect EffectState) { return 0; }
 event string GetSpecialDamageMessageName() { return FriendlyName; }
 
+// Start Issue #923
+/// HL-Docs: feature:ExtraDamageModifierHooks; issue:923; tags:tactical,compatibility
+/// The base game does not work well with certain types of damage-modifier
+/// effects. In particular, attempts to implement multiplicative,
+/// percentage-based damage modifiers are hindered by the fact that the
+/// overall calculated damage depends on the order in which such effects
+/// are applied to a unit.
+///
+/// The following hooks solve the problem by applying configured damage
+/// modifiers either before or after the "default" behaviour, which
+/// is where normal flat damage is added or subtracted. As long as all
+/// the effects using these hooks are commutative with one another, the
+/// final damage result will be independent of the order in which effects
+/// are applied.
+///
+/// ## Pre-default hooks
+/// The first step of the damage calculation involves working out the
+/// base damage. Once that's done, the "pre-default" hooks are applied.
+/// This allows mods to apply damage modifiers based on the base damage
+/// before any flat damage modifiers are applied.
+///
+/// The following hook is used for effects that are applied to the
+/// attacker:
+/// ```unrealscript
+/// float GetPreDefaultAttackingDamageModifier_CH(
+///         XComGameState_Effect EffectState,
+///         XComGameState_Unit SourceUnit,
+///         Damageable Target,
+///         XComGameState_Ability AbilityState,
+///         const out EffectAppliedData ApplyEffectParameters,
+///         float WeaponDamage,
+///         XComGameState NewGameState)
+/// ```
+/// This next one is used for effects that are applied to the target
+/// (the "defender"):
+/// ```unrealscript
+/// float GetPreDefaultDefendingDamageModifier_CH(
+///         XComGameState_Effect EffectState,
+///         XComGameState_Unit SourceUnit,
+///         XComGameState_Unit TargetUnit,
+///         XComGameState_Ability AbilityState,
+///         const out EffectAppliedData ApplyEffectParameters,
+///         float WeaponDamage,
+///         XComGameState NewGameState)
+/// ```
+/// The arguments are largely self explanatory, but note that `WeaponDamage`
+/// is a float, as is the return value. `WeaponDamage` is the current total
+/// damage, which is the base damage with any preceding damage modifiers
+/// already applied.
+///
+/// Your implementations of these functions should return the amount of
+/// damage your effect is adding or subtracting, **not** the overall damage.
+/// The value you return will be added to `WeaponDamage`.
+///
+/// ## Post-default hooks
+/// Once the pre-default modifiers have been applied, the traditional (flat)
+/// damage modifiers are processed as per existing base game behaviour. When
+/// that has finished, the "post-default" hooks are applied. This allows mods
+/// to apply damage modifiers to the total damage including any bonus flat
+/// damage.
+///
+/// The following hook is used for effects that are applied to the
+/// attacker:
+/// ```unrealscript
+/// float GetPostDefaultAttackingDamageModifier_CH(
+///         XComGameState_Effect EffectState,
+///         XComGameState_Unit SourceUnit,
+///         Damageable Target,
+///         XComGameState_Ability AbilityState,
+///         const out EffectAppliedData ApplyEffectParameters,
+///         float WeaponDamage,
+///         XComGameState NewGameState)
+/// ```
+/// This next one is used for effects that are applied to the target
+/// (the "defender"):
+/// ```unrealscript
+/// float GetPostDefaultDefendingDamageModifier_CH(
+///         XComGameState_Effect EffectState,
+///         XComGameState_Unit SourceUnit,
+///         XComGameState_Unit TargetUnit,
+///         XComGameState_Ability AbilityState,
+///         const out EffectAppliedData ApplyEffectParameters,
+///         float WeaponDamage,
+///         XComGameState NewGameState)
+/// ```
+/// The arguments are largely self explanatory, but note that `WeaponDamage`
+/// is a float, as is the return value. `WeaponDamage` is the current total
+/// damage.
+///
+/// Your implementations of these functions should return the amount of
+/// damage your effect is adding or subtracting, **not** the overall damage.
+/// The value you return will be added to `WeaponDamage`.
+///
+/// ## Compatibility
+/// If you implement any of these functions in your own effects, they will do
+/// nothing unless the game is using version 1.22.0+ of the Community
+/// Highlander.
+///
+/// Do note that these are applied along with any traditional damage modifiers
+/// your effect has, so if you want your effects to work with older versions
+/// of the Community Highlander and setups without any Community Highlander at
+/// all, then you should guard the old damage modifier functions with a
+/// [check for Community Highlander version](../../misc/ComponentVersions/).
+function float GetPreDefaultAttackingDamageModifier_CH(XComGameState_Effect EffectState, XComGameState_Unit SourceUnit, Damageable Target, XComGameState_Ability AbilityState, const out EffectAppliedData ApplyEffectParameters, float WeaponDamage, XComGameState NewGameState) { return 0.0; }
+function float GetPreDefaultDefendingDamageModifier_CH(XComGameState_Effect EffectState, XComGameState_Unit SourceUnit, XComGameState_Unit TargetUnit, XComGameState_Ability AbilityState, const out EffectAppliedData ApplyEffectParameters, float WeaponDamage, XComGameState NewGameState) { return 0.0; }
+function float GetPostDefaultAttackingDamageModifier_CH(XComGameState_Effect EffectState, XComGameState_Unit SourceUnit, Damageable Target, XComGameState_Ability AbilityState, const out EffectAppliedData ApplyEffectParameters, float WeaponDamage, XComGameState NewGameState) { return 0.0; }
+function float GetPostDefaultDefendingDamageModifier_CH(XComGameState_Effect EffectState, XComGameState_Unit SourceUnit, XComGameState_Unit TargetUnit, XComGameState_Ability AbilityState, const out EffectAppliedData ApplyEffectParameters, float WeaponDamage, XComGameState NewGameState) { return 0.0; }
+// End Issue #923
+
 final event int CallModifyDamageFromDestructible(XComGameState_Destructible DestructibleState, int IncomingDamage, XComGameState_Unit TargetUnit, XComGameState_Effect EffectState)
 {
 	return ModifyDamageFromDestructible(DestructibleState, IncomingDamage, TargetUnit, EffectState);


### PR DESCRIPTION
This adds 4 extra hooks to `X2Effect_Persistent` that allow mods better control over the order in which damage modifiers are applied. These hooks occur for both attacking and defending modifiers just before the existing modifiers are applied and just after. This primarily helps mods that want to multiply weapon damage by some factor without running into issues with the order effects are applied (since most effects add or substract flat damage and those are not commutative with multipliers).

Resolves #923 