### PR TITLE
Fix smoke and poison grenade targeting and effects

### DIFF
--- a/X2WOTCCommunityHighlander/Config/XComGame.ini
+++ b/X2WOTCCommunityHighlander/Config/XComGame.ini
@@ -35,6 +35,19 @@ bEnableVersionDisplay=true
 ;;; HL-Docs: ref:UnrestrictPsiPCS
 +ClassesAllowPsiPCS="PsiOperative"
 
+;;; HL-Docs: ref:DisableExtraLOSCheckForSmoke; issue:669
+; DisableExtraLOSCheckForSmoke=true
+
+;;; HL-Docs: ref:DisableExtraLOSCheckForPoison; issue:669
+; DisableExtraLOSCheckForPoison=true
+
+;;; HL-Docs: ref:GrenadesRequiringUnitsOnTargetedTiles; issue:669
+; An array of grenade template names for which only units actually on
+; painted tiles should be affected by that grenade. Main example is
+; smoke, since only units on smoked tiles should get the effect.
+; +GrenadesRequiringUnitsOnTargetedTiles=SmokeGrenade
+; +GrenadesRequiringUnitsOnTargetedTiles=SmokeGrenadeMk2
+
 ;;; HL-Docs: ref:RequiresTargetingActivation
 +RequiresTargetingActivation=X2TargetingMethod_Grenade
 +RequiresTargetingActivation=X2TargetingMethod_Cone

--- a/X2WOTCCommunityHighlander/Src/XComGame/Classes/CHHelpers.uc
+++ b/X2WOTCCommunityHighlander/Src/XComGame/Classes/CHHelpers.uc
@@ -196,6 +196,25 @@ var config name PlaceEvacZoneAbilityName;
 // Variable for Issue #854
 var config float CameraRotationAngle;
 
