### PR TITLE
Rework mod dependency checking

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,19 +7,6 @@ No new changes should be added here. Documented features should be removed from 
 
 ### Ini settings
 
-#### Mod compatibility
-
-In `XComGame.ini` mods can specify an array of incompatible and/or required mods. This will be used to show an warning popup if they are present. (#524)
-
-```
-[ModSafeName CHModDependency]
-+IncompatibleMods=OtherModSafeName
-+IgnoreIncompatibleMods=OtherModSafeName
-+RequiredMods=OtherModSafeName
-+IgnoreRequiredMods=OtherModSafeName
-DisplayName="Fancy Mod"
-```
-
 #### DLC Run Order
 
 In `XComGame.ini` mods can define an array of other mods which dlc hooks should run before and/or after the mods dlc hook.

--- a/X2WOTCCommunityHighlander/Src/X2WOTCCommunityHighlander/Classes/X2WOTCCH_DialogCallbackData.uc
+++ b/X2WOTCCommunityHighlander/Src/X2WOTCCommunityHighlander/Classes/X2WOTCCH_DialogCallbackData.uc
@@ -4,4 +4,4 @@
  **/
 class X2WOTCCH_DialogCallbackData extends UICallbackData dependson (X2WOTCCH_ModDependencies);
 
-var ModDependency DependencyData;
+var ModDependencyData DependencyData;

--- a/X2WOTCCommunityHighlander/Src/X2WOTCCommunityHighlander/Classes/X2WOTCCH_ModDependencies.uc
+++ b/X2WOTCCommunityHighlander/Src/X2WOTCCommunityHighlander/Classes/X2WOTCCH_ModDependencies.uc
@@ -77,6 +77,10 @@ function Init()
 	foreach default.AdditionalDepInfoNames(AddDepInfo)
 	{
 		DepInfo = new(none, string(AddDepInfo)) class'CHModDependency';
+		if (DepInfo.DisplayName == "")
+		{
+			DepInfo.DisplayName = string(AddDepInfo);
+		}
 		self.DepInfos.AddItem(DepInfo);
 	}
 

--- a/X2WOTCCommunityHighlander/Src/X2WOTCCommunityHighlander/Classes/X2WOTCCH_ModDependencies.uc
+++ b/X2WOTCCommunityHighlander/Src/X2WOTCCommunityHighlander/Classes/X2WOTCCH_ModDependencies.uc
@@ -1,7 +1,4 @@
-/**
- * Issue #524
- * Check mods required and incompatible mods against the actually loaded mod and display a popup
- **/
+/// HL-Docs: ref:ModDependencyCheck
 class X2WOTCCH_ModDependencies extends Object config(Game);
 
 enum CHPolarity

--- a/X2WOTCCommunityHighlander/Src/X2WOTCCommunityHighlander/Classes/X2WOTCCH_ModDependencies.uc
+++ b/X2WOTCCommunityHighlander/Src/X2WOTCCommunityHighlander/Classes/X2WOTCCH_ModDependencies.uc
@@ -12,7 +12,7 @@ struct ModDependencyData
 	var string ModName; // The display name of the mod causing this error.
 	var name SourceName; // The stored name of the mod in case user presses "ok, please ignore"
 	var CHPolarity Polarity; // Whether these mods are required and not installed, or incompatible but present
-	var array<String> Children; // The set of mods required by or incompatible with the cause
+	var array<string> Children; // The set of mods required by or incompatible with the cause
 };
 
 var localized string ModRequired;
@@ -30,6 +30,13 @@ var array<string> IgnoreIncompatibleMods;
 // Faster than retrieving from OnlineEventMgr all the time, and enables `.Find()`
 var array<name> EnabledDLCNames;
 var array<CHModDependency> DepInfos;
