### PR TITLE
Extend HasHeavyWeapon() check

### DIFF
--- a/X2WOTCCommunityHighlander/Src/XComGame/Classes/X2DownloadableContentInfo.uc
+++ b/X2WOTCCommunityHighlander/Src/XComGame/Classes/X2DownloadableContentInfo.uc
@@ -336,6 +336,13 @@ static function GetNumUtilitySlotsOverride(out int NumUtilitySlots, XComGameStat
 
 /// Allows override number of heavy weapons slots
 /// These are the only base game slots that can be safely unrestricted since they are optional and not expected by class perks, if you want other multi slots use the CHItemSlot feature
+/// HL-Docs: feature:GetNumHeavyWeaponSlotsOverride; issue:171; tags:loadoutslots,strategy
+/// The `GetNumHeavyWeaponSlotsOverride()` X2DLCInfo method allows mods to override 
+/// the base game logic that determines how many Heavy Weapon Slots a Unit has.
+/// To do so, simply interact with the `NumHeavySlots` argument by increasing,
+/// decreasing or setting its value directly.
+/// Note that this X2DLCInfo method is executed 
+/// after the [OverrideHasHeavyWeapon](../loadoutslots/OverrideHasHeavyWeapon.md) event, and may override its result.
 static function GetNumHeavyWeaponSlotsOverride(out int NumHeavySlots, XComGameState_Unit UnitState, XComGameState CheckGameState)
 {
 }

--- a/X2WOTCCommunityHighlander/Src/XComGame/Classes/XComGameState_Unit.uc
+++ b/X2WOTCCommunityHighlander/Src/XComGame/Classes/XComGameState_Unit.uc
@@ -4090,11 +4090,16 @@ function bool HasHeavyWeapon(optional XComGameState CheckGameState)
 	}
 	// End Issue Issue #172
 
-	foreach class'X2AbilityTemplateManager'.default.AbilityUnlocksHeavyWeapon(CheckAbility)
+	// Start Issue #881
+	/// HL-Docs: feature:ExtendHasHeavyWeapon; issue:881; tags:loadoutslots,strategy
+	/// Extends the ability check in `HasHeavyWeapon()` for the config array `AbilityUnlocksHeavyWeapon` (`XComGameData.ini`) to item granted abilities
+	/// and abilities granted by the character template.
+	bHasHeavyWeapon = HasAnyOfTheAbilitiesFromAnySource(class'X2AbilityTemplateManager'.default.AbilityUnlocksHeavyWeapon);
+	if (bHasHeavyWeapon)
 	{
-		if (HasSoldierAbility(CheckAbility))
-			return true;
+		return true;
 	}
+	// End Issue #881
 
 	ItemState = GetItemInSlot(eInvSlot_Armor, CheckGameState);
 	if (ItemState != none)

--- a/X2WOTCCommunityHighlander/Src/XComGame/Classes/XComGameState_Unit.uc
+++ b/X2WOTCCommunityHighlander/Src/XComGame/Classes/XComGameState_Unit.uc
@@ -4079,7 +4079,7 @@ function bool HasHeavyWeapon(optional XComGameState CheckGameState)
 	Tuple.Data[2].kind = XComLWTVObject;
 	Tuple.Data[2].o = CheckGameState;
 
-	`XEVENTMGR.TriggerEvent('OverrideHasHeavyWeapon', Tuple, self);
+	`XEVENTMGR.TriggerEvent('OverrideHasHeavyWeapon', Tuple, self, CheckGameState);
 
 	bOverrideHasHeavyWeapon = Tuple.Data[0].b;
 	bHasHeavyWeapon = Tuple.Data[1].b;

--- a/X2WOTCCommunityHighlander/Src/XComGame/Classes/XComGameState_Unit.uc
+++ b/X2WOTCCommunityHighlander/Src/XComGame/Classes/XComGameState_Unit.uc
@@ -4052,12 +4052,23 @@ function bool HasExtraUtilitySlotFromAbility()
 function bool HasHeavyWeapon(optional XComGameState CheckGameState)
 {
 	local XComGameState_Item ItemState;
-	local name CheckAbility;
 	// Variables for Issue #172
 	local XComLWTuple Tuple;
 	local bool bOverrideHasHeavyWeapon, bHasHeavyWeapon;
 
 	// Start Issue #172
+	/// HL-Docs: feature:OverrideHasHeavyWeapon; issue:172; tags:loadoutslots,strategy
+	/// The `OverrideHasHeavyWeapon` event allows mods to override the base game logic
+	/// that determines whether a Unit has a Heavy Weapon Slot or not.
+	/// Keep in mind the [GetNumHeavyWeaponSlotsOverride()](../loadoutslots/GetNumHeavyWeaponSlotsOverride.md) X2DLCInfo method may override
+	/// this later.
+	///
+	/// ```event
+	/// EventID: OverrideHasHeavyWeapon,
+	/// EventData: [inout bool bOverrideHasHeavyWeapon, inout bool bHasHeavyWeapon],
+	/// EventSource: XComGameState_Unit (UnitState),
+	/// NewGameState: maybe
+	/// ```
 	Tuple = new class'XComLWTuple';
 	Tuple.Id = 'OverrideHasHeavyWeapon';
 	Tuple.Data.Add(3);


### PR DESCRIPTION
Closes #881 

Adds docs for Issue #172 and added the Game State from the `HasHeavyWeapon()` function to its `OverrideHasHeavyWeapon` Event Trigger. Please let me know if it's okay to do.

Adds partial docs for Issue #171 (the `GetNumHeavyWeaponSlotsOverride()` X2DLCInfo method).