### PR TITLE
Added speech personality config for TLP attitudes

### DIFF
--- a/X2WOTCCommunityHighlander/Config/XComGame.ini
+++ b/X2WOTCCommunityHighlander/Config/XComGame.ini
@@ -42,7 +42,9 @@ bEnableVersionDisplay=true
 +RequiresTargetingActivation=X2TargetingMethod_BlazingPinions
 +RequiresTargetingActivation=X2TargetingMethod_Grapple
 
-;Vanilla Personality Speech entries
+; Begin Issue #317
+;;; HL-Docs: ref:PersonalitySpeech
+; Vanilla Attitudes Personality Speech entries
 +PersonalitySpeech=( Personality="Personality_ByTheBook",	\\
 					CharSpeeches = (	\\
 						(CharSpeech="Moving", PersonalityVariant=("Moving_BY_THE_BOOK")),	\\
@@ -139,8 +141,7 @@ bEnableVersionDisplay=true
 						(CharSpeech="PickingUpBody", PersonalityVariant=("PickingUpBody_INTENSE"))	\\
 					))
 
-; Begin Issue #317
-; Add personality to TLP attitudes.
+; TLP Attitudes Personality Speech entries
 ; Angry
 +PersonalitySpeech=( Personality="Personality_TLE1",	\\
 					CharSpeeches = (	\\

--- a/X2WOTCCommunityHighlander/Config/XComGame.ini
+++ b/X2WOTCCommunityHighlander/Config/XComGame.ini
@@ -139,6 +139,94 @@ bEnableVersionDisplay=true
 						(CharSpeech="PickingUpBody", PersonalityVariant=("PickingUpBody_INTENSE"))	\\
 					))
 
