### PR TITLE
Fix pods not scampering (#1008)

### DIFF
--- a/X2WOTCCommunityHighlander/Src/XComGame/Classes/XGAIBehavior.uc
+++ b/X2WOTCCommunityHighlander/Src/XComGame/Classes/XGAIBehavior.uc
@@ -9988,8 +9988,11 @@ simulated function SkipTurn( optional string DebugLogText="" )
 	RefreshUnitCache();
 	if (UnitState.NumAllActionPoints() != 0)
 	{
+		/// HL-Docs: ref:Bugfixes; issue:1008
+		/// Entire pods no longer fail to scamper if the pod leader skips its turn,
+		/// for example if it's immobilized.
 		// If unrevealed, the entire group skips its turn.  Fixes assert with group movement, after group leader skips its move.
-		if( StartedTurnUnrevealed() )
+		if( StartedTurnUnrevealed() && /* Issue #1008 */ !m_kPlayer.IsScampering(UnitState.ObjectID) )
 		{
 			SkipGroupTurn();
 		}


### PR DESCRIPTION
The `SkipTurn()` implementation in `XGAIBehavior` skips the entire pod's turn if the pod starts the turn "unrevealed", which basically means they haven't activated by the start of the turn. This happens when the pod
leader skips moving on activation, for example if they're immobilized or panicked.

The fix I've implemented here is to check whether the pod is scampering and only skip the pod's turn if they *aren't*. This ensures that the pod members that can scamper actually do so.

Fixes #1008.