### PR TITLE
Add X2Condition mapping decorator and inverse condition

### DIFF
--- a/X2WOTCCommunityHighlander/Src/XComGame/Classes/X2Condition_MappingDecorator.uc
+++ b/X2WOTCCommunityHighlander/Src/XComGame/Classes/X2Condition_MappingDecorator.uc
@@ -35,12 +35,18 @@ private function name RemapCondition(const name OriginalCode)
 {
 	local int Index;
 
+	`LOG("Remapping Condition:" @ InnerCondition.Class.Name @ "original return code:" @ OriginalCode,, 'IRITEST');
+
 	Index = MappingDecorations.Find('OriginalCode', OriginalCode);
 
 	if (Index != INDEX_NONE)
 	{
+		`LOG("Found remapped code:" @ Index @ ":" @ MappingDecorations[Index].ReplacementCode,, 'IRITEST');
 		return MappingDecorations[Index].ReplacementCode;
 	}
+
+	`LOG("Did not find remapped code, defaulting to:" @ UnmappedCode == '' ? OriginalCode : UnmappedCode,, 'IRITEST');
+
 	return UnmappedCode == '' ? OriginalCode : UnmappedCode;
 }
 

--- a/X2WOTCCommunityHighlander/Src/XComGame/Classes/X2Condition_MappingDecorator.uc
+++ b/X2WOTCCommunityHighlander/Src/XComGame/Classes/X2Condition_MappingDecorator.uc
@@ -52,17 +52,17 @@ private function name RemapCondition(const name OriginalCode)
 
 event name CallMeetsCondition(XComGameState_BaseObject kTarget) 
 {
-	return RemapCondition(InnerCondition.CallMeetsCondition(kTarget));
+	return RemapCondition(InnerCondition.MeetsCondition(kTarget));
 }
 
 event name CallMeetsConditionWithSource(XComGameState_BaseObject kTarget, XComGameState_BaseObject kSource) 
 { 
-	return RemapCondition(InnerCondition.CallMeetsConditionWithSource(kTarget, kSource));
+	return RemapCondition(InnerCondition.MeetsConditionWithSource(kTarget, kSource));
 }
 
 event name CallAbilityMeetsCondition(XComGameState_Ability kAbility, XComGameState_BaseObject kTarget) 
 {
-	return RemapCondition(InnerCondition.CallAbilityMeetsCondition(kAbility, kTarget));
+	return RemapCondition(InnerCondition.AbilityMeetsCondition(kAbility, kTarget));
 }
 
 function bool CanEverBeValid(XComGameState_Unit SourceUnit, bool bStrategyCheck)

--- a/X2WOTCCommunityHighlander/Src/XComGame/Classes/X2Condition_MappingDecorator.uc
+++ b/X2WOTCCommunityHighlander/Src/XComGame/Classes/X2Condition_MappingDecorator.uc
@@ -1,0 +1,82 @@
+//---------------------------------------------------------------------------------------
+//  FILE:    X2Condition_MappingDecorator.uc
+//  AUTHOR:  X2CommunityCore
+//  PURPOSE: Remap return codes of a provided X2Condition.
+//---------------------------------------------------------------------------------------
+class X2Condition_MappingDecorator extends X2Condition;
+
+struct MappingDecorationStruct
+{
+	var name OriginalCode;
+	var name ReplacementCode;
+};
+
+var X2Condition InnerCondition;
+
+var bool bUseCanEverBeValid;
+var bool bReverseCanEverBeValid;
+
+// If specified, will be used as the default return code for return codes that do not have mapping decoration config.
+var name UnmappedCode;
+
+var array<MappingDecorationStruct> MappingDecorations;
+
+function AddMappingDecoration(const name OriginalCode, const name ReplacementCode)
+{
+	local MappingDecorationStruct NewMappingDecoration;
+
+	NewMappingDecoration.OriginalCode = OriginalCode;
+	NewMappingDecoration.ReplacementCode = ReplacementCode;
+
+	MappingDecorations.AddItem(NewMappingDecoration);
+}
+
+private function name RemapCondition(const name OriginalCode)
+{
+	local int Index;
+
+	Index = MappingDecorations.Find('OriginalCode', OriginalCode);
+
+	if (Index != INDEX_NONE)
+	{
+		return MappingDecorations[Index].ReplacementCode;
+	}
+	return UnmappedCode == '' ? OriginalCode : UnmappedCode;
+}
+
+event name CallMeetsCondition(XComGameState_BaseObject kTarget) 
+{
+	return RemapCondition(InnerCondition.CallMeetsCondition(kTarget));
+}
+
+event name CallMeetsConditionWithSource(XComGameState_BaseObject kTarget, XComGameState_BaseObject kSource) 
+{ 
+	return RemapCondition(InnerCondition.CallMeetsConditionWithSource(kTarget, kSource));
+}
+
+event name CallAbilityMeetsCondition(XComGameState_Ability kAbility, XComGameState_BaseObject kTarget) 
+{
+	return RemapCondition(InnerCondition.CallAbilityMeetsCondition(kAbility, kTarget));
+}
+
+function bool CanEverBeValid(XComGameState_Unit SourceUnit, bool bStrategyCheck)
+{
+	local bool bCanEverBeValid;
+
+	if (bUseCanEverBeValid)
+	{	
+		bCanEverBeValid = InnerCondition.CanEverBeValid(SourceUnit, bStrategyCheck);
+
+		if (bReverseCanEverBeValid)
+		{
+			return !bCanEverBeValid;
+		}
+		return bCanEverBeValid;
+	}
+	return true;
+}
+
+defaultproperties
+{
+	bUseCanEverBeValid = true
+}

--- a/X2WOTCCommunityHighlander/Src/XComGame/Classes/X2Condition_ReverseCondition.uc
+++ b/X2WOTCCommunityHighlander/Src/XComGame/Classes/X2Condition_ReverseCondition.uc
@@ -1,0 +1,15 @@
+//---------------------------------------------------------------------------------------
+//  FILE:    X2Condition_ReverseCondition.uc
+//  AUTHOR:  X2CommunityCore
+//  PURPOSE: Reverse return code output of a provided X2Condition.
+//---------------------------------------------------------------------------------------
+class X2Condition_ReverseCondition extends X2Condition_MappingDecorator;
+
+defaultproperties
+{
+	bReverseCanEverBeValid = true
+
+	MappingDecorations(0) = (OriginalCode = "AA_Success", ReplacementCode = "AA_AbilityUnavailable")
+
+	UnmappedCode = "AA_Success"
+}

--- a/X2WOTCCommunityHighlander/X2WOTCCommunityHighlander.x2proj
+++ b/X2WOTCCommunityHighlander/X2WOTCCommunityHighlander.x2proj
@@ -382,6 +382,12 @@
     <Content Include="Src\XComGame\Classes\X2Ability_GrenadierAbilitySet.uc">
       <SubType>Content</SubType>
     </Content>
+    <Content Include="Src\XComGame\Classes\X2Condition_MappingDecorator.uc">
+      <SubType>Content</SubType>
+    </Content>
+    <Content Include="Src\XComGame\Classes\X2Condition_ReverseCondition.uc">
+      <SubType>Content</SubType>
+    </Content>
     <Content Include="Src\XComGame\Classes\X2CovertActionTemplate.uc">
       <SubType>Content</SubType>
     </Content>


### PR DESCRIPTION
Closes #699

Adds an `X2Condition_MappingDecorator` class that stores an `X2Condition` and remaps its return codes according to specified remapping data.

Adds `X2Condition_ReverseCondition`, which is an extension of the previous class, preconfigured for simply reversing the return codes of the inlaid condition. 