### PR TITLE
Reimplement issue #694

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -114,7 +114,6 @@ RunPriorityGroup=RUN_STANDARD
   meet the vanilla game's conditions for it (#633)
 - Triggers the event `OverrideNextRetaliationDisplay` to allow mods to customize and/or enable/disable "next retaliation"
   display in `UIAdventOperations` (#667)
-- Triggers the event `ItemAddedToSlot` & `ItemRemovedFromSlot` to allow mods to change Items that have been Equipped/Unequipped during runtime(#694)
 - Triggers the event `CovertAction_AllowResActivityRecord` to allow mods to enable/disable "covert action completed"
   record for the monthly resistance report (#696)
 - Triggers the event `OverrideDarkEventCount` to allow mods to change the number of dark events in the monthly report (#711)

--- a/X2WOTCCommunityHighlander/Src/XComGame/Classes/XComGameState_Unit.uc
+++ b/X2WOTCCommunityHighlander/Src/XComGame/Classes/XComGameState_Unit.uc
@@ -7895,6 +7895,22 @@ function bool AddItemToInventory(XComGameState_Item Item, EInventorySlot Slot, X
 			`XEVENTMGR.TriggerEvent('EffectBreakUnitConcealment', self, self, NewGameState);
 		}
 
+		// Start Issue #694
+		/// HL-Docs: feature:ItemAddedOrRemovedToSlot; issue:694; tags:
+		/// Triggers `ItemAddedToSlot` event when a unit adds an item to their inventory.
+		/// Triggers `ItemRemovedFromSlot` event when a unit removes an item from their inventory.
+		/// These events are perfect when relying on `X2ItemTemplate::OnEquippedFn` and `X2ItemTemplate::OnUnequippedFn` is not an option,
+		/// such as when you need to execute arbitrary code whenever any unit adds any item to their inventory.
+		///
+		/// ```event
+		/// EventID: ItemAddedToSlot,
+		/// EventData: XComGameState_Item,
+		/// EventSource: XComGameState_Unit,
+		/// NewGameState: yes
+		/// ```
+		`XEVENTMGR.TriggerEvent('ItemAddedToSlot', Item, self, NewGameState);
+		// End Issue #694
+
 		return true;
 	}
 	return false;
@@ -8260,6 +8276,18 @@ simulated function bool RemoveItemFromInventory(XComGameState_Item Item, optiona
 		}
 
 		Item.InventorySlot = eInvSlot_Unknown;
+
+		// Start Issue #694
+		/// HL-Docs: ref:ItemAddedOrRemovedToSlot
+		/// ```event
+		/// EventID: ItemRemovedFromSlot,
+		/// EventData: XComGameState_Item,
+		/// EventSource: XComGameState_Unit,
+		/// NewGameState: maybe
+		/// ```
+		`XEVENTMGR.TriggerEvent('ItemRemovedFromSlot', Item, self, ModifyGameState);
+		// End Issue #694
+
 		return true;
 	}
 	return false;


### PR DESCRIPTION
Implements issue #694, the PR for which was either accidentally reverted or never merged in the first place. 
Documented and tested to be working at least as far as logging equipped/unequipped items on units. 

I got confused a bit, `XCGS_Unit::RemoveItemFromInventory()` marks XComGameState as `optional`, even though I don't see anywhere in the code this function being called without giving it a game state, and I don't particularly understand how it would work anyway. Still, I marked the Game State in the event docs as `optional`, since it technically is.

Closes #694