### PR TITLE
Remove campaign-start listeners once not needed (#971)

### DIFF
--- a/X2WOTCCommunityHighlander/Src/XComGame/Classes/XComGameStateContext_StrategyGameRule.uc
+++ b/X2WOTCCommunityHighlander/Src/XComGame/Classes/XComGameStateContext_StrategyGameRule.uc
@@ -235,6 +235,13 @@ static function XComGameState CreateStrategyGameStart(
 		}
 	}
 
+	// Start Issue #971
+	//
+	// Clear out the campaign start listeners to ensure they don't hang around
+	// for longer than they're needed.
+	class'X2EventListenerTemplateManager'.static.UnRegisterAllListeners();
+	// End Issue #971
+
 	return StartState;
 }
 


### PR DESCRIPTION
The campaign-start listeners are now removed at the end of `CreateStrategyGameStart` to ensure they don't end up hanging around too long.

Resolves #971 *-- @Xymanek*