+
+function bool HasHLSupport()
+{
+	// Check whether XComGame replacement is active at all.
+	// The internal refactoring in #965 works with older versions of `CHModDependency` too.
+	return Class'XComGame.CHModDependency' != none;
+}
 
 function Init()
 {
@@ -92,7 +99,7 @@ private function CHModDependency CreateUniqueDepInfoForInstalled(string DLCName)
 
 	DepInfo = new(none, DLCName) class'CHModDependency';
 
-	if (!DepInfo.IsInteresting())
+	if (!IsInteresting(DepInfo))
 	{
 		return None;
 	}
@@ -109,6 +116,13 @@ private function CHModDependency CreateUniqueDepInfoForInstalled(string DLCName)
 
 	self.DepInfos.AddItem(DepInfo);
 	return DepInfo;
+}
+
+final function bool IsInteresting(CHModDependency DepInfo)
+{
+	return DepInfo.IncompatibleMods.Length > 0 || DepInfo.RequiredMods.Length > 0
+		|| DepInfo.IgnoreIncompatibleMods.Length > 0 || DepInfo.IgnoreRequiredMods.Length > 0
+		|| DepInfo.DisplayName != "";
 }
 
 function array<ModDependencyData> GetModsWithMissingRequirements()

--- a/X2WOTCCommunityHighlander/Src/X2WOTCCommunityHighlander/Classes/X2WOTCCH_UIScreenListener_ShellPopup.uc
+++ b/X2WOTCCommunityHighlander/Src/X2WOTCCommunityHighlander/Classes/X2WOTCCH_UIScreenListener_ShellPopup.uc
@@ -15,10 +15,12 @@ event OnInit(UIScreen Screen)
 	if(UIShell(Screen) != none && UIShell(Screen).DebugMenuContainer == none)
 	{
 		DependencyChecker = new class'X2WOTCCH_ModDependencies';
-		DependencyChecker.Init();
-
-		Screen.SetTimer(2.5f, false, nameof(IncompatibleModsPopups), self);
-		Screen.SetTimer(2.6f, false, nameof(RequiredModsPopups), self);
+		if (DependencyChecker.HasHLSupport())
+		{
+			DependencyChecker.Init();
+			Screen.SetTimer(2.5f, false, nameof(IncompatibleModsPopups), self);
+			Screen.SetTimer(2.6f, false, nameof(RequiredModsPopups), self);
+		}
 	}
 }
 

