### PR TITLE
Allow mods to update strategy-map nav help (#932)

### DIFF
--- a/X2WOTCCommunityHighlander/Src/XComGame/Classes/UIStrategyMap.uc
+++ b/X2WOTCCommunityHighlander/Src/XComGame/Classes/UIStrategyMap.uc
@@ -707,7 +707,7 @@ simulated function UpdateButtonHelp()
 	/// ```event
 	/// EventID: StrategyMap_NavHelpUpdated,
 	/// EventData: UINavigationHelp,
-	/// EventSource: UIStrategyMap (self),
+	/// EventSource: UIStrategyMap (StrategyMap),
 	/// NewGameState: none
 	/// ```
 	// This event is modeled on the 'UIArmory_WeaponUpgrade_NavHelpUpdated' event.

--- a/X2WOTCCommunityHighlander/Src/XComGame/Classes/UIStrategyMap.uc
+++ b/X2WOTCCommunityHighlander/Src/XComGame/Classes/UIStrategyMap.uc
@@ -698,7 +698,23 @@ simulated function UpdateButtonHelp()
 			}
 		}
 	}
+
+	// Start Issue #932
+	/// HL-Docs: feature:StrategyMap_NavHelpUpdated; issue:932;tags:strategy,ui
+	/// This event is fired after the base game has performed its own updates to
+	/// the nav help on the Geoscape (StrategyMap), allowing mods to make further
+	/// changes if they wish.
+	/// ```event
+	/// EventID: StrategyMap_NavHelpUpdated,
+	/// EventData: UINavigationHelp,
+	/// EventSource: UIStrategyMap (self),
+	/// NewGameState: none
+	/// ```
+	// This event is modeled on the 'UIArmory_WeaponUpgrade_NavHelpUpdated' event.
+	`XEVENTMGR.TriggerEvent('StrategyMap_NavHelpUpdated', NavBar, self);
+	// End Issue #932
 }
+
 simulated function UpdateCenteredNavHelp()
 {
 	local int i, bgPadding, containerMargin, lineHeight, helpCount;


### PR DESCRIPTION
I have added a 'StrategyMap_NavHelpUpdated' event to the end of `UIStratgyMap.UpdateButtonHelp()` that allows mods to modify the nav help after the base game has done its thing.

The event takes the form:
```
EventID: StrategyMap_NavHelpUpdated,
EventData: UINavigationHelp,
EventSource: UIStrategyMap (self),
NewGameState: none
```

Resolves #932.