+; Begin Issue #317
+; Add personality to TLP attitudes.
+; Angry
++PersonalitySpeech=( Personality="Personality_TLE1",	\\
+					CharSpeeches = (	\\
+						(CharSpeech="Moving", PersonalityVariant=("Moving_HARD_LUCK")),	\\
+						(CharSpeech="TargetKilled", PersonalityVariant=("TargetKilled_HARD_LUCK", "TargetKilled_INTENSE")),	\\
+						(CharSpeech="Panic", PersonalityVariant=("Panic_HARD_LUCK")),	\\
+						(CharSpeech="SoldierVIP", PersonalityVariant=("SoldierVIP_HARD_LUCK")),	\\
+						(CharSpeech="UsefulVIP", PersonalityVariant=("UsefulVIP_HARD_LUCK")),	\\
+						(CharSpeech="GenericVIP", PersonalityVariant=("GenericVIP_HARD_LUCK")),	\\
+						(CharSpeech="HostileVIP", PersonalityVariant=("HostileVIP_HARD_LUCK")),	\\
+						(CharSpeech="LootCaptured", PersonalityVariant=("LootCaptured_INTENSE")),	\\
+						(CharSpeech="HackWorkstation", PersonalityVariant=("HackWorkstation_HARD_LUCK")),	\\
+						(CharSpeech="LootSpotted", PersonalityVariant=("LootSpotted_HARD_LUCK")),	\\
+						(CharSpeech="TargetEliminated", PersonalityVariant=("TargetEliminated_HARD_LUCK")),	\\
+						(CharSpeech="PickingUpBody", PersonalityVariant=("PickingUpBody_HARD_LUCK"))	\\
+					))
+
+; Cocky
++PersonalitySpeech=( Personality="Personality_TLE2",	\\
+					CharSpeeches = (	\\
+						(CharSpeech="Moving", PersonalityVariant=("Moving_COLD", "Moving_LAID_BACK")),	\\
+						(CharSpeech="TargetKilled", PersonalityVariant=("TargetKilled_COLD")),	\\
+						(CharSpeech="Panic", PersonalityVariant=("Panic_COLD")),	\\
+						(CharSpeech="SoldierVIP", PersonalityVariant=("SoldierVIP_COLD")),	\\
+						(CharSpeech="UsefulVIP", PersonalityVariant=("UsefulVIP_COLD")),	\\
+						(CharSpeech="GenericVIP", PersonalityVariant=("GenericVIP_COLD")),	\\
+						(CharSpeech="HostileVIP", PersonalityVariant=("HostileVIP_COLD")),	\\
+						(CharSpeech="LootCaptured", PersonalityVariant=("LootCaptured_COLD")),	\\
+						(CharSpeech="HackWorkstation", PersonalityVariant=("HackWorkstation_COLD")),	\\
+						(CharSpeech="LootSpotted", PersonalityVariant=("LootSpotted_COLD")),	\\
+						(CharSpeech="TargetEliminated", PersonalityVariant=("TargetEliminated_COLD")),	\\
+						(CharSpeech="PickingUpBody", PersonalityVariant=("PickingUpBody_COLD"))	\\
+					))
+
+; Suspicious
++PersonalitySpeech=( Personality="Personality_TLE3",	\\
+					CharSpeeches = (	\\
+						(CharSpeech="Moving", PersonalityVariant=("Moving_TWITCHY")),	\\
+						(CharSpeech="TargetKilled", PersonalityVariant=("TargetKilled_TWITCHY")),	\\
+						(CharSpeech="Panic", PersonalityVariant=("Panic_TWITCHY")),	\\
+						(CharSpeech="SoldierVIP", PersonalityVariant=("SoldierVIP_TWITCHY")),	\\
+						(CharSpeech="UsefulVIP", PersonalityVariant=("UsefulVIP_TWITCHY")),	\\
+						(CharSpeech="GenericVIP", PersonalityVariant=("GenericVIP_TWITCHY")),	\\
+						(CharSpeech="HostileVIP", PersonalityVariant=("HostileVIP_TWITCHY")),	\\
+						(CharSpeech="LootCaptured", PersonalityVariant=("LootCaptured_TWITCHY")),	\\
+						(CharSpeech="HackWorkstation", PersonalityVariant=("HackWorkstation_TWITCHY")),	\\
+						(CharSpeech="LootSpotted", PersonalityVariant=("LootSpotted_TWITCHY")),	\\
+						(CharSpeech="TargetEliminated", PersonalityVariant=("TargetEliminated_TWITCHY")),	\\
+						(CharSpeech="PickingUpBody", PersonalityVariant=("PickingUpBody_TWITCHY"))	\\
+					))
+
+; Smug
++PersonalitySpeech=( Personality="Personality_TLE4",	\\
+					CharSpeeches = (	\\
+						(CharSpeech="Moving", PersonalityVariant=("Moving_LAID_BACK", "Moving_HAPPY_GO_LUCKY")),	\\
+						(CharSpeech="TargetKilled", PersonalityVariant=("TargetKilled_LAID_BACK", "TargetKilled_HAPPY_GO_LUCKY")),	\\
+						(CharSpeech="Panic", PersonalityVariant=("Panic_LAID_BACK")),	\\
+						(CharSpeech="SoldierVIP", PersonalityVariant=("SoldierVIP_LAID_BACK")),	\\
+						(CharSpeech="UsefulVIP", PersonalityVariant=("UsefulVIP_LAID_BACK")),	\\
+						(CharSpeech="GenericVIP", PersonalityVariant=("GenericVIP_LAID_BACK")),	\\
+						(CharSpeech="HostileVIP", PersonalityVariant=("HostileVIP_LAID_BACK")),	\\
+						(CharSpeech="LootCaptured", PersonalityVariant=("LootCaptured_LAID_BACK")),	\\
+						(CharSpeech="HackWorkstation", PersonalityVariant=("HackWorkstation_LAID_BACK")),	\\
+						(CharSpeech="LootSpotted", PersonalityVariant=("LootSpotted_LAID_BACK")),	\\
+						(CharSpeech="TargetEliminated", PersonalityVariant=("TargetEliminated_LAID_BACK")),	\\
+						(CharSpeech="PickingUpBody", PersonalityVariant=("PickingUpBody_LAID_BACK"))	\\
+					))
+
+; Let's Go
++PersonalitySpeech=( Personality="Personality_TLE5",	\\
+					CharSpeeches = (	\\
+						(CharSpeech="Moving", PersonalityVariant=("Moving_INTENSE")),	\\
+						(CharSpeech="TargetKilled", PersonalityVariant=("TargetKilled_INTENSE")),	\\
+						(CharSpeech="Panic", PersonalityVariant=("Panic_INTENSE")),	\\
+						(CharSpeech="SoldierVIP", PersonalityVariant=("SoldierVIP_INTENSE")),	\\
+						(CharSpeech="UsefulVIP", PersonalityVariant=("UsefulVIP_INTENSE")),	\\
+						(CharSpeech="GenericVIP", PersonalityVariant=("GenericVIP_INTENSE")),	\\
+						(CharSpeech="HostileVIP", PersonalityVariant=("HostileVIP_INTENSE")),	\\
+						(CharSpeech="LootCaptured", PersonalityVariant=("LootCaptured_HARD_LUCK")),	\\
+						(CharSpeech="HackWorkstation", PersonalityVariant=("HackWorkstation_INTENSE")),	\\
+						(CharSpeech="LootSpotted", PersonalityVariant=("LootSpotted_INTENSE")),	\\
+						(CharSpeech="TargetEliminated", PersonalityVariant=("TargetEliminated_INTENSE")),	\\
+						(CharSpeech="PickingUpBody", PersonalityVariant=("PickingUpBody_INTENSE"))	\\
+					))
+; End Issue #317
+
 ; Range (in meters) of the 'AlertedByYell' alert produced by fleeing civilians through the DoNoiseAlert action.
 +NoiseAlertSoundRange=27
 