+// Start Issue #669
+//
+/// HL-Docs: feature:GrenadesRequiringUnitsOnTargetedTiles; issue:669; tags:tactical
+/// An array of grenade template names for which only units actually on
+/// painted tiles should be affected by that grenade. Main example is
+/// smoke, since only units on smoked tiles should get the effect.
+var config array<name> GrenadesRequiringUnitsOnTargetedTiles;
+
+/// HL-Docs: feature:DisableExtraLOSCheckForSmoke; issue:669; tags:tactical
+/// When true, this option fixes smoke so that it applies to all tiles that
+/// are highlighted in targeting (as per the Reliable Smoke mod).
+var config bool DisableExtraLOSCheckForSmoke;
+
+/// HL-Docs: feature:DisableExtraLOSCheckForPoison; issue:669; tags:tactical
+/// When true, this option fixes poison so that clouds of it apply to all
+/// tiles that are highlighted in targeting.
+var config bool DisableExtraLOSCheckForPoison;
+// End Issue #669
+
 // Start Issue #885
 enum EHLDelegateReturn
 {

--- a/X2WOTCCommunityHighlander/Src/XComGame/Classes/X2Effect_ApplyPoisonToWorld.uc
+++ b/X2WOTCCommunityHighlander/Src/XComGame/Classes/X2Effect_ApplyPoisonToWorld.uc
@@ -1,0 +1,92 @@
+//---------------------------------------------------------------------------------------
+//  FILE:    X2Effect_ApplyPoisonToWorld.uc
+//  AUTHOR:  Ryan McFall
+//           
+//---------------------------------------------------------------------------------------
+//  Copyright (c) 2016 Firaxis Games, Inc. All rights reserved.
+//---------------------------------------------------------------------------------------
+class X2Effect_ApplyPoisonToWorld extends X2Effect_World 
+	config(GameData) 
+	native(Core);
+
+var config string PoisonParticleSystemFill_Name;
+var config int Duration;
+
+// Called from native code to get a list of effects to apply, as well as by the effect system based on EffectRefs
+event array<X2Effect> GetTileEnteredEffects()
+{
+	local array<X2Effect> TileEnteredEffectsUncached;
+
+	TileEnteredEffectsUncached.AddItem(class'X2StatusEffects'.static.CreatePoisonedStatusEffect());
+
+	return TileEnteredEffectsUncached;
+}
+
+simulated protected function OnEffectAdded(const out EffectAppliedData ApplyEffectParameters, XComGameState_BaseObject kNewTargetState, XComGameState NewGameState, XComGameState_Effect NewEffectState)
+{
+}
+
+event array<ParticleSystem> GetParticleSystem_Fill()
+{
+	local array<ParticleSystem> ParticleSystems;
+	ParticleSystems.AddItem( none );
+	ParticleSystems.AddItem(ParticleSystem(DynamicLoadObject(PoisonParticleSystemFill_Name, class'ParticleSystem')));
+	return ParticleSystems;
+}
+
+simulated function AddX2ActionsForVisualization(XComGameState VisualizeGameState, out VisualizationActionMetadata ActionMetadata, name EffectApplyResult)
+{
+	local X2Action_UpdateWorldEffects_Poison AddPoisonAction;
+	if( ActionMetadata.StateObject_NewState.IsA('XComGameState_WorldEffectTileData') )
+	{
+		AddPoisonAction = X2Action_UpdateWorldEffects_Poison(class'X2Action_UpdateWorldEffects_Poison'.static.AddToVisualizationTree(ActionMetadata, VisualizeGameState.GetContext(), false, ActionMetadata.LastActionAdded));
+		AddPoisonAction.bCenterTile = bCenterTile;
+		AddPoisonAction.SetParticleSystems(GetParticleSystem_Fill());
+	}
+}
+
+simulated function AddX2ActionsForVisualization_Tick(XComGameState VisualizeGameState, out VisualizationActionMetadata ActionMetadata, const int TickIndex, XComGameState_Effect EffectState)
+{
+}
+
+static simulated function bool FillRequiresLOSToTargetLocation( ) { return true; }
+static simulated function int GetTileDataDynamicFlagValue() { return 16; }  //TileDataContainsPoison
+
+static simulated event AddEffectToTiles(Name EffectName, X2Effect_World Effect, XComGameState NewGameState, array<TilePosPair> Tiles, vector TargetLocation, float Radius, float Coverage, optional XComGameState_Unit SourceStateObject = none, optional XComGameState_Item SourceWeaponState = none, optional bool bUseFireChance)
+{
+	local XComGameState_WorldEffectTileData GameplayTileUpdate;
+	local array<TileIsland> TileIslands;
+	local array<TileParticleInfo> TileParticleInfos;
+	local VolumeEffectTileData InitialTileData;
+
+	GameplayTileUpdate = XComGameState_WorldEffectTileData(NewGameState.CreateNewStateObject(class'XComGameState_WorldEffectTileData'));
+	GameplayTileUpdate.WorldEffectClassName = EffectName;
+
+	InitialTileData.EffectName = EffectName;
+	InitialTileData.NumTurns = GetTileDataNumTurns();
+	InitialTileData.DynamicFlagUpdateValue = GetTileDataDynamicFlagValue();
+	if( SourceStateObject != none )
+		InitialTileData.SourceStateObjectID = SourceStateObject.ObjectID;
+	if( SourceWeaponState != none )
+		InitialTileData.ItemStateObjectID = SourceWeaponState.ObjectID;
+
+	FilterForLOS( Tiles, TargetLocation, Radius );
+
+	TileIslands = CollapseTilesToPools(Tiles);
+	DetermineFireBlocks(TileIslands, Tiles, TileParticleInfos);
+
+	GameplayTileUpdate.SetInitialTileData(Tiles, InitialTileData, TileParticleInfos);
+
+	`XEVENTMGR.TriggerEvent('GameplayTileEffectUpdate', GameplayTileUpdate, SourceStateObject, NewGameState);
+}
+
+static simulated function int GetTileDataNumTurns() 
+{ 
+	return default.Duration; 
+}
+
+defaultproperties
+{
+	bCenterTile = false;
+	DamageTypes.Add("Poison");
+}

--- a/X2WOTCCommunityHighlander/Src/XComGame/Classes/X2Effect_ApplyPoisonToWorld.uc
+++ b/X2WOTCCommunityHighlander/Src/XComGame/Classes/X2Effect_ApplyPoisonToWorld.uc
@@ -49,7 +49,7 @@ simulated function AddX2ActionsForVisualization_Tick(XComGameState VisualizeGame
 {
 }
 
-static simulated function bool FillRequiresLOSToTargetLocation( ) { return true; }
+static simulated function bool FillRequiresLOSToTargetLocation( ) { return !class'CHHelpers'.default.DisableExtraLOSCheckForPoison; /* Issue #669 */ }
 static simulated function int GetTileDataDynamicFlagValue() { return 16; }  //TileDataContainsPoison
 
 static simulated event AddEffectToTiles(Name EffectName, X2Effect_World Effect, XComGameState NewGameState, array<TilePosPair> Tiles, vector TargetLocation, float Radius, float Coverage, optional XComGameState_Unit SourceStateObject = none, optional XComGameState_Item SourceWeaponState = none, optional bool bUseFireChance)

--- a/X2WOTCCommunityHighlander/Src/XComGame/Classes/X2Effect_ApplySmokeGrenadeToWorld.uc
+++ b/X2WOTCCommunityHighlander/Src/XComGame/Classes/X2Effect_ApplySmokeGrenadeToWorld.uc
@@ -1,0 +1,57 @@
+//---------------------------------------------------------------------------------------
+//  FILE:    X2Effect_ApplySmokeGrenadeToWorld.uc
+//  AUTHOR:  Joshua Bouscher
+//           
+//---------------------------------------------------------------------------------------
+//  Copyright (c) 2016 Firaxis Games, Inc. All rights reserved.
+//---------------------------------------------------------------------------------------
+class X2Effect_ApplySmokeGrenadeToWorld extends X2Effect_World config(GameData);
+
+var config string SmokeParticleSystemFill_Name;
+var config int Duration;
+
+simulated protected function OnEffectAdded(const out EffectAppliedData ApplyEffectParameters, XComGameState_BaseObject kNewTargetState, XComGameState NewGameState, XComGameState_Effect NewEffectState)
+{
+}
+
+event array<X2Effect> GetTileEnteredEffects()
+{
+	local array<X2Effect> TileEnteredEffects;
+	TileEnteredEffects.AddItem(class'X2Item_DefaultGrenades'.static.SmokeGrenadeEffect());
+	return TileEnteredEffects;
+}
+
+event array<ParticleSystem> GetParticleSystem_Fill()
+{
+	local array<ParticleSystem> ParticleSystems;
+	ParticleSystems.AddItem(none);
+	ParticleSystems.AddItem(ParticleSystem(DynamicLoadObject(SmokeParticleSystemFill_Name, class'ParticleSystem')));
+	return ParticleSystems;
+}
+
+simulated function AddX2ActionsForVisualization(XComGameState VisualizeGameState, out VisualizationActionMetadata ActionMetadata, name EffectApplyResult)
+{
+	local X2Action_UpdateWorldEffects_Smoke AddSmokeAction;
+	if( ActionMetadata.StateObject_NewState.IsA('XComGameState_WorldEffectTileData') )
+	{
+		AddSmokeAction = X2Action_UpdateWorldEffects_Smoke(class'X2Action_UpdateWorldEffects_Smoke'.static.AddToVisualizationTree(ActionMetadata, VisualizeGameState.GetContext(), false, ActionMetadata.LastActionAdded));
+		AddSmokeAction.bCenterTile = bCenterTile;
+		AddSmokeAction.SetParticleSystems(GetParticleSystem_Fill());
+	}
+}
+
+simulated function AddX2ActionsForVisualization_Tick(XComGameState VisualizeGameState, out VisualizationActionMetadata ActionMetadata, const int TickIndex, XComGameState_Effect EffectState)
+{
+}
+
+static simulated function bool FillRequiresLOSToTargetLocation( ) { return true; }
+
+static simulated function int GetTileDataNumTurns() 
+{ 
+	return default.Duration; 
+}
+
+defaultproperties
+{
+	bCenterTile = true;
+}

--- a/X2WOTCCommunityHighlander/Src/XComGame/Classes/X2Effect_ApplySmokeGrenadeToWorld.uc
+++ b/X2WOTCCommunityHighlander/Src/XComGame/Classes/X2Effect_ApplySmokeGrenadeToWorld.uc
@@ -44,7 +44,7 @@ simulated function AddX2ActionsForVisualization_Tick(XComGameState VisualizeGame
 {
 }
 
-static simulated function bool FillRequiresLOSToTargetLocation( ) { return true; }
+static simulated function bool FillRequiresLOSToTargetLocation( ) { return !class'CHHelpers'.default.DisableExtraLOSCheckForSmoke; /* Issue #669 */ }
 
 static simulated function int GetTileDataNumTurns() 
 { 

--- a/X2WOTCCommunityHighlander/Src/XComGame/Classes/X2Effect_ApplySmokeToWorld.uc
+++ b/X2WOTCCommunityHighlander/Src/XComGame/Classes/X2Effect_ApplySmokeToWorld.uc
@@ -1,0 +1,40 @@
+//---------------------------------------------------------------------------------------
+//  FILE:    X2Effect_ApplySmokeToWorld.uc
+//  AUTHOR:  Ryan McFall
+//           
+//---------------------------------------------------------------------------------------
+//  Copyright (c) 2016 Firaxis Games, Inc. All rights reserved.
+//---------------------------------------------------------------------------------------
+class X2Effect_ApplySmokeToWorld extends X2Effect_World config(GameData);
+
+var config string SmokeParticleSystemFill_Name;
+
+simulated protected function OnEffectAdded(const out EffectAppliedData ApplyEffectParameters, XComGameState_BaseObject kNewTargetState, XComGameState NewGameState, XComGameState_Effect NewEffectState)
+{
+}
+
+event array<ParticleSystem> GetParticleSystem_Fill()
+{
+	local array<ParticleSystem> ParticleSystems;
+	ParticleSystems.AddItem(none);
+	ParticleSystems.AddItem(ParticleSystem(DynamicLoadObject(SmokeParticleSystemFill_Name, class'ParticleSystem')));
+	return ParticleSystems;
+}
+
+static simulated function int GetTileDataDynamicFlagValue() { return 8; }  //TileDataContainsSmoke
+
+simulated function AddX2ActionsForVisualization(XComGameState VisualizeGameState, out VisualizationActionMetadata ActionMetadata, name EffectApplyResult)
+{
+	local X2Action_UpdateWorldEffects_Smoke AddSmokeAction;
+	if( ActionMetadata.StateObject_NewState.IsA('XComGameState_WorldEffectTileData') )
+	{
+		AddSmokeAction = X2Action_UpdateWorldEffects_Smoke(class'X2Action_UpdateWorldEffects_Smoke'.static.AddToVisualizationTree(ActionMetadata, VisualizeGameState.GetContext(), false, ActionMetadata.LastActionAdded));
+		AddSmokeAction.SetParticleSystems(GetParticleSystem_Fill());
+	}
+}
+
+simulated function AddX2ActionsForVisualization_Tick(XComGameState VisualizeGameState, out VisualizationActionMetadata ActionMetadata, const int TickIndex, XComGameState_Effect EffectState)
+{
+}
+
+static simulated function bool FillRequiresLOSToTargetLocation( ) { return true; }

--- a/X2WOTCCommunityHighlander/Src/XComGame/Classes/X2Effect_ApplySmokeToWorld.uc
+++ b/X2WOTCCommunityHighlander/Src/XComGame/Classes/X2Effect_ApplySmokeToWorld.uc
@@ -37,4 +37,4 @@ simulated function AddX2ActionsForVisualization_Tick(XComGameState VisualizeGame
 {
 }
 
-static simulated function bool FillRequiresLOSToTargetLocation( ) { return true; }
+static simulated function bool FillRequiresLOSToTargetLocation( ) { return !class'CHHelpers'.default.DisableExtraLOSCheckForSmoke; /* Issue #669 */ }

--- a/X2WOTCCommunityHighlander/Src/XComGame/Classes/X2TargetingMethod_Grenade.uc
+++ b/X2WOTCCommunityHighlander/Src/XComGame/Classes/X2TargetingMethod_Grenade.uc
@@ -1,0 +1,285 @@
+//---------------------------------------------------------------------------------------
+//  FILE:    X2TargetingMethod_Grenade.uc
+//  AUTHOR:  David Burchanowski  --  8/04/2014
+//  PURPOSE: Targeting method for throwing grenades and other such bouncy objects
+//           
+//---------------------------------------------------------------------------------------
+//  Copyright (c) 2016 Firaxis Games, Inc. All rights reserved.
+//---------------------------------------------------------------------------------------
+
+class X2TargetingMethod_Grenade extends X2TargetingMethod
+	native(Core);
+
+var protected XCom3DCursor Cursor;
+var protected XComPrecomputedPath GrenadePath;
+var protected transient XComEmitter ExplosionEmitter;
+var protected bool bRestrictToSquadsightRange;
+var protected XComGameState_Player AssociatedPlayerState;
+
+var bool SnapToTile;
+
+function Init(AvailableAction InAction, int NewTargetIndex)
+{
+	local XComGameStateHistory History;
+	local XComWeapon WeaponEntity;
+	local PrecomputedPathData WeaponPrecomputedPathData;
+	local float TargetingRange;
+	local X2AbilityTarget_Cursor CursorTarget;
+	local X2AbilityTemplate AbilityTemplate;
+
+	super.Init(InAction, NewTargetIndex);
+
+	History = `XCOMHISTORY;
+
+	AssociatedPlayerState = XComGameState_Player(History.GetGameStateForObjectID(UnitState.ControllingPlayer.ObjectID));
+	`assert(AssociatedPlayerState != none);
+
+	// determine our targeting range
+	AbilityTemplate = Ability.GetMyTemplate();
+	TargetingRange = Ability.GetAbilityCursorRangeMeters();
+
+	// lock the cursor to that range
+	Cursor = `Cursor;
+	Cursor.m_fMaxChainedDistance = `METERSTOUNITS(TargetingRange);
+
+	// set the cursor location to itself to make sure the chain distance updates
+	Cursor.CursorSetLocation(Cursor.GetCursorFeetLocation(), false, true); 
+
+	CursorTarget = X2AbilityTarget_Cursor(Ability.GetMyTemplate().AbilityTargetStyle);
+	if (CursorTarget != none)
+		bRestrictToSquadsightRange = CursorTarget.bRestrictToSquadsightRange;
+
+	GetGrenadeWeaponInfo(WeaponEntity, WeaponPrecomputedPathData);
+	// Tutorial Band-aid #2 - Should look at a proper fix for this
+	if (WeaponEntity.m_kPawn == none)
+	{
+		WeaponEntity.m_kPawn = FiringUnit.GetPawn();
+	}
+
+	if (UseGrenadePath())
+	{
+		GrenadePath = `PRECOMPUTEDPATH;
+		GrenadePath.ClearOverrideTargetLocation(); // Clear this flag in case the grenade target location was locked.
+		GrenadePath.ActivatePath(WeaponEntity, FiringUnit.GetTeam(), WeaponPrecomputedPathData);
+		if( X2TargetingMethod_MECMicroMissile(self) != none )
+		{
+			//Explicit firing socket name for the Micro Missile, which is defaulted to gun_fire
+			GrenadePath.SetFiringFromSocketPosition(name("gun_fire"));
+		}
+	}	
+
+	if (!AbilityTemplate.SkipRenderOfTargetingTemplate)
+	{
+		// setup the blast emitter
+		ExplosionEmitter = `BATTLE.spawn(class'XComEmitter');
+		if(AbilityIsOffensive)
+		{
+			ExplosionEmitter.SetTemplate(ParticleSystem(DynamicLoadObject("UI_Range.Particles.BlastRadius_Shpere", class'ParticleSystem')));
+		}
+		else
+		{
+			ExplosionEmitter.SetTemplate(ParticleSystem(DynamicLoadObject("UI_Range.Particles.BlastRadius_Shpere_Neutral", class'ParticleSystem')));
+		}
+		
+		ExplosionEmitter.LifeSpan = 60 * 60 * 24 * 7; // never die (or at least take a week to do so)
+	}
+}
+
+function GetGrenadeWeaponInfo(out XComWeapon WeaponEntity, out PrecomputedPathData WeaponPrecomputedPathData)
+{
+	local XComGameState_Item WeaponItem;
+	local X2WeaponTemplate WeaponTemplate;
+	local XGWeapon WeaponVisualizer;
+
+	WeaponItem = Ability.GetSourceWeapon();
+	WeaponTemplate = X2WeaponTemplate(WeaponItem.GetMyTemplate());
+	WeaponVisualizer = XGWeapon(WeaponItem.GetVisualizer());
+
+	// Tutorial Band-aid fix for missing visualizer due to cheat GiveItem
+	if (WeaponVisualizer == none)
+	{
+		class'XGItem'.static.CreateVisualizer(WeaponItem);
+		WeaponVisualizer = XGWeapon(WeaponItem.GetVisualizer());
+		WeaponEntity = XComWeapon(WeaponVisualizer.CreateEntity(WeaponItem));
+
+		if (WeaponEntity != none)
+		{
+			WeaponEntity.m_kPawn = FiringUnit.GetPawn();
+		}
+	}
+	else
+	{
+		WeaponEntity = WeaponVisualizer.GetEntity();
+	}
+
+	WeaponPrecomputedPathData = WeaponTemplate.WeaponPrecomputedPathData;
+}
+
+function Canceled()
+{
+	super.Canceled();
+
+	// unlock the 3d cursor
+	Cursor.m_fMaxChainedDistance = -1;
+
+	// clean up the ui
+	ExplosionEmitter.Destroy();
+	if (UseGrenadePath())
+	{
+		GrenadePath.ClearPathGraphics();
+	}	
+	ClearTargetedActors();
+}
+
+function Committed()
+{
+	Canceled();
+}
+
+simulated protected function Vector GetSplashRadiusCenter( bool SkipTileSnap = false )
+{
+	local vector Center;
+	local TTile SnapTile;
+
+	if (UseGrenadePath())
+		Center = GrenadePath.GetEndPosition();
+	else
+		Center = Cursor.GetCursorFeetLocation();
+
+	if (SnapToTile && !SkipTileSnap)
+	{
+		SnapTile = `XWORLD.GetTileCoordinatesFromPosition( Center );
+		
+		// keep moving down until we find a floor tile.
+		while ((SnapTile.Z >= 0) && !`XWORLD.GetFloorPositionForTile( SnapTile, Center ))
+		{
+			--SnapTile.Z;
+		}
+	}
+
+	return Center;
+}
+
+simulated protected function DrawSplashRadius()
+{
+	local Vector Center;
+	local float Radius;
+	local LinearColor CylinderColor;
+
+	Center = GetSplashRadiusCenter( true );
+
+	Radius = Ability.GetAbilityRadius();
+	
+	/*
+	if (!bValid || (m_bTargetMustBeWithinCursorRange && (fTest >= fRestrictedRange) )) {
+		CylinderColor = MakeLinearColor(1, 0.2, 0.2, 0.2);
+	} else if (m_iSplashHitsFriendliesCache > 0 || m_iSplashHitsFriendlyDestructibleCache > 0) {
+		CylinderColor = MakeLinearColor(1, 0.81, 0.22, 0.2);
+	} else {
+		CylinderColor = MakeLinearColor(0.2, 0.8, 1, 0.2);
+	}
+	*/
+
+	if( (ExplosionEmitter != none) && (Center != ExplosionEmitter.Location))
+	{
+		ExplosionEmitter.SetLocation(Center); // Set initial location of emitter
+		ExplosionEmitter.SetDrawScale(Radius / 48.0f);
+		ExplosionEmitter.SetRotation( rot(0,0,1) );
+
+		if( !ExplosionEmitter.ParticleSystemComponent.bIsActive )
+		{
+			ExplosionEmitter.ParticleSystemComponent.ActivateSystem();			
+		}
+
+		ExplosionEmitter.ParticleSystemComponent.SetMICVectorParameter(0, Name("RadiusColor"), CylinderColor);
+		ExplosionEmitter.ParticleSystemComponent.SetMICVectorParameter(1, Name("RadiusColor"), CylinderColor);
+	}
+}
+
+function Update(float DeltaTime)
+{
+	local array<Actor> CurrentlyMarkedTargets;
+	local vector NewTargetLocation;
+	local array<TTile> Tiles;
+
+	NewTargetLocation = GetSplashRadiusCenter();
+
+	if(NewTargetLocation != CachedTargetLocation)
+	{		
+		GetTargetedActors(NewTargetLocation, CurrentlyMarkedTargets, Tiles);
+		CheckForFriendlyUnit(CurrentlyMarkedTargets);	
+		MarkTargetedActors(CurrentlyMarkedTargets, (!AbilityIsOffensive) ? FiringUnit.GetTeam() : eTeam_None );
+		DrawAOETiles(Tiles);
+	}
+	DrawSplashRadius( );
+
+	super.Update(DeltaTime);
+}
+
+function GetTargetLocations(out array<Vector> TargetLocations)
+{
+	TargetLocations.Length = 0;
+	TargetLocations.AddItem(GetSplashRadiusCenter());
+}
+
+function name ValidateTargetLocations(const array<Vector> TargetLocations)
+{
+	local TTile TestLoc;
+	if (TargetLocations.Length == 1)
+	{
+		if (bRestrictToSquadsightRange)
+		{
+			TestLoc = `XWORLD.GetTileCoordinatesFromPosition(TargetLocations[0]);
+			if (!class'X2TacticalVisibilityHelpers'.static.CanSquadSeeLocation(AssociatedPlayerState.ObjectID, TestLoc))
+				return 'AA_NotVisible';
+		}
+		return 'AA_Success';
+	}
+	return 'AA_NoTargets';
+}
+
+function int GetTargetIndex()
+{
+	return 0;
+}
+
+function bool GetAdditionalTargets(out AvailableTarget AdditionalTargets)
+{
+	Ability.GatherAdditionalAbilityTargetsForLocation(GetSplashRadiusCenter(), AdditionalTargets);
+	return true;
+}
+
+function bool GetCurrentTargetFocus(out Vector Focus)
+{
+	Focus = GetSplashRadiusCenter();
+	return true;
+}
+
+static function bool UseGrenadePath() { return true; }
+
+static function name GetProjectileTimingStyle()
+{
+	if( UseGrenadePath() )
+	{
+		return default.ProjectileTimingStyle;
+	}
+
+	return '';
+}
+
+static function name GetOrdnanceType()
+{
+	if( UseGrenadePath() )
+	{
+		return default.OrdnanceTypeName;
+	}
+
+	return '';
+}
+
+defaultproperties
+{
+	SnapToTile = true;
+	ProjectileTimingStyle="Timing_Grenade"
+	OrdnanceTypeName="Ordnance_Grenade"
+}

