### PR TITLE
Add PostRollForTrainingCenterAbilities event

### DIFF
--- a/X2WOTCCommunityHighlander/Src/XComGame/Classes/XComGameState_Unit.uc
+++ b/X2WOTCCommunityHighlander/Src/XComGame/Classes/XComGameState_Unit.uc
@@ -3702,7 +3702,7 @@ function RollForTrainingCenterAbilities()
 		///```event,notemplate
 		/// EventID: PostRollForTrainingCenterAbilities,
 		/// EventData: none,
-		/// EventSource: inout XComGameState_Unit (UnitState),
+		/// EventSource: XComGameState_Unit (UnitState),
 		/// NewGameState: none
 		///```
 		/// Example code:

--- a/X2WOTCCommunityHighlander/Src/XComGame/Classes/XComGameState_Unit.uc
+++ b/X2WOTCCommunityHighlander/Src/XComGame/Classes/XComGameState_Unit.uc
@@ -3689,43 +3689,43 @@ function RollForTrainingCenterAbilities()
 				EligibleAbilities.Remove(AbilityIdx, 1); // Remove the ability which was chosen so it won't get picked again
 			}
 		}
-	}
 
-	/// HL-Docs: feature:PostRollForTrainingCenterAbilities; issue:815; tags:strategy
-	/// The `PostRollForTrainingCenterAbilities` event allows mods to make arbitrary changes
-	/// to a Soldier after their Training Center abilities have been rolled.
-	///
-	/// Typicaly this should be used to add or remove Training Center abilities
-	/// from the Soldier. To do so you have to access `UnitState.AbilityTree` directly. 
-	/// If the Soldier has rolled any Training Center abilities, 
-	/// they will be in the very last Rank Index.
-	///
-	///```event
-	/// EventID: PostRollForTrainingCenterAbilities,
-	/// EventData: none,
-	/// EventSource: XComGameState_Unit (UnitState),
-	/// NewGameState: none
-	///```
-	/// Example code:
-	///```unrealscript
-	///static function EventListenerReturn ListenerEventFunction(Object EventData, Object EventSource, XComGameState NewGameState, Name Event, Object CallbackData)
-	///{
-	///    local XComGameState_Unit UnitState;
-	///    local int MaxRankIndex;
-	///    local int i;
-	///
-	///    UnitState = XComGameState_Unit(EventSource);
-	///    MaxRankIndex = UnitState.GetSoldierClassTemplate().GetMaxConfiguredRank() - 1;
-	///
-	///    // Cycle through the row of Training Center perks
-	///    for (i = 0; i < UnitState.AbilityTree[MaxRankIndex].Abilities.Length; i++)
-	///    {
-	///        // Do something with UnitState.AbilityTree[MaxRankIndex].Abilities[i]
-	///    }
-	///    return ELR_NoInterrupt;
-	///}
-	// Single line for Issue #815
-	`XEVENTMGR.TriggerEvent('PostRollForTrainingCenterAbilities',, self);
+		/// HL-Docs: feature:PostRollForTrainingCenterAbilities; issue:815; tags:strategy
+		/// The `PostRollForTrainingCenterAbilities` event allows mods to make arbitrary changes
+		/// to a Soldier after their Training Center abilities have been rolled.
+		///
+		/// Typicaly this should be used to add or remove Training Center abilities
+		/// from the Soldier. To do so you have to access `UnitState.AbilityTree` directly. 
+		/// If the Soldier has rolled any Training Center abilities, 
+		/// they will be in the very last Rank Index.
+		///
+		///```event,notemplate
+		/// EventID: PostRollForTrainingCenterAbilities,
+		/// EventData: none,
+		/// EventSource: inout XComGameState_Unit (UnitState),
+		/// NewGameState: none
+		///```
+		/// Example code:
+		///```unrealscript
+		///static function EventListenerReturn ListenerEventFunction(Object EventData, Object EventSource, XComGameState NewGameState, Name Event, Object CallbackData)
+		///{
+		///    local XComGameState_Unit UnitState;
+		///    local int MaxRankIndex;
+		///    local int i;
+		///
+		///    UnitState = XComGameState_Unit(EventSource);
+		///    MaxRankIndex = UnitState.GetSoldierClassTemplate().GetMaxConfiguredRank() - 1;
+		///
+		///    // Cycle through the row of Training Center perks
+		///    for (i = 0; i < UnitState.AbilityTree[MaxRankIndex].Abilities.Length; i++)
+		///    {
+		///        // Do something with UnitState.AbilityTree[MaxRankIndex].Abilities[i]
+		///    }
+		///    return ELR_NoInterrupt;
+		///}
+		// Single line for Issue #815
+		`XEVENTMGR.TriggerEvent('PostRollForTrainingCenterAbilities',, self);
+	}
 }
 
 function bool NeedsAWCAbilityPopup()

--- a/X2WOTCCommunityHighlander/Src/XComGame/Classes/XComGameState_Unit.uc
+++ b/X2WOTCCommunityHighlander/Src/XComGame/Classes/XComGameState_Unit.uc
@@ -3690,6 +3690,42 @@ function RollForTrainingCenterAbilities()
 			}
 		}
 	}
+
+	/// HL-Docs: feature:PostRollForTrainingCenterAbilities; issue:815; tags:strategy
+	/// The `PostRollForTrainingCenterAbilities` event allows mods to make arbitrary changes
+	/// to a Soldier after their Training Center abilities have been rolled.
+	///
+	/// Typicaly this should be used to add or remove Training Center abilities
+	/// from the Soldier. To do so you have to access `UnitState.AbilityTree` directly. 
+	/// If the Soldier has rolled any Training Center abilities, 
+	/// they will be in the very last Rank Index.
+	///
+	///```event
+	/// EventID: PostRollForTrainingCenterAbilities,
+	/// EventData: none,
+	/// EventSource: XComGameState_Unit (UnitState),
+	/// NewGameState: none
+	///```
+	/// Example code:
+	///```unrealscript
+	///static function EventListenerReturn ListenerEventFunction(Object EventData, Object EventSource, XComGameState NewGameState, Name Event, Object CallbackData)
+	///{
+	///    local XComGameState_Unit UnitState;
+	///    local int MaxRankIndex;
+	///    local int i;
+	///
+	///    UnitState = XComGameState_Unit(EventSource);
+	///    MaxRankIndex = UnitState.GetSoldierClassTemplate().GetMaxConfiguredRank() - 1;
+	///
+	///    // Cycle through the row of Training Center perks
+	///    for (i = 0; i < UnitState.AbilityTree[MaxRankIndex].Abilities.Length; i++)
+	///    {
+	///        // Do something with UnitState.AbilityTree[MaxRankIndex].Abilities[i]
+	///    }
+	///    return ELR_NoInterrupt;
+	///}
+	// Single line for Issue #815
+	`XEVENTMGR.TriggerEvent('PostRollForTrainingCenterAbilities',, self);
 }
 
 function bool NeedsAWCAbilityPopup()


### PR DESCRIPTION
Closes #815

I have tested this to be working fine for a typical use case, although for some reason the event is triggered twice for each soldier. If I make changes to the `AbilityTree` the first time, the changes are reflected when the event is triggered the second time. This should probably be reflected in the docs.

Here's log output from a quick dumb test that replaces `RapidFire` with `Reaper` in the `AbilityTree` row with the Training Center abilities:
```
[0089.94] IRITEST: PostRollForTrainingCenterAbilities triggered for: Lucy Wood
[0089.94] IRITEST: Lucy Wood 0 RapidFire
[0089.94] IRITEST: Replacing Rapid Fire with Reaper
[0089.94] IRITEST: Lucy Wood 1 BulletShred
[0089.94] IRITEST: PostRollForTrainingCenterAbilities triggered for: Lucy Wood
[0089.94] IRITEST: Lucy Wood 0 Reaper
[0089.94] IRITEST: Lucy Wood 1 BulletShred
```
Also, somewhat unconventionally, the event trigger passes `none` as `EventData`; the event has nothing to put there at this time. 
I was thinking we could keep it `none` for now, and potentially put something into it later if we have a use for it. 
