### PR TITLE
Support campaign-start event listeners (#297)

### DIFF
--- a/X2WOTCCommunityHighlander/Src/XComGame/Classes/CHEventListenerTemplate.uc
+++ b/X2WOTCCommunityHighlander/Src/XComGame/Classes/CHEventListenerTemplate.uc
@@ -60,6 +60,14 @@ struct CHEventListenerTemplate_Event extends X2EventListenerTemplate_EventCallba
 	var int Priority;
 };
 
+// Variable for issue #869
+//
+/// HL-Docs: feature:RegisterInCampaignStart; issue:869; tags:strategy
+/// Specifies that a listener template should be registered before campaign
+/// initialization occurs so that it can respond to events fired during
+/// that initialization (strategy listeners don't receive those events).
+var bool RegisterInCampaignStart;
+
 var protected array<CHEventListenerTemplate_Event> CHEventsToRegister;
 
 function AddCHEvent(name Event, delegate<X2EventManager.OnEventDelegate> EventFn, optional EventListenerDeferral Deferral = ELD_OnStateSubmitted, optional int Priority = 50)

--- a/X2WOTCCommunityHighlander/Src/XComGame/Classes/X2EventListenerTemplateManager.uc
+++ b/X2WOTCCommunityHighlander/Src/XComGame/Classes/X2EventListenerTemplateManager.uc
@@ -1,0 +1,77 @@
+//---------------------------------------------------------------------------------------
+//  FILE:    X2EventListenerTemplateManager.uc
+//  AUTHOR:  David Burchanowsk
+//           
+//---------------------------------------------------------------------------------------
+//  Copyright (c) 2016 Firaxis Games, Inc. All rights reserved.
+//---------------------------------------------------------------------------------------
+class X2EventListenerTemplateManager extends X2DataTemplateManager
+	native(Core);
+
+static function native X2EventListenerTemplateManager GetEventListenerTemplateManager();
+
+event X2EventListenerTemplate FindEventListenerTemplate(name TemplateName)
+{
+	local X2EventListenerTemplate Template;
+
+	Template = X2EventListenerTemplate(FindDataTemplate(TemplateName));
+	if(Template == none)
+	{
+		`Redscreen("Could not find X2EventListenerTemplate " $ TemplateName);
+	}
+
+	return Template;
+}
+
+static function RegisterTacticalListeners()
+{
+	local X2EventListenerTemplate ListenerTemplate;
+	local X2DataTemplate Template;
+
+	// unregister any previously registered templates
+	UnRegisterAllListeners();
+
+	foreach GetEventListenerTemplateManager().IterateTemplates(Template)
+	{
+		ListenerTemplate = X2EventListenerTemplate(Template);
+		if(ListenerTemplate.RegisterInTactical)
+		{
+			ListenerTemplate.RegisterForEvents();
+		}
+	}
+}
+
+static function RegisterStrategyListeners()
+{
+	local X2EventListenerTemplate ListenerTemplate;
+	local X2DataTemplate Template;
+
+	// unregister any previously registered templates
+	UnRegisterAllListeners();
+
+	foreach GetEventListenerTemplateManager().IterateTemplates(Template)
+	{
+		ListenerTemplate = X2EventListenerTemplate(Template);
+		if(ListenerTemplate.RegisterInStrategy)
+		{
+			ListenerTemplate.RegisterForEvents();
+		}
+	}
+}
+
+static function UnRegisterAllListeners()
+{
+	local X2EventListenerTemplate ListenerTemplate;
+	local X2DataTemplate Template;
+
+	foreach GetEventListenerTemplateManager().IterateTemplates(Template)
+	{
+		ListenerTemplate = X2EventListenerTemplate(Template);
+		ListenerTemplate.UnRegisterFromEvents();
+	}
+}
+
+defaultproperties
+{
+	TemplateDefinitionClass=class'X2EventListener'
+}

--- a/X2WOTCCommunityHighlander/Src/XComGame/Classes/X2EventListenerTemplateManager.uc
+++ b/X2WOTCCommunityHighlander/Src/XComGame/Classes/X2EventListenerTemplateManager.uc
@@ -59,6 +59,28 @@ static function RegisterStrategyListeners()
 	}
 }
 
+// Start Issue #869
+//
+// Registers CHL event listeners that are configured to listen for
+// events during a new campaign start.
+static function RegisterCampaignStartListeners()
+{
+	local CHEventListenerTemplate ListenerTemplate;
+	local X2DataTemplate Template;
+
+	UnRegisterAllListeners();
+
+	foreach GetEventListenerTemplateManager().IterateTemplates(Template)
+	{
+		ListenerTemplate = CHEventListenerTemplate(Template);
+		if (ListenerTemplate != none && ListenerTemplate.RegisterInCampaignStart)
+		{
+			ListenerTemplate.RegisterForEvents();
+		}
+	}
+}
+// End Issue #869
+
 static function UnRegisterAllListeners()
 {
 	local X2EventListenerTemplate ListenerTemplate;

--- a/X2WOTCCommunityHighlander/Src/XComGame/Classes/XComGameStateContext_StrategyGameRule.uc
+++ b/X2WOTCCommunityHighlander/Src/XComGame/Classes/XComGameStateContext_StrategyGameRule.uc
@@ -135,6 +135,13 @@ static function XComGameState CreateStrategyGameStart(
 		LocalGameEngine.SetRandomSeeds(Seed);
 	}
 
+	// Start Issue #869
+	//
+	// Register campaign-start listeners after the start state has been created
+	// but before any campaign initialization has occurred.
+	class'X2EventListenerTemplateManager'.static.RegisterCampaignStartListeners();
+	// End Issue #869
+
 	//Create start time
 	class'XComGameState_GameTime'.static.CreateGameStartTime(StartState);
 

--- a/X2WOTCCommunityHighlander/X2WOTCCommunityHighlander.x2proj
+++ b/X2WOTCCommunityHighlander/X2WOTCCommunityHighlander.x2proj
@@ -667,6 +667,9 @@
     <Content Include="Src\XComGame\Classes\X2EventListenerTemplate.uc">
       <SubType>Content</SubType>
     </Content>
+    <Content Include="Src\XComGame\Classes\X2EventListenerTemplateManager.uc">
+      <SubType>Content</SubType>
+    </Content>
     <Content Include="Src/XComGame/Classes/X2StrategyElement_DefaultStaffSlots.uc">
       <Subtype>Content</Subtype>
     </Content>


### PR DESCRIPTION
This change adds an extra `RegisterInCampaignStart` boolean to CHL event listener templates (on top of the existing `RegisterInTactical` and `RegisterInStrategy` ones). Listeners registered for campaign start will now receive events that are fired during campaign initialization, which strategy listeners don't receive.

Resolves #869.
