### PR TITLE
Include DLC2 Highlander in documentation

### DIFF
--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -37,7 +37,7 @@ jobs:
         # Build base docs (master)
         git checkout ${{ github.base_ref }}
         mkdir target
-        python ./.scripts/make_docs.py ./X2WOTCCommunityHighlander/Src/ ./X2WOTCCommunityHighlander/Config/ --docsdir ./docs_src --dumpelt ./target/CHL_Event_Compiletest.uc
+        python ./.scripts/make_docs.py --indirsfile ./docs_directories.txt --docsdir ./docs_src --dumpelt ./target/CHL_Event_Compiletest.uc
         if [ $? -ne 0 ]
         then
           echo "master docs build broken?"
@@ -47,7 +47,7 @@ jobs:
 
         # Build PR merge docs
         git checkout ${{ github.sha }}
-        python ./.scripts/make_docs.py ./X2WOTCCommunityHighlander/Src/ ./X2WOTCCommunityHighlander/Config/ --docsdir ./docs_src --dumpelt ./target/CHL_Event_Compiletest.uc
+        python ./.scripts/make_docs.py --indirsfile ./docs_directories.txt --docsdir ./docs_src --dumpelt ./target/CHL_Event_Compiletest.uc
         if [ $? -ne 0 ]
         then
           echo "PR docs fail -- should be caught by build job"
@@ -81,7 +81,7 @@ jobs:
       uses: actions/checkout@v2
     - name: Build Docs
       run: |
-        python ./.scripts/make_docs.py ./X2WOTCCommunityHighlander/Src/ ./X2WOTCCommunityHighlander/Config/ --outdir ./mkdocs --docsdir ./docs_src
+        python ./.scripts/make_docs.py --indirsfile ./docs_directories.txt --outdir ./mkdocs --docsdir ./docs_src
         pip install mkdocs
         cd mkdocs
         mkdocs build -d ../target

--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -41,7 +41,7 @@ jobs:
         if [ $? -ne 0 ]
         then
           echo "master docs build broken?"
-          exit 0
+          exit 1
         fi
         git add -f ./target/CHL_Event_Compiletest.uc
 
@@ -51,7 +51,7 @@ jobs:
         if [ $? -ne 0 ]
         then
           echo "PR docs fail -- should be caught by build job"
-          exit 0
+          exit 1
         fi
 
         # Generate diff between master and PR merge

--- a/.vscode/tasks.json
+++ b/.vscode/tasks.json
@@ -59,7 +59,7 @@
         {
             "label": "makeDocs",
             "type": "shell",
-            "command": "python .\\.scripts\\make_docs.py .\\X2WOTCCommunityHighlander\\Src .\\X2WOTCCommunityHighlander\\Config --outdir .\\target --docsdir .\\docs_src --dumpelt .\\target\\CHL_Event_Compiletest.uc",
+            "command": "python .\\.scripts\\make_docs.py --indirsfile .\\docs_directories.txt --outdir .\\target --docsdir .\\docs_src --dumpelt .\\target\\CHL_Event_Compiletest.uc",
             "problemMatcher": []
         },
         {

--- a/Components/DLC2CommunityHighlander/DLC2CommunityHighlander/Src/DLC_2/Classes/XComGameState_AlienRulerManager.uc
+++ b/Components/DLC2CommunityHighlander/DLC2CommunityHighlander/Src/DLC_2/Classes/XComGameState_AlienRulerManager.uc
@@ -486,7 +486,7 @@ function UpdateRulerSpawningData(XComGameState NewGameState, XComGameState_Missi
 // Start issue #791
 /// HL-Docs: feature:AllowRulerOnMission; issue:791; tags:strategy,dlc2
 /// Allows listeners to forbid a particular (or all) rulers from a particular `XComGameState_MissionSite`.
-//
+///
 /// Be aware that the AlienRulerLocations system completely bypasses this check (doesn't trigger this event).
 ///
 /// ```event

--- a/docs_directories.txt
+++ b/docs_directories.txt
@@ -1,0 +1,4 @@
+./X2WOTCCommunityHighlander/Config/
+./X2WOTCCommunityHighlander/Src/
+#./Components/DLC2CommunityHighlander/DLC2CommunityHighlander/Config/
+./Components/DLC2CommunityHighlander/DLC2CommunityHighlander/Src/

--- a/docs_src/docs/index.md
+++ b/docs_src/docs/index.md
@@ -24,7 +24,7 @@ MarkDown pages, which `MkDocs` in turn renders to a web page.
 You can run the documentation tool locally by installing Python (recommended version 3.7)
 and running
 
-    python .\.scripts\make_docs.py .\X2WOTCCommunityHighlander\Src\ .\X2WOTCCommunityHighlander\Config\ --outdir .\target\ --docsdir .\docs_src\ --dumpelt .\target\CHL_Event_Compiletest.uc
+    python .\.scripts\make_docs.py --indirsfile .\docs_directories.txt --outdir .\target\ --docsdir .\docs_src\ --dumpelt .\target\CHL_Event_Compiletest.uc
 
 or the `makeDocs` task in VS Code. This creates Markdown files for the documentation; rendering HTML documentation requires
 `MkDocs`:


### PR DESCRIPTION
Fixes #1017. Folders list got a bit unwieldy, so we allow a separate file to list documentation input directories.