### PR TITLE
Mods can specify required Highlander version in config

### DIFF
--- a/X2WOTCCommunityHighlander/Localization/X2WOTCCommunityHighlander.int
+++ b/X2WOTCCommunityHighlander/Localization/X2WOTCCommunityHighlander.int
@@ -13,3 +13,10 @@ ModRequired="Please ACTIVATE the following mods and restart or %s will not work 
 ModIncompatiblePopupTitle="detected INCOMPATIBLE mods"
 ModIncompatible="Please DEACTIVATE the following mods and restart or %s will not work properly:"
 DisablePopup="DO NOT SHOW ME THIS AGAIN"
+
+;	Issue #909
+ModRequiresNewerHighlanderVersionTitle = "MOD REQUIRES NEWER HIGHLANDER VERSION"
+ModRequiresNewerHighlanderVersionText = "Mod requires newer Highlander version:"
+CurrentHighlanderVersionTitle =  "Installed Version:"
+RequiredHighlanderVersionTitle = "Required Version: "
+ModRequiresNewerHighlanderVersionExtraText = "Please update Highlander to the required version. Otherwise you may experience crashes and other malfunctions."

--- a/X2WOTCCommunityHighlander/Src/X2WOTCCommunityHighlander/Classes/X2WOTCCH_ModDependencies.uc
+++ b/X2WOTCCommunityHighlander/Src/X2WOTCCommunityHighlander/Classes/X2WOTCCH_ModDependencies.uc
@@ -17,6 +17,14 @@ var localized string ModRequiredPopupTitle;
 var localized string ModIncompatiblePopupTitle;
 var localized string DisablePopup;
 
