### PR TITLE
Detach all equippable items before destroying them

### DIFF
--- a/X2WOTCCommunityHighlander/Src/XComGame/Classes/UIPawnMgr.uc
+++ b/X2WOTCCommunityHighlander/Src/XComGame/Classes/UIPawnMgr.uc
@@ -305,7 +305,14 @@ simulated function AssociateWeaponPawnInternal(int CosmeticSlot, Actor WeaponPaw
 		if (PawnStore[StoreIdx].Weapons[CosmeticSlot] != none)
 		{
 			PreviousItem = XGInventoryItem(PawnStore[StoreIdx].Weapons[CosmeticSlot]);
-			OwningPawn.DetachItem(XComWeapon(PreviousItem.m_kEntity).Mesh);
+			
+			// Start Issue #337
+			/// HL-Docs: ref:Bugfixes; issue:337
+			/// Add `none` checks before attempting to detach the mesh.
+			if (PreviousItem != none && XComWeapon(PreviousItem.m_kEntity) != none && XComWeapon(PreviousItem.m_kEntity).Mesh != none)
+			{
+				OwningPawn.DetachItem(XComWeapon(PreviousItem.m_kEntity).Mesh);
+			}// End Issue #337
 			PawnStore[StoreIdx].Weapons[CosmeticSlot].Destroy();
 		}
 		PawnStore[StoreIdx].Weapons[CosmeticSlot] = WeaponPawn;
@@ -430,7 +437,13 @@ simulated private function AssociateMultiSlotWeaponPawnInternal(out array<PawnIn
 		if (PawnStore[StoreIndex].MultiSlotWeaponsPawnInfos[i].MultiSlotWeapons[MultiSlotIndex] != none)
 		{
 			PreviousItem = XGInventoryItem(PawnStore[StoreIndex].MultiSlotWeaponsPawnInfos[i].MultiSlotWeapons[MultiSlotIndex]);
-			OwningPawn.DetachItem(XComWeapon(PreviousItem.m_kEntity).Mesh);
+			// Start Issue #337
+			/// HL-Docs: ref:Bugfixes; issue:337
+			/// Add `none` checks before attempting to detach the mesh.
+			if (PreviousItem != none && XComWeapon(PreviousItem.m_kEntity) != none && XComWeapon(PreviousItem.m_kEntity).Mesh != none)
+			{
+				OwningPawn.DetachItem(XComWeapon(PreviousItem.m_kEntity).Mesh);
+			}// End Issue #337
 			PawnStore[StoreIndex].MultiSlotWeaponsPawnInfos[i].MultiSlotWeapons[MultiSlotIndex].Destroy();
 		}
 		PawnStore[StoreIndex].MultiSlotWeaponsPawnInfos[i].MultiSlotWeapons[MultiSlotIndex] = WeaponPawn;


### PR DESCRIPTION
Closes #337 

According to my tests this "fix" doesn't seem to actually fix anything, or at least it doesn't have an effect on the number of `Attempting to detach NULL component` log warnings. Check the comment section of #337 for details.

As such, I'm not sure there's much reason to merge this PR. I'll leave this decision to seniors. 