### PR TITLE
Mods can specify required Highlander version in config (reupload)

### DIFF
--- a/X2WOTCCommunityHighlander/Localization/X2WOTCCommunityHighlander.int
+++ b/X2WOTCCommunityHighlander/Localization/X2WOTCCommunityHighlander.int
@@ -14,6 +14,13 @@ ModIncompatiblePopupTitle="detected INCOMPATIBLE mods"
 ModIncompatible="Please DEACTIVATE the following mods and restart or %s will not work properly:"
 DisablePopup="DO NOT SHOW ME THIS AGAIN"
 
+;    Issue #909
+ModRequiresNewerHighlanderVersionTitle = "MOD REQUIRES NEWER HIGHLANDER VERSION"
+ModRequiresNewerHighlanderVersionText = "Mod requires newer Highlander version:"
+CurrentHighlanderVersionTitle = "Installed Version:"
+RequiredHighlanderVersionTitle = "Required Version: "
+ModRequiresNewerHighlanderVersionExtraText = "Please update X2WOTCCommunityHighlander to the required version. Otherwise you may experience crashes and other malfunctions."
+
 [X2WOTCCH_UIScreenListener_ShellPopup]
 ErrorTitle="Mod Configuration Error"
 

--- a/X2WOTCCommunityHighlander/Src/XComGame/Classes/CHModDependency.uc
+++ b/X2WOTCCommunityHighlander/Src/XComGame/Classes/CHModDependency.uc
@@ -128,3 +128,30 @@ var config array<string> IgnoreIncompatibleMods;
 var config array<string> RequiredMods;
 var config array<string> IgnoreRequiredMods;
 var config string DisplayName;
+
+// Start Issue #909
+/// HL-Docs: feature:RequiredHighlanderVersion; issue:909; tags:compatibility
+/// Mods can specify the required Highlander version in the mod's `XComGame.ini`, e.g.:
+///```ini
+/// [DLCName CHModDependency]
+/// RequiredHighlanderVersion = (MajorVersion = 1, MinorVersion = 22, PatchVersion = 0)
+///```
+/// If the mod user has an older version of the Highlander installed, they will 
+/// see a popup warning when they start the game. 
+/// Note: this feature is disabled if the game is started without the `-review`
+/// launch argument. 
+struct CHLVersionStruct
+{
+	var int MajorVersion;
+	var int MinorVersion;
+	var int PatchVersion;
+
+	structdefaultproperties
+	{
+		MajorVersion = -1
+		MinorVersion = -1
+		PatchVersion = -1
+	}
+};
+var config CHLVersionStruct RequiredHighlanderVersion;
+// End Issue #909


### PR DESCRIPTION
Closes #909

Replaces #955

Here's how the popup looks: 

https://i.imgur.com/Mrll6e9.jpg

A slight issue with this approach is that we don't display Highlander version on the workshop, so most people who see this popup will have trouble figuring out what are they supposed to do to update the Highlander.