+// Begin Issue #909
+var localized string ModRequiresNewerHighlanderVersionTitle;
+var localized string ModRequiresNewerHighlanderVersionText;
+var localized string CurrentHighlanderVersionTitle;
+var localized string RequiredHighlanderVersionTitle;
+var localized string ModRequiresNewerHighlanderVersionExtraText;
+// End Issue #909
+
 static function array<ModDependency> GetRequiredMods()
 {
 	local array<X2DownloadableContentInfo> DLCInfos;
@@ -175,3 +183,40 @@ function static string Join(array<string> StringArray, optional string Delimiter
 
 	return Result;
 }
+
+// Begin Issue #909
+static final function GetModsThatRequireNewerCHLVersion(out array<CHModDependency> ModsThatRequireNewerCHLVersion)
+{
+	local array<X2DownloadableContentInfo> DLCInfos;
+	local X2DownloadableContentInfo        DLCInfo;
+	local CHModDependency                  ModDependencyObj;
+	local CHLVersionStruct                 CurrentCHLVersion;
+
+	GetCurrentCHLVersion(CurrentCHLVersion);
+	DLCInfos = `ONLINEEVENTMGR.GetDLCInfos(false);
+	
+	foreach DLCInfos(DLCInfo)
+	{
+		ModDependencyObj = DLCInfo.GetMyCHModDependency();
+
+		if (IsCurrentCHLVersionOlderThanRequired(CurrentCHLVersion, ModDependencyObj.RequiredHighlanderVersion))
+		{
+			ModsThatRequireNewerCHLVersion.AddItem(ModDependencyObj);
+		}
+	}
+}	
+
+static final function GetCurrentCHLVersion(out CHLVersionStruct CurrentCHLVersion)
+{
+	CurrentCHLVersion.MajorVersion = class'CHXComGameVersionTemplate'.default.MajorVersion;
+	CurrentCHLVersion.MinorVersion = class'CHXComGameVersionTemplate'.default.MinorVersion;
+	CurrentCHLVersion.PatchVersion = class'CHXComGameVersionTemplate'.default.PatchVersion;
+}
+
+static private function bool IsCurrentCHLVersionOlderThanRequired(const out CHLVersionStruct CurrentCHLVersion, const out CHLVersionStruct RequiredCHLVersion)
+{
+    return CurrentCHLVersion.MajorVersion < RequiredCHLVersion.MajorVersion ||
+           CurrentCHLVersion.MinorVersion < RequiredCHLVersion.MinorVersion ||
+           CurrentCHLVersion.PatchVersion < RequiredCHLVersion.PatchVersion;
+}
+// End Issue #909

--- a/X2WOTCCommunityHighlander/Src/X2WOTCCommunityHighlander/Classes/X2WOTCCH_ModDependencies.uc
+++ b/X2WOTCCommunityHighlander/Src/X2WOTCCommunityHighlander/Classes/X2WOTCCH_ModDependencies.uc
@@ -215,8 +215,18 @@ static final function GetCurrentCHLVersion(out CHLVersionStruct CurrentCHLVersio
 
 static private function bool IsCurrentCHLVersionOlderThanRequired(const out CHLVersionStruct CurrentCHLVersion, const out CHLVersionStruct RequiredCHLVersion)
 {
-    return CurrentCHLVersion.MajorVersion < RequiredCHLVersion.MajorVersion ||
-           CurrentCHLVersion.MinorVersion < RequiredCHLVersion.MinorVersion ||
-           CurrentCHLVersion.PatchVersion < RequiredCHLVersion.PatchVersion;
+	if (CurrentCHLVersion.MajorVersion > RequiredCHLVersion.MajorVersion)
+		return false;
+
+	if (CurrentCHLVersion.MajorVersion < RequiredCHLVersion.MajorVersion)
+		return true;
+
+	if (CurrentCHLVersion.MinorVersion > RequiredCHLVersion.MinorVersion)
+		return false;
+
+	if (CurrentCHLVersion.MinorVersion < RequiredCHLVersion.MinorVersion)
+		return true;
+
+	return CurrentCHLVersion.PatchVersion < RequiredCHLVersion.PatchVersion;
 }
 // End Issue #909

--- a/X2WOTCCommunityHighlander/Src/XComGame/Classes/CHModDependency.uc
+++ b/X2WOTCCommunityHighlander/Src/XComGame/Classes/CHModDependency.uc
@@ -6,4 +6,20 @@ var config array<string> RequiredMods;
 var config array<string> IgnoreRequiredMods;
 var string DisplayName;
 
+// Start Issue #909
+struct CHLVersionStruct
+{
+    var int MajorVersion;
+    var int MinorVersion;
+    var int PatchVersion;
 
+    structdefaultproperties
+    {
+        MajorVersion = -1
+        MinorVersion = -1
+        PatchVersion = -1
+    }
+};
+var config CHLVersionStruct RequiredHighlanderVersion;
+var name DLCIdentifier;
+// End Issue #909

--- a/X2WOTCCommunityHighlander/Src/XComGame/Classes/CHModDependency.uc
+++ b/X2WOTCCommunityHighlander/Src/XComGame/Classes/CHModDependency.uc
@@ -4,7 +4,7 @@ var config array<string> IncompatibleMods;
 var config array<string> IgnoreIncompatibleMods;
 var config array<string> RequiredMods;
 var config array<string> IgnoreRequiredMods;
-var string DisplayName;
+var config string DisplayName;
 
 // Start Issue #909
 struct CHLVersionStruct

--- a/X2WOTCCommunityHighlander/Src/XComGame/Classes/X2DownloadableContentInfo.uc
+++ b/X2WOTCCommunityHighlander/Src/XComGame/Classes/X2DownloadableContentInfo.uc
@@ -758,7 +758,7 @@ final function string GetDisplayName()
 	local CHModDependency ModDependency;
 
 	ModDependency = new(none, DLCIdentifier)class'CHModDependency';
-	// Equivalent to empty string if not specified in localization
+	// Equivalent to empty string if not specified in config
 	return ModDependency.DisplayName;
 }
 /// End Issue #524

--- a/X2WOTCCommunityHighlander/Src/XComGame/Classes/X2DownloadableContentInfo.uc
+++ b/X2WOTCCommunityHighlander/Src/XComGame/Classes/X2DownloadableContentInfo.uc
@@ -762,3 +762,32 @@ final function string GetDisplayName()
 	return ModDependency.DisplayName;
 }
 /// End Issue #524
+
+/// Start Issue #909
+/// <summary>
+/// Allow mods to specify the required Highlander version.
+/// Should be specified in the mod's XComGame.ini like this:
+/// [ModSafeName CHModDependency]
+/// RequiredHighlanderVersion = (MajorVersion = 1, MinorVersion = 22, PatchVersion = 0)
+/// </summary>
+/// HL-Docs: feature:RequiredHighlanderVersion; issue:909; tags:compatibility
+/// Mods can specify the version of the Highlander they require to function properly.
+/// If the mod user has an older version of the Highlander installed, they will 
+/// see a popup warning when they start the game. 
+/// Note: this feature is disabled if the game is started without the `-review`
+/// launch argument. 
+/// The required version should be specified in the mod's `XComGame.ini` config file:
+///```ini
+/// [ModSafeName CHModDependency]
+/// RequiredHighlanderVersion = (MajorVersion = 1, MinorVersion = 22, PatchVersion = 0)
+///```
+final function CHModDependency GetMyCHModDependency()
+{
+	local CHModDependency ModDependencyObj;
+
+	ModDependencyObj = new(none, DLCIdentifier)class'CHModDependency';
+	ModDependencyObj.DLCIdentifier = name(DLCIdentifier);
+
+	return ModDependencyObj;
+}
+/// End Issue #909


### PR DESCRIPTION
Closes #909

Localized descriptions are placeholder and we should probably have a discussion about them. Once we finalize them, I can get a person to translate them (and other localized Highlander text) to Russian. 

I didn't commentate the code because it's relatively straightforward and heavily based on Musashi's implementation of #524.