### PR TITLE
Make OverrideItemImage pass on Item State

### DIFF
--- a/X2WOTCCommunityHighlander/Src/XComGame/Classes/UIArmory_LoadoutItem.uc
+++ b/X2WOTCCommunityHighlander/Src/XComGame/Classes/UIArmory_LoadoutItem.uc
@@ -146,7 +146,8 @@ simulated function UIArmory_LoadoutItem SetImage(XComGameState_Item Item, option
 	DLCInfos = `ONLINEEVENTMGR.GetDLCInfos(false);
 	for(i = 0; i < DLCInfos.Length; ++i)
 	{
-		DLCInfos[i].OverrideItemImage(NewImages, EquipmentSlot, ItemTemplate, UIArmory(Screen).GetUnit());
+		// Single line for Issue #962 - pass on Item State.
+		DLCInfos[i].OverrideItemImage_Improved(NewImages, EquipmentSlot, ItemTemplate, UIArmory(Screen).GetUnit(), Item);
 	}
 	// End Issue #171
 

--- a/X2WOTCCommunityHighlander/Src/XComGame/Classes/X2DownloadableContentInfo.uc
+++ b/X2WOTCCommunityHighlander/Src/XComGame/Classes/X2DownloadableContentInfo.uc
@@ -320,6 +320,19 @@ static private function bool CanAddItemToInventory(out int bCanAddItem, const EI
 
 //end Issue #50
 
+// Start Issue #962
+/// HL-Docs: feature:OverrideItemImage_Improved; issue:962; tags:strategy
+/// The `OverrideItemImage_Improved` X2DLCInfo method is called from `UIArmory_Loadout`.
+/// It allows mods to conditionally override items' inventory image. 
+/// It can be used to replace the original image entirely
+/// or to overlay an additional icon on top of it to mark the specific item.
+/// To do so replace the contents of the `imagePath` array or add more image paths to it.
+static function OverrideItemImage_Improved(out array<string> imagePath, const EInventorySlot Slot, const X2ItemTemplate ItemTemplate, XComGameState_Unit UnitState, const XComGameState_Item ItemState)
+{
+	OverrideItemImage(imagePath, Slot, ItemTemplate, UnitState);
+}
+// End Issue #962
+
 // Start Issue #171
 /// Calls to override item image shown in UIArmory_Loadout
 /// For example it allows you to show multiple grenades on grenade slot for someone with heavy ordnance


### PR DESCRIPTION
Closes #962 

Wasn't sure if it would be better to add a new hook or change the signature of the old one, but judging by the nightmare we had with the `CanUnitMoveFromMelee`, I decided a separate hook would be best, though I can change it if instructed to do so.

I actually need this PR to resolve an MCO conflict between XSkin and several other popular mods, so some expediency here would be great. 