--- a/X2WOTCCommunityHighlander/Src/XComGame/Classes/CHHelpers.uc
+++ b/X2WOTCCommunityHighlander/Src/XComGame/Classes/CHHelpers.uc
@@ -128,6 +128,7 @@ var config(Content) array<name> FlagMaterial;
 var config bool PreserveProxyUnitData;
 // End Issue #465
 // Start Issue #317
+/// HL-Docs: ref:PersonalitySpeech
 struct CharSpeachLookup
 {
 	var name CharSpeech;

--- a/X2WOTCCommunityHighlander/Src/XComGame/Classes/XGUnit.uc
+++ b/X2WOTCCommunityHighlander/Src/XComGame/Classes/XGUnit.uc
@@ -1502,6 +1502,40 @@ function name MaybeAddPersonalityToSpeech(Name nCharSpeech)
 
 	nPersonality = GameStateUnit.GetPersonalityTemplate().DataName;
 	// Start Issue #317
+	/// HL-Docs: feature:PersonalitySpeech; issue:317; tags:tactical,customization
+	/// The soldier speech system allows soldiers to use different voicelines
+	/// in some situations based on their attitude. For example, an "Intense" soldier 
+	/// will voice react differently to killing an enemy than a "Twitchy" one.
+	///
+	/// This behavior was hardcoded in the base game. Highlander replaces the original implementation
+	/// with the `PersonalitySpeech` config array that takes values from `XComGame.ini` config file.
+	/// This potentailly allows mods to replace the original personality speech patterns,
+	/// as well as add new patterns for new attitudes, if a mod manages to add any.
+	/// 
+	/// Example entry for the "By The Book" attitude:
+	///```ini
+	///[XComGame.CHHelpers]
+	///+PersonalitySpeech=( Personality="Personality_ByTheBook", \\
+	/// CharSpeeches = ( \\
+	///  (CharSpeech="Moving", PersonalityVariant=("Moving_BY_THE_BOOK")), \\
+	///  (CharSpeech="TargetKilled", PersonalityVariant=("TargetKilled_BY_THE_BOOK")), \\
+	///  (CharSpeech="Panic", PersonalityVariant=("Panic_BY_THE_BOOK")), \\
+	///  (CharSpeech="SoldierVIP", PersonalityVariant=("SoldierVIP_BY_THE_BOOK")), \\
+	///  (CharSpeech="UsefulVIP", PersonalityVariant=("UsefulVIP_BY_THE_BOOK")), \\
+	///  (CharSpeech="GenericVIP", PersonalityVariant=("GenericVIP_BY_THE_BOOK")), \\
+	///  (CharSpeech="HostileVIP", PersonalityVariant=("HostileVIP_BY_THE_BOOK")), \\
+	///  (CharSpeech="LootCaptured", PersonalityVariant=("LootCaptured_BY_THE_BOOK")), \\
+	///  (CharSpeech="HackWorkstation", PersonalityVariant=("HackWorkstation_BY_THE_BOOK")), \\
+	///  (CharSpeech="LootSpotted", PersonalityVariant=("LootSpotted_BY_THE_BOOK")), \\
+	///  (CharSpeech="TargetEliminated", PersonalityVariant=("TargetEliminated_BY_THE_BOOK")), \\
+	///  (CharSpeech="PickingUpBody", PersonalityVariant=("PickingUpBody_BY_THE_BOOK")) \\
+	/// ))
+	///```
+	/// Note: only one `PersonalitySpeech` entry per attitude will be taken into account, any others will be ignored.
+	/// If your mod wants to replace the original speech personality config with your own, 
+	/// you should copy the original entry to their own config exactly as it appears in the Highlander, 
+	/// and replace the `+` at the start of the entry with a `-`, which will remove the entry when your mod is loaded.
+	/// Then you can specify your own config entry for that attitude below.
 	Pidx=class'CHHelpers'.default.PersonalitySpeech.Find('Personality', nPersonality);
 	if (Pidx != INDEX_NONE)
 	{


### PR DESCRIPTION
Issue #317 was supposed to address the fact that TLP attitudes do not have any speech personality set up for them. 

PR #360 has replaced vanilla hard coded behavior with configurable one, but did not actually add any speech personality config for TLP attitudes. 

The [(WOTC+TLP) TLP Attitude Voice Fix](https://steamcommunity.com/sharedfiles/filedetails/?id=1547952490) mod MCOs `XGUnit` with more or less the same code as found in #360, and then adds some config for both vanilla and TLP attitudes. 

I propose to obsolete that mod by copying that mod's config to the CHL. I have already obtained permission of the mod author to do so. 

Closes #317