### PR TITLE
Document syntax for NewGameState in event specification

### DIFF
--- a/.scripts/make_docs/event_tuples.py
+++ b/.scripts/make_docs/event_tuples.py
@@ -296,7 +296,7 @@ def parse_event_spec(text: str) -> dict:
             elif b == "maybe":
                 spec.newgs = NewGameState.MAYBE
             else:
-                raise ParseError("expected yes, none, or maybe")
+                raise ParseError("expected yes, none, or maybe for NewGameState")
         else:
             raise ParseError(
                 "unexpected key (expected EventID, EventSource, EventData, NewGameState)"

--- a/docs_src/docs/index.md
+++ b/docs_src/docs/index.md
@@ -152,6 +152,7 @@ The syntax for events is the following
     * `enum`s can be typed with `enum[EnumType]`
     * `class`es can be typed with `class[class<Type>]`
     * If the type is not a primitive, it's assumed to be an object
+* `NewGameState` needs to be one of three values: `yes`, `maybe` or `none`
 
 The above example generates the following code
 


### PR DESCRIPTION
Because `event block has error: expected yes, none, or maybe` on the

```
```event
```

line isn't helpful.

See https://github.com/X2CommunityCore/X2WOTCCommunityHighlander/pull/901/checks?check_run_id=1934620008#step:4:9 for an example