--- a/X2WOTCCommunityHighlander/Src/X2WOTCCommunityHighlander/Classes/X2WOTCCH_UIScreenListener_ShellPopup.uc
+++ b/X2WOTCCommunityHighlander/Src/X2WOTCCommunityHighlander/Classes/X2WOTCCH_UIScreenListener_ShellPopup.uc
@@ -37,7 +37,7 @@ simulated function IncompatibleModsPopups()
 
 	foreach ModsWithIncompats(Mod)
 	{
-		Index = HideIncompatibleModWarnings.Find(Mod.SourceDLCIdentifier);
+		Index = HideIncompatibleModWarnings.Find(Mod.SourceName);
 
 		if (Index == INDEX_NONE && Mod.ModName != "" && Mod.Children.Length > 0)
 		{
@@ -71,7 +71,7 @@ simulated function RequiredModsPopups()
 
 	foreach ModsWithMissing(Mod)
 	{
-		Index = HideRequiredModWarnings.Find(Mod.SourceDLCIdentifier);
+		Index = HideRequiredModWarnings.Find(Mod.SourceName);
 		if (Index == INDEX_NONE && Mod.ModName != "" && Mod.Children.Length > 0)
 		{
 			CallbackData = new class'X2WOTCCH_DialogCallbackData';
@@ -99,7 +99,7 @@ simulated function IncompatibleModsCB(Name eAction, UICallbackData xUserData)
 	if (eAction == 'eUIAction_Accept')
 	{
 		CallbackData = X2WOTCCH_DialogCallbackData(xUserData);
-		HideIncompatibleModWarnings.AddItem(CallbackData.DependencyData.SourceDLCIdentifier);
+		HideIncompatibleModWarnings.AddItem(CallbackData.DependencyData.SourceName);
 
 		`PRESBASE.PlayUISound(eSUISound_MenuSelect);
 		
@@ -118,7 +118,7 @@ simulated function RequiredModsCB(Name eAction, UICallbackData xUserData)
 	if (eAction == 'eUIAction_Accept')
 	{
 		CallbackData = X2WOTCCH_DialogCallbackData(xUserData);
-		HideRequiredModWarnings.AddItem(CallbackData.DependencyData.SourceDLCIdentifier);
+		HideRequiredModWarnings.AddItem(CallbackData.DependencyData.SourceName);
 
 		`PRESBASE.PlayUISound(eSUISound_MenuSelect);
 		

--- a/X2WOTCCommunityHighlander/Src/X2WOTCCommunityHighlander/Classes/X2WOTCCH_UIScreenListener_ShellPopup.uc
+++ b/X2WOTCCommunityHighlander/Src/X2WOTCCommunityHighlander/Classes/X2WOTCCH_UIScreenListener_ShellPopup.uc
@@ -1,7 +1,4 @@
-/**
- * Issue #524
- * Check mods required and incompatible mods against the actually loaded mod and display a popup for each mod
- **/
+/// HL-Docs: ref:ModDependencyCheck
 class X2WOTCCH_UIScreenListener_ShellPopup
 	extends UIScreenListener
 	dependson (X2WOTCCH_ModDependencies)

--- a/X2WOTCCommunityHighlander/Src/X2WOTCCommunityHighlander/Classes/X2WOTCCH_UIScreenListener_ShellPopup.uc
+++ b/X2WOTCCommunityHighlander/Src/X2WOTCCommunityHighlander/Classes/X2WOTCCH_UIScreenListener_ShellPopup.uc
@@ -31,15 +31,12 @@ simulated function IncompatibleModsPopups()
 	local array<ModDependencyData> ModsWithIncompats;
 	local ModDependencyData Mod;
 	local X2WOTCCH_DialogCallbackData CallbackData;
-	local int Index;
 
 	ModsWithIncompats = DependencyChecker.GetModsWithEnabledIncompatibilities();
 
 	foreach ModsWithIncompats(Mod)
 	{
-		Index = HideIncompatibleModWarnings.Find(Mod.SourceName);
-
-		if (Index == INDEX_NONE && Mod.ModName != "" && Mod.Children.Length > 0)
+		if (HideIncompatibleModWarnings.Find(Mod.SourceName) == INDEX_NONE)
 		{
 			CallbackData = new class'X2WOTCCH_DialogCallbackData';
 			CallbackData.DependencyData = Mod;
@@ -65,14 +62,12 @@ simulated function RequiredModsPopups()
 	local array<ModDependencyData> ModsWithMissing;
 	local ModDependencyData Mod;
 	local X2WOTCCH_DialogCallbackData CallbackData;
-	local int Index;
 
 	ModsWithMissing = DependencyChecker.GetModsWithMissingRequirements();
 
 	foreach ModsWithMissing(Mod)
 	{
-		Index = HideRequiredModWarnings.Find(Mod.SourceName);
-		if (Index == INDEX_NONE && Mod.ModName != "" && Mod.Children.Length > 0)
+		if (HideRequiredModWarnings.Find(Mod.SourceName) == INDEX_NONE)
 		{
 			CallbackData = new class'X2WOTCCH_DialogCallbackData';
 			CallbackData.DependencyData = Mod;
@@ -130,19 +125,19 @@ simulated function RequiredModsCB(Name eAction, UICallbackData xUserData)
 	}
 }
 
-simulated function string GetIncompatibleModsText(ModDependencyData Dep)
+simulated function string GetIncompatibleModsText(const out ModDependencyData Dep)
 {
 	return class'UIUtilities_Text'.static.GetColoredText(Repl(class'X2WOTCCH_ModDependencies'.default.ModIncompatible, "%s", Dep.ModName, true), eUIState_Header) $ "\n\n" $
 			class'UIUtilities_Text'.static.GetColoredText(MakeBulletList(Dep.Children), eUIState_Bad) $ "\n";
 }
 
-simulated function string GetRequiredModsText(ModDependencyData Dep)
+simulated function string GetRequiredModsText(const out ModDependencyData Dep)
 {
 	return class'UIUtilities_Text'.static.GetColoredText(Repl(class'X2WOTCCH_ModDependencies'.default.ModRequired, "%s", Dep.ModName, true), eUIState_Header) $ "\n\n" $
 			class'UIUtilities_Text'.static.GetColoredText(MakeBulletList(Dep.Children), eUIState_Bad) $ "\n";
 }
 
-function static string MakeBulletList(array<string> List)
+function static string MakeBulletList(const out array<string> List)
 {
 	local string Buffer;
 	local int Index;

--- a/X2WOTCCommunityHighlander/Src/XComGame/Classes/CHModDependency.uc
+++ b/X2WOTCCommunityHighlander/Src/XComGame/Classes/CHModDependency.uc
@@ -4,6 +4,4 @@ var config array<string> IncompatibleMods;
 var config array<string> IgnoreIncompatibleMods;
 var config array<string> RequiredMods;
 var config array<string> IgnoreRequiredMods;
-var string DisplayName;
-
-
+var config string DisplayName;

--- a/X2WOTCCommunityHighlander/Src/XComGame/Classes/CHModDependency.uc
+++ b/X2WOTCCommunityHighlander/Src/XComGame/Classes/CHModDependency.uc
@@ -110,6 +110,12 @@
 /// and the popup would display that incompatibility as "Classless XCOM: MINT (AddMintToMyChocolate)".
 /// The same system can also be used to provide a DisplayName for requirements that may be missing
 /// and as such can't inform the dependency checker about their DisplayName.
+///
+/// If the user presses "Do not show me this again", the Highlander will store the object
+/// name (DLCName or DLCIdentifier, depending on how the depencency checker found it in
+/// the first place) of the mod that provides this data in a user config file
+/// (`%USERPROFILE%/Documents/My Games/XCOM 2 War of the Chosen/XComGame/Config/X2WOTCCommunityHighlander_NullConfig.ini`)
+/// and won't show this popup again.
 
 class CHModDependency extends Object perobjectconfig Config(Game);
 

--- a/X2WOTCCommunityHighlander/Src/XComGame/Classes/CHModDependency.uc
+++ b/X2WOTCCommunityHighlander/Src/XComGame/Classes/CHModDependency.uc
@@ -72,11 +72,11 @@
 /// so another mod should not consider `NewPromotionScreenbyDefault` missing if RPGO
 /// is enabled.
 ///
-/// There also is a `IgnoreIncompatibleMods` list of DLCNames that allows mods to
-/// suppress incompatibilites. For example, an overhaul can consider itself
-/// incompatible with a mod that adds a new weapon type unless a "bridge mod" is
-/// installed that provides functionality the overhaul expects -- that mod would then
-/// add `+IgnoreIncompatibleMods="ThatNewWeaponMod"`.
+/// There also is a `IgnoreIncompatibleMods` list of DLCNames that I am unfortunately
+/// not qualified to present a use case for. What `+IgnoreIncompatibleMods="SomeDLCName"`
+/// does is silence any warning that a third mod would throw if it listed 
+/// `+IncompatibleMods="SomeDLCName"`. If you think this is useful in any way, please tell
+/// us about it in [HL issue #967](https://github.com/X2CommunityCore/X2WOTCCommunityHighlander/issues/967).
 ///
 /// This is what the popup for missing requirements looks like:
 /// ![Screenshot of RPGO's missing required mods](https://i.imgur.com/D1G6ZF7.png)

--- a/X2WOTCCommunityHighlander/Src/XComGame/Classes/CHModDependency.uc
+++ b/X2WOTCCommunityHighlander/Src/XComGame/Classes/CHModDependency.uc
@@ -12,12 +12,12 @@
 /// specify in the `ActiveMods` list, and the way the game knows how to load that mod. Every mod has exactly
 /// one DLCName. Mods with the same DLCName can only be enabled or disabled together.
 /// The game stores the `DLCName` in the save file, and shows a warning upon attempting to load a save file
-/// when it had recorded a mod that's no longer enabled.
+/// when it had recorded a mod that's no longer enabled. DLCNames are case-insensitive.
 /// * **`DLCIdentifier`** is an identifier corresponding to a `X2DownloadableContentInfo` classes.
 /// Every mod has zero, one, or several `X2DownloadableContentInfo` classes, and the DLCIdentifier may be empty for
 /// any of them. This DLCIdentifier is used for some customization aspects (like part icons or slider names) and
 /// narrative content options (for the official DLCs). It's also used in CHL's Run Order (still need docs, sorry)
-/// since Run Order is all about `X2DownloadableContentInfo` classes.
+/// since Run Order is all about `X2DownloadableContentInfo` classes. DLCIdentifiers are generally case-sensitive.
 ///
 /// In the default ModBuddy mod project, the mod has exactly one `X2DownloadableContentInfo` subclass
 /// with a DLCIdentifier identical to the DLCName. However, config-only mods have no `X2DownloadableContentInfo`
@@ -90,11 +90,15 @@
 /// * All currently enabled DLCNames
 /// * All non-empty DLCIdentifiers from found `X2DownloadableContentInfo` classes
 /// 
-/// while ignoring duplicates.
+/// while ignoring duplicates. Note that only DLCNames are supported for `IncompatibleMods`,
+/// `RequiredMods` etc., you cannot specify a requirement on or incompatibility with a given DLCIdentifier!
+///
+///
 /// This means that mods can easily provide dependency info for other mods --
 /// the config object will be ignored if the corresponding DLCName isn't
 /// enabled. This also allows mods to add friendly names for other mods so
-/// that even if the mod isn't installed or doesn't set a `DisplayName`.
+/// that even if the mod isn't installed or doesn't set a `DisplayName`, the
+/// popup doesn't only show an internal ID.
 ///
 /// For example, `AddMintToMyChocolate` doesn't participate in the CHL depencency
 /// checker at all, but this DLCName is kind of confusing and a reported incompatibility

--- a/X2WOTCCommunityHighlander/Src/XComGame/Classes/CHModDependency.uc
+++ b/X2WOTCCommunityHighlander/Src/XComGame/Classes/CHModDependency.uc
@@ -1,3 +1,116 @@
+/// HL-Docs: feature:ModDependencyCheck; issue:524; tags:compatibility
+/// Allows mods to declare required and incompatible mods. The Highlander
+/// will show popups for missing requirements and detected incompatibilities.
+///
+/// ## Terminology
+///
+/// We'll need to distinguish a few identifiers in mod project setups to explain this feature,
+/// so here's a short rundown.
+///
+/// * **`DLCName`** is the actual ID of the mod. It's always the base name of the `.XComMod` file,
+/// so `YetAnotherF1.XComMod` has a DLCName of `YetAnotherF1`. This is also the name that mod launchers
+/// specify in the `ActiveMods` list, and the way the game knows how to load that mod. Every mod has exactly
+/// one DLCName. Mods with the same DLCName can only be enabled or disabled together.
+/// The game stores the `DLCName` in the save file, and shows a warning upon attempting to load a save file
+/// when it had recorded a mod that's no longer enabled.
+/// * **`DLCIdentifier`** is an identifier corresponding to a `X2DownloadableContentInfo` classes.
+/// Every mod has zero, one, or several `X2DownloadableContentInfo` classes, and the DLCIdentifier may be empty for
+/// any of them. This DLCIdentifier is used for some customization aspects (like part icons or slider names) and
+/// narrative content options (for the official DLCs). It's also used in CHL's Run Order (still need docs, sorry)
+/// since Run Order is all about `X2DownloadableContentInfo` classes.
+///
+/// In the default ModBuddy mod project, the mod has exactly one `X2DownloadableContentInfo` subclass
+/// with a DLCIdentifier identical to the DLCName. However, config-only mods have no `X2DownloadableContentInfo`
+/// at all, and some mods may have one but misconfigured the class so that the `DLCIdentifier` is empty.
+///
+/// ## CHModDependency
+/// 
+/// Now for the actual feature: Let's call the information about a mod provided to
+/// the dependency checker *dependency info*, or *DepInfo*. A mod declares dependency
+/// info through configuration entries for a class of type `CHModDependency` in `XComGame.ini`.
+/// Let's look at an example upfront (taken from [Musashi's RPG Overhaul](https://steamcommunity.com/sharedfiles/filedetails/?id=1280477867)):
+///
+/// ```ini
+/// [XCOM2RPGOverhaul CHModDependency]
+/// DisplayName="Musashis RPG Overhaul"
+///
+/// +IncompatibleMods="NewPromotionScreenbyDefault"
+/// +IncompatibleMods="DetailedSoldierListWOTC"
+/// +IncompatibleMods="ABetterBarracksTLE"
+/// +IncompatibleMods="ABetterBarracks"
+/// +IncompatibleMods="ViewLockedSkillsWotc"
+/// +IncompatibleMods="AddMintToMyChocolate"
+/// +IncompatibleMods="RevisedWeaponUpgrades"
+///
+/// +RequiredMods="WOTC_LW2SecondaryWeapons"
+/// +RequiredMods="PrimarySecondaries"
+/// +RequiredMods="BetterSecondWaveSupport"
+///
+/// +IgnoreRequiredMods="NewPromotionScreenbyDefault"
+/// +IgnoreRequiredMods="ViewLockedSkillsWotc"
+/// +IgnoreRequiredMods="DetailedSoldierListWOTC"
+/// ```
+///
+/// `CHModDependency` is the class that contains our DepInfo. That class is
+/// `perobjectconfig`, so we can provide unique configuration for differently
+/// named instances of the class. In this case, since the DLCName of RPGO is
+/// `XCOM2RPGOverhaul`, we use that in the header.
+///
+/// `DisplayName` is a human-readable name of the mod. This is used for the actual
+/// popup that says for example "&lt;DisplayName&gt; detected INCOMPATIBLE mods".
+///
+/// `IncompatibleMods` is a list of DLCNames that should not be enabled together
+/// with this mod. For every mod with an enabled incompatible mod, there will be a popup
+/// that lists all enabled incompatible mods.
+///
+/// `RequiredMods` is a list of DLCNames that should be enabled together with
+/// this mod. For every mod with a missing required mod, there will be a popup
+/// that lists all missing requirements.
+///
+/// `IgnoreRequiredMods` is a list of DLCNames that should be considered enabled if
+/// this mod is enabled. For example, RPGO integrates `NewPromotionScreenbyDefault`,
+/// so another mod should not consider `NewPromotionScreenbyDefault` missing if RPGO
+/// is enabled.
+///
+/// There also is a `IgnoreIncompatibleMods` list of DLCNames that allows mods to
+/// suppress incompatibilites. For example, an overhaul can consider itself
+/// incompatible with a mod that adds a new weapon type unless a "bridge mod" is
+/// installed that provides functionality the overhaul expects -- that mod would then
+/// add `+IgnoreIncompatibleMods="ThatNewWeaponMod"`.
+///
+/// This is what the popup for missing requirements looks like:
+/// ![Screenshot of RPGO's missing required mods](https://i.imgur.com/D1G6ZF7.png)
+/// Since the missing requirements aren't enabled, we don't have any info about their
+/// DisplayName.
+///
+/// ## How the dependency checker retrieves dependency info
+///
+/// The dependency checker looks at the config objects from
+///
+/// * All currently enabled DLCNames
+/// * All non-empty DLCIdentifiers from found `X2DownloadableContentInfo` classes
+/// 
+/// while ignoring duplicates.
+/// This means that mods can easily provide dependency info for other mods --
+/// the config object will be ignored if the corresponding DLCName isn't
+/// enabled. This also allows mods to add friendly names for other mods so
+/// that even if the mod isn't installed or doesn't set a `DisplayName`.
+///
+/// For example, `AddMintToMyChocolate` doesn't participate in the CHL depencency
+/// checker at all, but this DLCName is kind of confusing and a reported incompatibility
+/// would leave users unable to figure out what the actual conflict is.
+///
+/// RPGO could add this to its `XComGame.ini` so that the name becomes clearer:
+///
+/// ```ini
+/// [AddMintToMyChocolate CHModDependency]
+/// DisplayName="Classless XCOM: MINT"
+/// ```
+///
+/// and the popup would display that incompatibility as "Classless XCOM: MINT (AddMintToMyChocolate)".
+/// The same system can also be used to provide a DisplayName for requirements that may be missing
+/// and as such can't inform the dependency checker about their DisplayName.
+
 class CHModDependency extends Object perobjectconfig Config(Game);
 
 var config array<string> IncompatibleMods;

--- a/X2WOTCCommunityHighlander/Src/XComGame/Classes/CHModDependency.uc
+++ b/X2WOTCCommunityHighlander/Src/XComGame/Classes/CHModDependency.uc
@@ -5,3 +5,10 @@ var config array<string> IgnoreIncompatibleMods;
 var config array<string> RequiredMods;
 var config array<string> IgnoreRequiredMods;
 var config string DisplayName;
+
+final function bool IsInteresting()
+{
+	return IncompatibleMods.Length > 0 || RequiredMods.Length > 0
+		|| IgnoreIncompatibleMods.Length > 0 || IgnoreRequiredMods.Length > 0
+		|| DisplayName != "";
+}

--- a/X2WOTCCommunityHighlander/Src/XComGame/Classes/CHModDependency.uc
+++ b/X2WOTCCommunityHighlander/Src/XComGame/Classes/CHModDependency.uc
@@ -128,10 +128,3 @@ var config array<string> IgnoreIncompatibleMods;
 var config array<string> RequiredMods;
 var config array<string> IgnoreRequiredMods;
 var config string DisplayName;
-
-final function bool IsInteresting()
-{
-	return IncompatibleMods.Length > 0 || RequiredMods.Length > 0
-		|| IgnoreIncompatibleMods.Length > 0 || IgnoreRequiredMods.Length > 0
-		|| DisplayName != "";
-}

--- a/X2WOTCCommunityHighlander/Src/XComGame/Classes/X2DownloadableContentInfo.uc
+++ b/X2WOTCCommunityHighlander/Src/XComGame/Classes/X2DownloadableContentInfo.uc
@@ -768,7 +768,7 @@ final function int GetRunPriorityGroup()
 /// +IgnoreRequiredMods=...
 /// DisplayName="..."
 /// </summary>
-final function array<string> GetIncompatibleDLCIdentifiers()
+final function array<string> GetIncompatibleDLCNames()
 {
 	local CHModDependency ModDependency;
 
@@ -777,7 +777,7 @@ final function array<string> GetIncompatibleDLCIdentifiers()
 	return ModDependency.IncompatibleMods;
 }
 
-final function array<string> GetIgnoreIncompatibleDLCIdentifiers()
+final function array<string> GetIgnoreIncompatibleDLCNames()
 {
 	local CHModDependency ModDependency;
 
@@ -786,7 +786,7 @@ final function array<string> GetIgnoreIncompatibleDLCIdentifiers()
 	return ModDependency.IgnoreIncompatibleMods;
 }
 
-final function array<string> GetRequiredDLCIdentifiers()
+final function array<string> GetRequiredDLCNames()
 {
 	local CHModDependency ModDependency;
 
@@ -795,7 +795,7 @@ final function array<string> GetRequiredDLCIdentifiers()
 	return ModDependency.RequiredMods;
 }
 
-final function array<string> GetIgnoreRequiredDLCIdentifiers()
+final function array<string> GetIgnoreRequiredDLCNames()
 {
 	local CHModDependency ModDependency;
 

--- a/X2WOTCCommunityHighlander/Src/XComGame/Classes/X2DownloadableContentInfo.uc
+++ b/X2WOTCCommunityHighlander/Src/XComGame/Classes/X2DownloadableContentInfo.uc
@@ -757,63 +757,6 @@ final function int GetRunPriorityGroup()
 }
 /// End Issue #511
 
-/// Start Issue #524
-/// <summary>
-/// Allow mods to specify array of incompatible and required mod.
-/// Should be specified in the mods XComGame.ini like
-/// [ModSafeName CHModDependency]
-/// +IncompatibleMods=...
-/// +IgnoreIncompatibleMods=...
-/// +RequiredMods=...
-/// +IgnoreRequiredMods=...
-/// DisplayName="..."
-/// </summary>
-final function array<string> GetIncompatibleDLCNames()
-{
-	local CHModDependency ModDependency;
-
-	ModDependency = new(none, DLCIdentifier)class'CHModDependency';
-	// Equivalent to empty array if not specified in config
-	return ModDependency.IncompatibleMods;
-}
-
-final function array<string> GetIgnoreIncompatibleDLCNames()
-{
-	local CHModDependency ModDependency;
-
-	ModDependency = new(none, DLCIdentifier)class'CHModDependency';
-	// Equivalent to empty array if not specified in config
-	return ModDependency.IgnoreIncompatibleMods;
-}
-
-final function array<string> GetRequiredDLCNames()
-{
-	local CHModDependency ModDependency;
-
-	ModDependency = new(none, DLCIdentifier)class'CHModDependency';
-	// Equivalent to empty array if not specified in config
-	return ModDependency.RequiredMods;
-}
-
-final function array<string> GetIgnoreRequiredDLCNames()
-{
-	local CHModDependency ModDependency;
-
-	ModDependency = new(none, DLCIdentifier)class'CHModDependency';
-	// Equivalent to empty array if not specified in config
-	return ModDependency.IgnoreRequiredMods;
-}
-
-final function string GetDisplayName()
-{
-	local CHModDependency ModDependency;
-
-	ModDependency = new(none, DLCIdentifier)class'CHModDependency';
-	// Equivalent to empty string if not specified in localization
-	return ModDependency.DisplayName;
-}
-/// End Issue #524
-
 // Start Issue #783
 // <summary>
 /// Called from XGCharacterGenerator:CreateTSoldier


### PR DESCRIPTION
The original code was somewhat loose with its terminology, in particular it didn't actually make clear whether a mod dependency was an edge or a reverse edge. This should be equivalent in functionality, but a bit more legible (both in terms of terminology and spelling) and efficient.

On top of that, this code doesn't rely on DLCIdentifiers anymore and instead reads Dependency Info for every DLCIdentifier and every DLCName (while ignoring duplicates).

Unresolved questions:

- [x] Does this work? Never used that feature.
- [x] Are the renamed functions and structs covered by our stability guarantee? Note that there's no way to make some of these functions private or protected, since `X2WOTCCommunityHighlander` needs to access them in `XComGame`.
- [x] Is `IgnoreIncompatibleMods` even a workable design? (moved to different issue)
- [x] Actually document this