--- a/X2WOTCCommunityHighlander/X2WOTCCommunityHighlander.x2proj
+++ b/X2WOTCCommunityHighlander/X2WOTCCommunityHighlander.x2proj
@@ -415,6 +415,15 @@
     <Content Include="Src\XComGame\Classes\X2Action_Death.uc">
       <SubType>Content</SubType>
     </Content>
+    <Content Include="Src\XComGame\Classes\X2Effect_ApplyPoisonToWorld.uc">
+      <SubType>Content</SubType>
+    </Content>
+    <Content Include="Src\XComGame\Classes\X2Effect_ApplySmokeGrenadeToWorld.uc">
+      <SubType>Content</SubType>
+    </Content>
+    <Content Include="Src\XComGame\Classes\X2Effect_ApplySmokeToWorld.uc">
+      <SubType>Content</SubType>
+    </Content>
     <Content Include="Src\XComGame\Classes\X2Effect_ApplyWeaponDamage.uc">
       <SubType>Content</SubType>
     </Content>
@@ -503,6 +512,9 @@
       <SubType>Content</SubType>
     </Content>
     <Content Include="Src\XComGame\Classes\X2TargetingMethod_EvacZone.uc">
+      <SubType>Content</SubType>
+    </Content>
+    <Content Include="Src\XComGame\Classes\X2TargetingMethod_Grenade.uc">
       <SubType>Content</SubType>
     </Content>
     <Content Include="Src\XComGame\Classes\X2TargetingMethod_MeleePath.uc">


### PR DESCRIPTION
Grenades that apply effects to the world, such as smoke grenades, are unreliable in their targeting because those effects are not always applied to tiles that are highlighted by targeting. This change adds two boolean config vars that, when true, fix that so that smoke and/or poison are applied to all the highlighted tiles.

In addition, there are some instances where the targeting will highlight units without highlighting the tiles that they're on. This gives the impression that those units will be affected by the world effects (like smoke) when they won't. This changes adds a config array of grenade names, where any grenade in that array will not highlight units unless they are on highlighted tiles. Smoke grenades and bombs are the main candidates for this array, but mods may add other types.

Resolves #669
