### PR TITLE
Allow runtime modification of loc in X2EncyclopediaTemplate

### DIFF
--- a/X2WOTCCommunityHighlander/Src/XComGame/Classes/X2EncyclopediaTemplate.uc
+++ b/X2WOTCCommunityHighlander/Src/XComGame/Classes/X2EncyclopediaTemplate.uc
@@ -1,0 +1,45 @@
+//---------------------------------------------------------------------------------------
+//  FILE:    X2EncyclopediaTemplate.uc
+//  AUTHOR:  Dan Kaplan - 10/1/2015
+//  PURPOSE: Template defining an Encyclopedia entry in X-Com 2.
+//           
+//---------------------------------------------------------------------------------------
+//  Copyright (c) 2016 Firaxis Games, Inc. All rights reserved.
+//---------------------------------------------------------------------------------------
+
+class X2EncyclopediaTemplate extends X2DataTemplate
+	native(Core)
+	config(Encyclopedia);
+
+var config Name					ListCategory;		// Internal name of the category to which this header/entry belong to
+var private localized string	ListTitle;			// Player facing name of this entry/header.
+var config string				ListImagePath;		// The URL to the image that should be displayed as part of the list entry if this is a header.
+
+var private localized string    DescriptionTitle;   // Player facing description title that appears when selected.
+var private localized string    DescriptionEntry;   // Player facing description body that appears when selected.
+var config string				DescriptionImagePath;		// The URL to the image that should be displayed as part of the list entry if this is a header.
+
+var config bool					bCategoryHeader;	// If true, this entry functions as a category header; if false, this entry functions as a regular entry.
+var config int					SortingPriority;	// The priority of this entry relative to others in the same category (lower priority sorts higher in the list).
+var config StrategyRequirement  Requirements;		// Requirements to show up in the archive
+
+
+
+function string GetListTitle()
+{
+	return ListTitle;
+}
+
+function string GetDescriptionTitle()
+{
+	return DescriptionTitle;
+}
+
+function string GetDescriptionEntry()
+{
+	return `XEXPAND.ExpandString(DescriptionEntry);
+}
+
+defaultproperties
+{
+}

--- a/X2WOTCCommunityHighlander/Src/XComGame/Classes/X2EncyclopediaTemplate.uc
+++ b/X2WOTCCommunityHighlander/Src/XComGame/Classes/X2EncyclopediaTemplate.uc
@@ -11,13 +11,15 @@ class X2EncyclopediaTemplate extends X2DataTemplate
 	native(Core)
 	config(Encyclopedia);
 
+// Start Issue #982 - allow runtime modification of loc
 var config Name					ListCategory;		// Internal name of the category to which this header/entry belong to
-var private localized string	ListTitle;			// Player facing name of this entry/header.
+var /*private*/ localized string	ListTitle;			// Player facing name of this entry/header.
 var config string				ListImagePath;		// The URL to the image that should be displayed as part of the list entry if this is a header.
 
-var private localized string    DescriptionTitle;   // Player facing description title that appears when selected.
-var private localized string    DescriptionEntry;   // Player facing description body that appears when selected.
+var /*private*/ localized string    DescriptionTitle;   // Player facing description title that appears when selected.
+var /*private*/ localized string    DescriptionEntry;   // Player facing description body that appears when selected.
 var config string				DescriptionImagePath;		// The URL to the image that should be displayed as part of the list entry if this is a header.
+// End Issue #982
 
 var config bool					bCategoryHeader;	// If true, this entry functions as a category header; if false, this entry functions as a regular entry.
 var config int					SortingPriority;	// The priority of this entry relative to others in the same category (lower priority sorts higher in the list).

--- a/X2WOTCCommunityHighlander/X2WOTCCommunityHighlander.x2proj
+++ b/X2WOTCCommunityHighlander/X2WOTCCommunityHighlander.x2proj
@@ -421,6 +421,9 @@
     <Content Include="Src\XComGame\Classes\X2Effect_Burning.uc">
       <SubType>Content</SubType>
     </Content>
+    <Content Include="Src\XComGame\Classes\X2EncyclopediaTemplate.uc">
+      <SubType>Content</SubType>
+    </Content>
     <Content Include="Src\XComGame\Classes\X2FiraxisLiveClient.uc">
       <SubType>Content</SubType>
     </Content>


### PR DESCRIPTION
Closes #982 

Marking `de-private/const` as #839 was - I don't think a formal way of documenting these changes has been implemented yet