### PR TITLE
Add gameplay visibility condition to second shots (#1022)

### DIFF
--- a/X2WOTCCommunityHighlander/Src/XComGame/Classes/X2Ability_GrenadierAbilitySet.uc
+++ b/X2WOTCCommunityHighlander/Src/XComGame/Classes/X2Ability_GrenadierAbilitySet.uc
@@ -898,6 +898,7 @@ static function X2AbilityTemplate ChainShot2()
 	Template.AddShooterEffectExclusions();
 
 	Template.AbilityTargetConditions.AddItem(default.LivingHostileTargetProperty);
+	Template.AbilityTargetConditions.AddItem(default.GameplayVisibilityCondition);
 
 	Template.AddTargetEffect(HoloTargetEffect());
 	Template.AssociatedPassives.AddItem('HoloTargeting');

--- a/X2WOTCCommunityHighlander/Src/XComGame/Classes/X2Ability_RangerAbilitySet.uc
+++ b/X2WOTCCommunityHighlander/Src/XComGame/Classes/X2Ability_RangerAbilitySet.uc
@@ -1,0 +1,843 @@
+//---------------------------------------------------------------------------------------
+//  FILE:    X2Ability_RangerAbilitySet.uc
+//  AUTHOR:  Timothy Talley  --  03/06/2014
+//  PURPOSE: Defines all Ranger Based Class Abilities
+//           
+//---------------------------------------------------------------------------------------
+//  Copyright (c) 2016 Firaxis Games, Inc. All rights reserved.
+//---------------------------------------------------------------------------------------
+class X2Ability_RangerAbilitySet extends X2Ability
+	dependson (XComGameStateContext_Ability) config(GameData_SoldierSkills);
+
+var config int BLADEMASTER_DMG, BLADEMASTER_AIM;
+var config int STEALTH_CHARGES;
+var config int SHADOWSTRIKE_AIM, SHADOWSTRIKE_CRIT;
+var config int MAX_UNTOUCHABLE;
+var config int REAPER_COOLDOWN;
+var config int INSTINCT_DMG, INSTINCT_CRIT;
+var config int RAPIDFIRE_AIM;
+var config int RUNANDGUN_COOLDOWN;
+
+var name SwordSliceName;
+
+static function array<X2DataTemplate> CreateTemplates()
+{
+	local array<X2DataTemplate> Templates;
+	
+	Templates.AddItem(Stealth());
+	Templates.AddItem(Blademaster());
+	Templates.AddItem(AddHuntersInstinctAbility());
+	Templates.AddItem(AddSwordSliceAbility());
+	Templates.AddItem(RunAndGunAbility('RunAndGun'));
+	Templates.AddItem(Reaper());
+	Templates.AddItem(Untouchable());
+	Templates.AddItem(Implacable());
+	Templates.AddItem(Shadowstep());
+	Templates.AddItem(Shadowstrike());
+	Templates.AddItem(Phantom());
+	Templates.AddItem(Bladestorm());
+	Templates.AddItem(BladestormAttack());
+	Templates.AddItem(DeepCover());
+	Templates.AddItem(DeepCoverTrigger());
+	Templates.AddItem(RapidFire());
+	Templates.AddItem(RapidFire2());
+
+	return Templates;
+}
+
+static function X2AbilityTemplate Stealth(name AbilityName = 'Stealth')
+{
+	local X2AbilityTemplate						Template;
+	local X2Effect_RangerStealth                StealthEffect;
+	local X2AbilityCharges                      Charges;
+
+	`CREATE_X2ABILITY_TEMPLATE(Template, AbilityName);
+
+	Template.AbilitySourceName = 'eAbilitySource_Perk';
+	Template.eAbilityIconBehaviorHUD = eAbilityIconBehavior_AlwaysShow;
+	Template.Hostility = eHostility_Neutral;
+	Template.IconImage = "img:///UILibrary_PerkIcons.UIPerk_stealth";
+	Template.ShotHUDPriority = class'UIUtilities_Tactical'.const.CLASS_COLONEL_PRIORITY;
+
+	Template.AbilityToHitCalc = default.DeadEye;
+	Template.AbilityTargetStyle = default.SelfTarget;
+	Template.AbilityTriggers.AddItem(default.PlayerInputTrigger);
+	Template.AbilityCosts.AddItem(new class'X2AbilityCost_Charges');
+	Template.AbilityCosts.AddItem(default.FreeActionCost);
+
+	Charges = new class'X2AbilityCharges';
+	Charges.InitialCharges = default.STEALTH_CHARGES;
+	Template.AbilityCharges = Charges;
+
+	Template.AbilityShooterConditions.AddItem(default.LivingShooterProperty);
+	Template.AbilityShooterConditions.AddItem(new class'X2Condition_Stealth');
+	Template.AddShooterEffectExclusions();
+
+	StealthEffect = new class'X2Effect_RangerStealth';
+	StealthEffect.BuildPersistentEffect(1, true, true, false, eGameRule_PlayerTurnEnd);
+	StealthEffect.SetDisplayInfo(ePerkBuff_Bonus, Template.LocFriendlyName, Template.GetMyHelpText(), Template.IconImage, true);
+	StealthEffect.bRemoveWhenTargetConcealmentBroken = true;
+	Template.AddTargetEffect(StealthEffect);
+
+	Template.AddTargetEffect(class'X2Effect_Spotted'.static.CreateUnspottedEffect());
+
+	Template.ActivationSpeech = 'ActivateConcealment';
+	Template.BuildNewGameStateFn = TypicalAbility_BuildGameState;
+	Template.BuildVisualizationFn = TypicalAbility_BuildVisualization;
+	Template.bSkipFireAction = true;
+
+	Template.ChosenActivationIncreasePerUse = class'X2AbilityTemplateManager'.default.NonAggressiveChosenActivationIncreasePerUse;
+
+	return Template;
+}
+
+static function X2AbilityTemplate Blademaster()
+{
+	local X2AbilityTemplate						Template;
+	local X2Effect_BonusWeaponDamage            DamageEffect;
+	local X2Effect_ToHitModifier                HitModEffect;
+
+	// Icon Properties
+	`CREATE_X2ABILITY_TEMPLATE(Template, 'Blademaster');
+	Template.IconImage = "img:///UILibrary_PerkIcons.UIPerk_momentum";
+
+	Template.AbilitySourceName = 'eAbilitySource_Perk';
+	Template.eAbilityIconBehaviorHUD = EAbilityIconBehavior_NeverShow;
+	Template.Hostility = eHostility_Neutral;
+
+	Template.AbilityToHitCalc = default.DeadEye;
+	Template.AbilityTargetStyle = default.SelfTarget;
+	Template.AbilityTriggers.AddItem(default.UnitPostBeginPlayTrigger);
+
+	DamageEffect = new class'X2Effect_BonusWeaponDamage';
+	DamageEffect.BonusDmg = default.BLADEMASTER_DMG;
+	DamageEffect.BuildPersistentEffect(1, true, false, false);
+	DamageEffect.SetDisplayInfo(ePerkBuff_Passive, Template.LocFriendlyName, Template.GetMyLongDescription(), Template.IconImage, true,,Template.AbilitySourceName);
+	Template.AddTargetEffect(DamageEffect);
+
+	HitModEffect = new class'X2Effect_ToHitModifier';
+	HitModEffect.AddEffectHitModifier(eHit_Success, default.BLADEMASTER_AIM, Template.LocFriendlyName, , true, false, true, true);
+	HitModEffect.BuildPersistentEffect(1, true, false, false);
+	HitModEffect.EffectName = 'BlademasterAim';
+	Template.AddTargetEffect(HitModEffect);
+
+	Template.BuildNewGameStateFn = TypicalAbility_BuildGameState;
+	//  NOTE: No visualization on purpose!
+
+	return Template;
+}
+
+//******** Hunter's Instinct Ability **********
+static function X2AbilityTemplate AddHuntersInstinctAbility()
+{
+	local X2AbilityTemplate						Template;
+	local X2Effect_HuntersInstinctDamage        DamageModifier;
+
+	`CREATE_X2ABILITY_TEMPLATE(Template, 'HuntersInstinct');
+
+	Template.AbilitySourceName = 'eAbilitySource_Perk';
+	Template.eAbilityIconBehaviorHUD = EAbilityIconBehavior_NeverShow;
+	Template.Hostility = eHostility_Neutral;
+	Template.IconImage = "img:///UILibrary_PerkIcons.UIPerk_hunter";
+
+	Template.AbilityToHitCalc = default.DeadEye;
+	Template.AbilityTargetStyle = default.SelfTarget;
+	Template.AbilityTriggers.AddItem(default.UnitPostBeginPlayTrigger);
+
+	DamageModifier = new class'X2Effect_HuntersInstinctDamage';
+	DamageModifier.BonusDamage = default.INSTINCT_DMG;
+	DamageModifier.BonusCritChance = default.INSTINCT_CRIT;
+	DamageModifier.BuildPersistentEffect(1, true, true, true);
+	DamageModifier.SetDisplayInfo(ePerkBuff_Passive, Template.LocFriendlyName, Template.GetMyLongDescription(), Template.IconImage, true,,Template.AbilitySourceName);
+	Template.AddTargetEffect(DamageModifier);
+
+	Template.BuildNewGameStateFn = TypicalAbility_BuildGameState;
+	//  NOTE: No visualization on purpose!
+
+	return Template;
+}
+
+static function X2AbilityTemplate AddSwordSliceAbility(optional Name AbilityName = default.SwordSliceName)
+{
+	local X2AbilityTemplate                 Template;
+	local X2AbilityCost_ActionPoints        ActionPointCost;
+	local X2AbilityToHitCalc_StandardMelee  StandardMelee;
+	local X2Effect_ApplyWeaponDamage        WeaponDamageEffect;
+	local array<name>                       SkipExclusions;
+
+	`CREATE_X2ABILITY_TEMPLATE(Template, AbilityName);
+
+	Template.AbilitySourceName = 'eAbilitySource_Standard';
+	Template.eAbilityIconBehaviorHUD = EAbilityIconBehavior_AlwaysShow;
+	Template.BuildNewGameStateFn = TypicalMoveEndAbility_BuildGameState;
+	Template.BuildVisualizationFn = TypicalAbility_BuildVisualization;
+	Template.BuildInterruptGameStateFn = TypicalMoveEndAbility_BuildInterruptGameState;	
+	Template.CinescriptCameraType = "Ranger_Reaper";
+	Template.IconImage = "img:///UILibrary_PerkIcons.UIPerk_swordSlash";
+	Template.bHideOnClassUnlock = false;
+	Template.ShotHUDPriority = class'UIUtilities_Tactical'.const.CLASS_SQUADDIE_PRIORITY;
+	Template.AbilityConfirmSound = "TacticalUI_SwordConfirm";
+
+	ActionPointCost = new class'X2AbilityCost_ActionPoints';
+	ActionPointCost.iNumPoints = 1;
+	ActionPointCost.bConsumeAllPoints = true;
+	Template.AbilityCosts.AddItem(ActionPointCost);
+	
+	StandardMelee = new class'X2AbilityToHitCalc_StandardMelee';
+	Template.AbilityToHitCalc = StandardMelee;
+
+	Template.AbilityTargetStyle = new class'X2AbilityTarget_MovingMelee';
+	Template.TargetingMethod = class'X2TargetingMethod_MeleePath';
+
+	Template.AbilityTriggers.AddItem(default.PlayerInputTrigger);
+	Template.AbilityTriggers.AddItem(new class'X2AbilityTrigger_EndOfMove');
+
+	// Target Conditions
+	//
+	Template.AbilityTargetConditions.AddItem(default.LivingHostileTargetProperty);
+	Template.AbilityTargetConditions.AddItem(default.MeleeVisibilityCondition);
+
+	// Shooter Conditions
+	//
+	Template.AbilityShooterConditions.AddItem(default.LivingShooterProperty);
+	SkipExclusions.AddItem(class'X2StatusEffects'.default.BurningName);
+	Template.AddShooterEffectExclusions(SkipExclusions);
+
+	// Damage Effect
+	//
+	WeaponDamageEffect = new class'X2Effect_ApplyWeaponDamage';
+	Template.AddTargetEffect(WeaponDamageEffect);
+
+	Template.bAllowBonusWeaponEffects = true;
+	Template.bSkipMoveStop = true;
+	
+	// Voice events
+	//
+	Template.SourceMissSpeech = 'SwordMiss';
+
+	Template.SuperConcealmentLoss = class'X2AbilityTemplateManager'.default.SuperConcealmentStandardShotLoss;
+	Template.ChosenActivationIncreasePerUse = class'X2AbilityTemplateManager'.default.StandardShotChosenActivationIncreasePerUse;
+	Template.LostSpawnIncreasePerUse = class'X2AbilityTemplateManager'.default.MeleeLostSpawnIncreasePerUse;
+	Template.bFrameEvenWhenUnitIsHidden = true;
+
+	return Template;
+}
+
+static function X2AbilityTemplate RunAndGunAbility(Name AbilityName)
+{
+	local X2AbilityTemplate				Template;
+	local X2AbilityCooldown				Cooldown;
+	local X2Effect_GrantActionPoints    ActionPointEffect;
+	local X2AbilityCost_ActionPoints    ActionPointCost;
+
+	`CREATE_X2ABILITY_TEMPLATE(Template, AbilityName);
+
+	// Icon Properties
+	Template.DisplayTargetHitChance = false;
+	Template.AbilitySourceName = 'eAbilitySource_Perk';                                       // color of the icon
+	Template.IconImage = "img:///UILibrary_PerkIcons.UIPerk_runandgun";
+	Template.ShotHUDPriority = class'UIUtilities_Tactical'.const.CLASS_LIEUTENANT_PRIORITY;
+	Template.Hostility = eHostility_Neutral;
+	Template.eAbilityIconBehaviorHUD = eAbilityIconBehavior_AlwaysShow;
+	Template.AbilityConfirmSound = "TacticalUI_Activate_Ability_Run_N_Gun";
+
+	Cooldown = new class'X2AbilityCooldown';
+	Cooldown.iNumTurns = default.RUNANDGUN_COOLDOWN;
+	Template.AbilityCooldown = Cooldown;
+
+	ActionPointCost = new class'X2AbilityCost_ActionPoints';
+	ActionPointCost.iNumPoints = 1;
+	ActionPointCost.bFreeCost = true;
+	Template.AbilityCosts.AddItem(ActionPointCost);
+
+	Template.AbilityToHitCalc = default.DeadEye;
+
+	SuperKillRestrictions(Template, 'RunAndGun_SuperKillCheck');
+	Template.AbilityShooterConditions.AddItem(default.LivingShooterProperty);
+	Template.AddShooterEffectExclusions();
+
+	ActionPointEffect = new class'X2Effect_GrantActionPoints';
+	ActionPointEffect.NumActionPoints = 1;
+	ActionPointEffect.PointType = class'X2CharacterTemplateManager'.default.RunAndGunActionPoint;
+	Template.AddTargetEffect(ActionPointEffect);
+
+	Template.AbilityTargetStyle = default.SelfTarget;	
+	Template.AbilityTriggers.AddItem(default.PlayerInputTrigger);
+
+	Template.bShowActivation = true;
+	Template.bSkipFireAction = true;
+
+	Template.ActivationSpeech = 'RunAndGun';
+		
+	Template.BuildNewGameStateFn = TypicalAbility_BuildGameState;
+	Template.BuildVisualizationFn = TypicalAbility_BuildVisualization;
+
+	Template.bCrossClassEligible = true;
+
+	return Template;
+}
+
+static function X2AbilityTemplate Reaper()
+{
+	local X2AbilityTemplate				Template;
+	local X2AbilityCooldown				Cooldown;
+	local X2Effect_Reaper               ReaperEffect;
+	local X2AbilityCost_ActionPoints    ActionPointCost;
+
+	`CREATE_X2ABILITY_TEMPLATE(Template, 'Reaper');
+
+	// Icon Properties
+	Template.DisplayTargetHitChance = false;
+	Template.AbilitySourceName = 'eAbilitySource_Perk';                                       // color of the icon
+	Template.IconImage = "img:///UILibrary_PerkIcons.UIPerk_reaper";
+	Template.ShotHUDPriority = class'UIUtilities_Tactical'.const.CLASS_COLONEL_PRIORITY;
+	Template.Hostility = eHostility_Neutral;
+	Template.eAbilityIconBehaviorHUD = eAbilityIconBehavior_AlwaysShow;
+	Template.AbilityConfirmSound = "TacticalUI_ActivateAbility";
+
+	Cooldown = new class'X2AbilityCooldown';
+	Cooldown.iNumTurns = default.REAPER_COOLDOWN;
+	Template.AbilityCooldown = Cooldown;
+
+	ActionPointCost = new class'X2AbilityCost_ActionPoints';
+	ActionPointCost.iNumPoints = 1;
+	ActionPointCost.bFreeCost = true;
+	Template.AbilityCosts.AddItem(ActionPointCost);
+
+	Template.AbilityToHitCalc = default.DeadEye;
+
+	SuperKillRestrictions(Template, 'Reaper_SuperKillCheck');
+	Template.AbilityShooterConditions.AddItem(default.LivingShooterProperty);
+	Template.AddShooterEffectExclusions();
+
+	ReaperEffect = new class'X2Effect_Reaper';
+	ReaperEffect.BuildPersistentEffect(1, false, true, false, eGameRule_PlayerTurnEnd);
+	ReaperEffect.SetDisplayInfo(ePerkBuff_Bonus, Template.LocFriendlyName, Template.GetMyHelpText(), Template.IconImage, true, , Template.AbilitySourceName);
+	Template.AddTargetEffect(ReaperEffect);
+
+	Template.AbilityTargetStyle = default.SelfTarget;	
+	Template.AbilityTriggers.AddItem(default.PlayerInputTrigger);
+	
+	Template.bShowActivation = true;
+	Template.bSkipFireAction = true;
+
+	Template.ActivationSpeech = 'Reaper';
+		
+	Template.BuildNewGameStateFn = TypicalAbility_BuildGameState;
+	Template.BuildVisualizationFn = TypicalAbility_BuildVisualization;
+
+	return Template;
+}
+
+static function X2AbilityTemplate Untouchable()
+{
+	local X2AbilityTemplate						Template;
+	local X2AbilityTargetStyle                  TargetStyle;
+	local X2AbilityTrigger						Trigger;
+	local X2Effect_Untouchable                  UntouchableEffect;
+
+	`CREATE_X2ABILITY_TEMPLATE(Template, 'Untouchable');
+
+	Template.AbilitySourceName = 'eAbilitySource_Perk';
+	Template.eAbilityIconBehaviorHUD = EAbilityIconBehavior_NeverShow;
+	Template.Hostility = eHostility_Neutral;
+	Template.IconImage = "img:///UILibrary_PerkIcons.UIPerk_evasion";
+
+	Template.AbilityToHitCalc = default.DeadEye;
+
+	TargetStyle = new class'X2AbilityTarget_Self';
+	Template.AbilityTargetStyle = TargetStyle;
+
+	Trigger = new class'X2AbilityTrigger_UnitPostBeginPlay';
+	Template.AbilityTriggers.AddItem(Trigger);
+
+	UntouchableEffect = new class'X2Effect_Untouchable';
+	UntouchableEffect.BuildPersistentEffect(1, true, false, false);
+	UntouchableEffect.SetDisplayInfo(ePerkBuff_Passive, Template.LocFriendlyName, Template.GetMyLongDescription(), Template.IconImage,,,Template.AbilitySourceName);
+	UntouchableEffect.DuplicateResponse = eDupe_Ignore;
+	Template.AddTargetEffect(UntouchableEffect);
+
+	Template.BuildNewGameStateFn = TypicalAbility_BuildGameState;
+	//  NOTE: No visualization on purpose!
+
+	Template.bCrossClassEligible = true;
+
+	return Template;
+}
+
+static function X2AbilityTemplate Implacable()
+{
+	local X2AbilityTemplate						Template;
+	local X2Effect_Implacable                   ImplacableEffect;
+
+	`CREATE_X2ABILITY_TEMPLATE(Template, 'Implacable');
+
+	Template.AbilitySourceName = 'eAbilitySource_Perk';
+	Template.eAbilityIconBehaviorHUD = EAbilityIconBehavior_NeverShow;
+	Template.Hostility = eHostility_Neutral;
+	Template.IconImage = "img:///UILibrary_PerkIcons.UIPerk_implacable";
+
+	Template.AbilityToHitCalc = default.DeadEye;
+	Template.AbilityTargetStyle = default.SelfTarget;
+	Template.AbilityTriggers.AddItem(default.UnitPostBeginPlayTrigger);
+
+	ImplacableEffect = new class'X2Effect_Implacable';
+	ImplacableEffect.BuildPersistentEffect(1, true, false, false);
+	ImplacableEffect.SetDisplayInfo(ePerkBuff_Passive, Template.LocFriendlyName, Template.GetMyLongDescription(), Template.IconImage,,,Template.AbilitySourceName);
+	ImplacableEffect.DuplicateResponse = eDupe_Ignore;
+	Template.AddTargetEffect(ImplacableEffect);
+
+	Template.BuildNewGameStateFn = TypicalAbility_BuildGameState;
+	//  NOTE: No visualization on purpose!
+
+	Template.bCrossClassEligible = true;
+
+	return Template;
+}
+
+static function X2AbilityTemplate Shadowstep()
+{
+	local X2AbilityTemplate						Template;
+	local X2Effect_Persistent                   Effect;
+
+	`CREATE_X2ABILITY_TEMPLATE(Template, 'Shadowstep');
+
+	Template.AbilitySourceName = 'eAbilitySource_Perk';
+	Template.eAbilityIconBehaviorHUD = eAbilityIconBehavior_NeverShow;
+	Template.Hostility = eHostility_Neutral;
+	Template.IconImage = "img:///UILibrary_PerkIcons.UIPerk_shadowstep";
+
+	Template.AbilityToHitCalc = default.DeadEye;
+	Template.AbilityTargetStyle = default.SelfTarget;
+	Template.AbilityTriggers.AddItem(default.UnitPostBeginPlayTrigger);
+
+	Effect = new class'X2Effect_Persistent';
+	Effect.EffectName = 'Shadowstep';
+	Effect.DuplicateResponse = eDupe_Ignore;
+	Effect.BuildPersistentEffect(1, true, false);
+	Effect.SetDisplayInfo(ePerkBuff_Passive, Template.LocFriendlyName, Template.GetMyLongDescription(), Template.IconImage,,,Template.AbilitySourceName);
+	Template.AddTargetEffect(Effect);
+
+	Template.BuildNewGameStateFn = TypicalAbility_BuildGameState;
+	//  NOTE: No visualization on purpose!
+
+	Template.bCrossClassEligible = true;
+
+	return Template;
+}
+
+static function X2AbilityTemplate Shadowstrike()
+{
+	local X2AbilityTemplate						Template;
+	local X2Effect_ToHitModifier                Effect;
+	local X2Condition_Visibility                VisCondition;
+
+	`CREATE_X2ABILITY_TEMPLATE(Template, 'Shadowstrike');
+
+	Template.AbilitySourceName = 'eAbilitySource_Perk';
+	Template.eAbilityIconBehaviorHUD = eAbilityIconBehavior_NeverShow;
+	Template.Hostility = eHostility_Neutral;
+	Template.IconImage = "img:///UILibrary_PerkIcons.UIPerk_shadowstrike";
+
+	Template.AbilityToHitCalc = default.DeadEye;
+	Template.AbilityTargetStyle = default.SelfTarget;
+	Template.AbilityTriggers.AddItem(default.UnitPostBeginPlayTrigger);
+
+	Effect = new class'X2Effect_ToHitModifier';
+	Effect.EffectName = 'Shadowstrike';
+	Effect.DuplicateResponse = eDupe_Ignore;
+	Effect.BuildPersistentEffect(1, true, false);
+	Effect.SetDisplayInfo(ePerkBuff_Passive, Template.LocFriendlyName, Template.GetMyLongDescription(), Template.IconImage,,,Template.AbilitySourceName);
+	Effect.AddEffectHitModifier(eHit_Success, default.SHADOWSTRIKE_AIM, Template.LocFriendlyName);
+	Effect.AddEffectHitModifier(eHit_Crit, default.SHADOWSTRIKE_CRIT, Template.LocFriendlyName);
+	VisCondition = new class'X2Condition_Visibility';
+	VisCondition.bExcludeGameplayVisible = true;
+	Effect.ToHitConditions.AddItem(VisCondition);
+	Template.AddTargetEffect(Effect);
+
+	Template.BuildNewGameStateFn = TypicalAbility_BuildGameState;
+	//  NOTE: No visualization on purpose!
+
+	return Template;
+}
+
+static function X2AbilityTemplate Phantom()
+{
+	local X2AbilityTemplate						Template;
+	local X2Effect_Persistent                   Effect;
+
+	`CREATE_X2ABILITY_TEMPLATE(Template, 'Phantom');
+
+	Template.AbilitySourceName = 'eAbilitySource_Perk';
+	Template.eAbilityIconBehaviorHUD = eAbilityIconBehavior_NeverShow;
+	Template.Hostility = eHostility_Neutral;
+	Template.IconImage = "img:///UILibrary_PerkIcons.UIPerk_phantom";
+
+	Template.AbilityToHitCalc = default.DeadEye;
+	Template.AbilityTargetStyle = default.SelfTarget;
+	Template.AbilityTriggers.AddItem(default.UnitPostBeginPlayTrigger);
+
+	Effect = new class'X2Effect_StayConcealed';
+	Effect.BuildPersistentEffect(1, true, false);
+	Effect.SetDisplayInfo(ePerkBuff_Passive, Template.LocFriendlyName, Template.GetMyLongDescription(), Template.IconImage,,,Template.AbilitySourceName);
+	Template.AddTargetEffect(Effect);
+
+	Template.BuildNewGameStateFn = TypicalAbility_BuildGameState;
+	//  NOTE: No visualization on purpose!
+
+	Template.bCrossClassEligible = true;
+//BEGIN AUTOGENERATED CODE: Template Overrides 'Phantom'
+	Template.AbilityConfirmSound = "TacticalUI_ActivateAbility";
+//END AUTOGENERATED CODE: Template Overrides 'Phantom'
+
+	return Template;
+}
+
+static function X2AbilityTemplate Bladestorm()
+{
+	local X2AbilityTemplate                 Template;
+
+	Template = PurePassive('Bladestorm', "img:///UILibrary_PerkIcons.UIPerk_bladestorm", false, 'eAbilitySource_Perk');
+	Template.AdditionalAbilities.AddItem('BladestormAttack');
+
+	return Template;
+}
+
+static function X2AbilityTemplate BladestormAttack(name TemplateName = 'BladestormAttack')
+{
+	local X2AbilityTemplate                 Template;
+	local X2AbilityToHitCalc_StandardMelee  ToHitCalc;
+	local X2AbilityTrigger_EventListener	Trigger;
+	local X2Effect_Persistent               BladestormTargetEffect;
+	local X2Condition_UnitEffectsWithAbilitySource BladestormTargetCondition;
+	local X2Condition_UnitProperty          SourceNotConcealedCondition;
+	local X2Condition_Visibility			TargetVisibilityCondition;
+	local X2Condition_UnitEffects			UnitEffectsCondition;
+	local X2Condition_UnitProperty			ExcludeSquadmatesCondition;
+
+	`CREATE_X2ABILITY_TEMPLATE(Template, TemplateName);
+
+	Template.AbilitySourceName = 'eAbilitySource_Perk';
+	Template.eAbilityIconBehaviorHUD = eAbilityIconBehavior_NeverShow;
+	Template.IconImage = "img:///UILibrary_PerkIcons.UIPerk_bladestorm";
+	Template.ShotHUDPriority = class'UIUtilities_Tactical'.const.CLASS_CAPTAIN_PRIORITY;
+
+	ToHitCalc = new class'X2AbilityToHitCalc_StandardMelee';
+	ToHitCalc.bReactionFire = true;
+	Template.AbilityToHitCalc = ToHitCalc;
+	Template.AbilityTargetStyle = default.SimpleSingleMeleeTarget;
+
+	//  trigger on movement
+	Trigger = new class'X2AbilityTrigger_EventListener';
+	Trigger.ListenerData.EventID = 'ObjectMoved';
+	Trigger.ListenerData.Deferral = ELD_OnStateSubmitted;
+	Trigger.ListenerData.Filter = eFilter_None;
+	Trigger.ListenerData.EventFn = class'XComGameState_Ability'.static.TypicalOverwatchListener;
+	Template.AbilityTriggers.AddItem(Trigger);
+	//  trigger on an attack
+	Trigger = new class'X2AbilityTrigger_EventListener';
+	Trigger.ListenerData.EventID = 'AbilityActivated';
+	Trigger.ListenerData.Deferral = ELD_OnStateSubmitted;
+	Trigger.ListenerData.Filter = eFilter_None;
+	Trigger.ListenerData.EventFn = class'XComGameState_Ability'.static.TypicalAttackListener;
+	Template.AbilityTriggers.AddItem(Trigger);
+
+	//  it may be the case that enemy movement caused a concealment break, which made Bladestorm applicable - attempt to trigger afterwards
+	Trigger = new class'X2AbilityTrigger_EventListener';
+	Trigger.ListenerData.Deferral = ELD_OnStateSubmitted;
+	Trigger.ListenerData.EventID = 'UnitConcealmentBroken';
+	Trigger.ListenerData.Filter = eFilter_Unit;
+	Trigger.ListenerData.EventFn = BladestormConcealmentListener;
+	Trigger.ListenerData.Priority = 55;
+	Template.AbilityTriggers.AddItem(Trigger);
+	
+	Template.AbilityTargetConditions.AddItem(default.LivingHostileUnitDisallowMindControlProperty);
+	TargetVisibilityCondition = new class'X2Condition_Visibility';
+	TargetVisibilityCondition.bRequireGameplayVisible = true;
+	TargetVisibilityCondition.bRequireBasicVisibility = true;
+	TargetVisibilityCondition.bDisablePeeksOnMovement = true; //Don't use peek tiles for over watch shots	
+	Template.AbilityTargetConditions.AddItem(TargetVisibilityCondition);
+	Template.AbilityTargetConditions.AddItem(class'X2Ability_DefaultAbilitySet'.static.OverwatchTargetEffectsCondition());
+	// Adding exclusion condition to prevent friendly bladestorm fire when panicked.
+	ExcludeSquadmatesCondition = new class'X2Condition_UnitProperty';
+	ExcludeSquadmatesCondition.ExcludeSquadmates = true;
+	Template.AbilityTargetConditions.AddItem(ExcludeSquadmatesCondition);
+
+	Template.AbilityShooterConditions.AddItem(default.LivingShooterProperty);	
+	Template.AddShooterEffectExclusions();
+
+	//Don't trigger when the source is concealed
+	SourceNotConcealedCondition = new class'X2Condition_UnitProperty';
+	SourceNotConcealedCondition.ExcludeConcealed = true;
+	Template.AbilityShooterConditions.AddItem(SourceNotConcealedCondition);
+
+	// Don't trigger if the unit has vanished
+	UnitEffectsCondition = new class'X2Condition_UnitEffects';
+	UnitEffectsCondition.AddExcludeEffect('Vanish', 'AA_UnitIsConcealed');
+	UnitEffectsCondition.AddExcludeEffect('VanishingWind', 'AA_UnitIsConcealed');
+	Template.AbilityShooterConditions.AddItem(UnitEffectsCondition);
+
+	Template.bAllowBonusWeaponEffects = true;
+	Template.AddTargetEffect(new class'X2Effect_ApplyWeaponDamage');
+
+	//Prevent repeatedly hammering on a unit with Bladestorm triggers.
+	//(This effect does nothing, but enables many-to-many marking of which Bladestorm attacks have already occurred each turn.)
+	BladestormTargetEffect = new class'X2Effect_Persistent';
+	BladestormTargetEffect.BuildPersistentEffect(1, false, true, true, eGameRule_PlayerTurnEnd);
+	BladestormTargetEffect.EffectName = 'BladestormTarget';
+	BladestormTargetEffect.bApplyOnMiss = true; //Only one chance, even if you miss (prevents crazy flailing counter-attack chains with a Muton, for example)
+	Template.AddTargetEffect(BladestormTargetEffect);
+	
+	BladestormTargetCondition = new class'X2Condition_UnitEffectsWithAbilitySource';
+	BladestormTargetCondition.AddExcludeEffect('BladestormTarget', 'AA_DuplicateEffectIgnored');
+	Template.AbilityTargetConditions.AddItem(BladestormTargetCondition);
+
+
+	Template.BuildNewGameStateFn = TypicalAbility_BuildGameState;
+	Template.BuildVisualizationFn = BladeStorm_BuildVisualization;
+	Template.bShowActivation = true;
+
+	Template.SuperConcealmentLoss = class'X2AbilityTemplateManager'.default.SuperConcealmentStandardShotLoss;
+	Template.ChosenActivationIncreasePerUse = class'X2AbilityTemplateManager'.default.NormalChosenActivationIncreasePerUse;
+	Template.LostSpawnIncreasePerUse = class'X2AbilityTemplateManager'.default.MeleeLostSpawnIncreasePerUse;
+
+	//BEGIN AUTOGENERATED CODE: Template Overrides 'BladestormAttack'
+	Template.bFrameEvenWhenUnitIsHidden = true;
+	//END AUTOGENERATED CODE: Template Overrides 'BladestormAttack'
+
+	return Template;
+}
+
+//Must be static, because it will be called with a different object (an XComGameState_Ability)
+//Used to trigger Bladestorm when the source's concealment is broken by a unit in melee range (the regular movement triggers get called too soon)
+static function EventListenerReturn BladestormConcealmentListener(Object EventData, Object EventSource, XComGameState GameState, Name Event, Object CallbackData)
+{
+	local XComGameStateContext_Ability AbilityContext;
+	local XComGameState_Unit ConcealmentBrokenUnit;
+	local StateObjectReference BladestormRef;
+	local XComGameState_Ability BladestormState;
+	local XComGameStateHistory History;
+
+	History = `XCOMHISTORY;
+
+	ConcealmentBrokenUnit = XComGameState_Unit(EventSource);	
+	if (ConcealmentBrokenUnit == None)
+		return ELR_NoInterrupt;
+
+	//Do not trigger if the Bladestorm Ranger himself moved to cause the concealment break - only when an enemy moved and caused it.
+	AbilityContext = XComGameStateContext_Ability(GameState.GetContext().GetFirstStateInEventChain().GetContext());
+	if (AbilityContext != None && AbilityContext.InputContext.SourceObject != ConcealmentBrokenUnit.ConcealmentBrokenByUnitRef)
+		return ELR_NoInterrupt;
+
+	BladestormRef = ConcealmentBrokenUnit.FindAbility('BladestormAttack');
+	if (BladestormRef.ObjectID == 0)
+		return ELR_NoInterrupt;
+
+	BladestormState = XComGameState_Ability(History.GetGameStateForObjectID(BladestormRef.ObjectID));
+	if (BladestormState == None)
+		return ELR_NoInterrupt;
+	
+	BladestormState.AbilityTriggerAgainstSingleTarget(ConcealmentBrokenUnit.ConcealmentBrokenByUnitRef, false);
+	return ELR_NoInterrupt;
+}
+
+simulated function BladeStorm_BuildVisualization(XComGameState VisualizeGameState)
+{
+	// Build the first shot of Bladestorm's visualization
+	TypicalAbility_BuildVisualization(VisualizeGameState);
+}
+
+static function X2AbilityTemplate DeepCover()
+{
+	local X2AbilityTemplate         Template;
+
+	Template = PurePassive('DeepCover', "img:///UILibrary_PerkIcons.UIPerk_one_for_all");
+	Template.AdditionalAbilities.AddItem('DeepCoverTrigger');
+
+	Template.bCrossClassEligible = true;
+
+	return Template;
+}
+
+static function X2AbilityTemplate DeepCoverTrigger()
+{
+	local X2AbilityTemplate                 Template;
+	local X2AbilityTrigger_EventListener    Trigger;
+
+	`CREATE_X2ABILITY_TEMPLATE(Template, 'DeepCoverTrigger');
+
+	Template.AbilityToHitCalc = default.DeadEye;
+	Template.AbilityShooterConditions.AddItem(default.LivingShooterProperty);
+	Template.AbilityTargetStyle = default.SelfTarget;
+	Template.eAbilityIconBehaviorHUD = eAbilityIconBehavior_NeverShow;
+	Template.Hostility = eHostility_Neutral;
+
+	Trigger = new class'X2AbilityTrigger_EventListener';
+	Trigger.ListenerData.Deferral = ELD_OnStateSubmitted;
+	Trigger.ListenerData.EventID = 'PlayerTurnEnded';
+	Trigger.ListenerData.Filter = eFilter_Player;
+	Trigger.ListenerData.EventFn = class'XComGameState_Ability'.static.DeepCoverTurnEndListener;
+	Template.AbilityTriggers.AddItem(Trigger);
+
+	Template.BuildNewGameStateFn = TypicalAbility_BuildGameState;
+	
+	return Template;
+}
+
+static function X2AbilityTemplate RapidFire()
+{
+	local X2AbilityTemplate					Template;
+	local X2AbilityCost_ActionPoints		ActionPointCost;
+	local X2AbilityCost_Ammo				AmmoCost;
+	local X2AbilityToHitCalc_StandardAim    ToHitCalc;
+	local X2AbilityCooldown					Cooldown;
+
+	`CREATE_X2ABILITY_TEMPLATE(Template, 'RapidFire');
+
+	ActionPointCost = new class'X2AbilityCost_ActionPoints';
+	ActionPointCost.iNumPoints = 0;
+	ActionPointCost.bAddWeaponTypicalCost = true;
+	ActionPointCost.bConsumeAllPoints = true;
+	Template.AbilityCosts.AddItem(ActionPointCost);
+
+	//  require 2 ammo to be present so that both shots can be taken
+	AmmoCost = new class'X2AbilityCost_Ammo';
+	AmmoCost.iAmmo = 2;
+	AmmoCost.bFreeCost = true;
+	Template.AbilityCosts.AddItem(AmmoCost);
+	//  actually charge 1 ammo for this shot. the 2nd shot will charge the extra ammo.
+	AmmoCost = new class'X2AbilityCost_Ammo';
+	AmmoCost.iAmmo = 1;
+	Template.AbilityCosts.AddItem(AmmoCost);
+
+	Cooldown = new class'X2AbilityCooldown';
+	Cooldown.iNumTurns = 5;
+	Template.AbilityCooldown = Cooldown;
+
+	ToHitCalc = new class'X2AbilityToHitCalc_StandardAim';
+	ToHitCalc.BuiltInHitMod = default.RAPIDFIRE_AIM;
+	Template.AbilityToHitCalc = ToHitCalc;
+	Template.AbilityToHitOwnerOnMissCalc = ToHitCalc;
+
+	Template.AbilityTargetStyle = default.SimpleSingleTarget;
+
+	Template.AbilityShooterConditions.AddItem(default.LivingShooterProperty);
+	Template.AddShooterEffectExclusions();
+
+	Template.AbilityTargetConditions.AddItem(default.LivingHostileTargetProperty);
+	Template.AbilityTargetConditions.AddItem(default.GameplayVisibilityCondition);
+
+	Template.AddTargetEffect(class'X2Ability_GrenadierAbilitySet'.static.HoloTargetEffect());
+	Template.AssociatedPassives.AddItem('HoloTargeting');
+	Template.AddTargetEffect(class'X2Ability_GrenadierAbilitySet'.static.ShredderDamageEffect());
+	Template.bAllowAmmoEffects = true;
+	Template.bAllowBonusWeaponEffects = true;
+
+	Template.AbilityTriggers.AddItem(default.PlayerInputTrigger);
+
+	Template.ShotHUDPriority = class'UIUtilities_Tactical'.const.CLASS_COLONEL_PRIORITY;
+	Template.AbilitySourceName = 'eAbilitySource_Perk';
+	Template.eAbilityIconBehaviorHUD = eAbilityIconBehavior_AlwaysShow;
+	Template.IconImage = "img:///UILibrary_PerkIcons.UIPerk_rapidfire";
+	Template.AbilityConfirmSound = "TacticalUI_ActivateAbility";
+
+	Template.BuildNewGameStateFn = TypicalAbility_BuildGameState;
+	Template.BuildVisualizationFn = TypicalAbility_BuildVisualization;
+	Template.BuildInterruptGameStateFn = TypicalAbility_BuildInterruptGameState;
+
+	Template.AdditionalAbilities.AddItem('RapidFire2');
+	Template.PostActivationEvents.AddItem('RapidFire2');
+
+	Template.bCrossClassEligible = true;
+
+	Template.SuperConcealmentLoss = class'X2AbilityTemplateManager'.default.SuperConcealmentStandardShotLoss;
+	Template.ChosenActivationIncreasePerUse = class'X2AbilityTemplateManager'.default.StandardShotChosenActivationIncreasePerUse;
+	Template.LostSpawnIncreasePerUse = class'X2AbilityTemplateManager'.default.StandardShotLostSpawnIncreasePerUse;
+//BEGIN AUTOGENERATED CODE: Template Overrides 'RapidFire'
+	Template.bFrameEvenWhenUnitIsHidden = true;
+//END AUTOGENERATED CODE: Template Overrides 'RapidFire'
+
+	return Template;
+}
+
+static function X2AbilityTemplate RapidFire2()
+{
+	local X2AbilityTemplate					Template;
+	local X2AbilityCost_Ammo				AmmoCost;
+	local X2AbilityToHitCalc_StandardAim    ToHitCalc;
+	local X2AbilityTrigger_EventListener    Trigger;
+
+	`CREATE_X2ABILITY_TEMPLATE(Template, 'RapidFire2');
+
+	AmmoCost = new class'X2AbilityCost_Ammo';
+	AmmoCost.iAmmo = 1;
+	Template.AbilityCosts.AddItem(AmmoCost);
+
+	ToHitCalc = new class'X2AbilityToHitCalc_StandardAim';
+	ToHitCalc.BuiltInHitMod = default.RAPIDFIRE_AIM;
+	Template.AbilityToHitCalc = ToHitCalc;
+	Template.AbilityToHitOwnerOnMissCalc = ToHitCalc;
+
+	Template.AbilityTargetStyle = default.SimpleSingleTarget;
+
+	Template.AbilityShooterConditions.AddItem(default.LivingShooterProperty);
+	Template.AddShooterEffectExclusions();
+
+	Template.AbilityTargetConditions.AddItem(default.LivingHostileTargetProperty);
+
+	Template.AddTargetEffect(class'X2Ability_GrenadierAbilitySet'.static.HoloTargetEffect());
+	Template.AssociatedPassives.AddItem('HoloTargeting');
+	Template.AddTargetEffect(class'X2Ability_GrenadierAbilitySet'.static.ShredderDamageEffect());
+	Template.bAllowAmmoEffects = true;
+	Template.bAllowBonusWeaponEffects = true;
+
+	Trigger = new class'X2AbilityTrigger_EventListener';
+	Trigger.ListenerData.Deferral = ELD_OnStateSubmitted;
+	Trigger.ListenerData.EventID = 'RapidFire2';
+	Trigger.ListenerData.Filter = eFilter_Unit;
+	Trigger.ListenerData.EventFn = class'XComGameState_Ability'.static.AbilityTriggerEventListener_OriginalTarget;
+	Template.AbilityTriggers.AddItem(Trigger);
+
+	Template.ShotHUDPriority = class'UIUtilities_Tactical'.const.CLASS_COLONEL_PRIORITY;
+	Template.AbilitySourceName = 'eAbilitySource_Perk';
+	Template.eAbilityIconBehaviorHUD = eAbilityIconBehavior_NeverShow;
+	Template.IconImage = "img:///UILibrary_PerkIcons.UIPerk_rapidfire";
+
+	Template.BuildNewGameStateFn = TypicalAbility_BuildGameState;
+	Template.BuildVisualizationFn = TypicalAbility_BuildVisualization;
+	Template.MergeVisualizationFn = SequentialShot_MergeVisualization;
+	
+	Template.bShowActivation = true;
+
+	Template.SuperConcealmentLoss = class'X2AbilityTemplateManager'.default.SuperConcealmentStandardShotLoss;
+	Template.ChosenActivationIncreasePerUse = class'X2AbilityTemplateManager'.default.StandardShotChosenActivationIncreasePerUse;
+	Template.LostSpawnIncreasePerUse = class'X2AbilityTemplateManager'.default.StandardShotLostSpawnIncreasePerUse;
+//BEGIN AUTOGENERATED CODE: Template Overrides 'RapidFire2'
+	Template.bFrameEvenWhenUnitIsHidden = true;
+//END AUTOGENERATED CODE: Template Overrides 'RapidFire2'
+
+	return Template;
+}
+
+static function SuperKillRestrictions(X2AbilityTemplate Template, name ThisSuperKill)
+{
+	local X2Condition_UnitValue ValueCondition;
+	local X2Effect_SetUnitValue ValueEffect;
+
+	ValueCondition = new class'X2Condition_UnitValue';
+	ValueCondition.AddCheckValue('RunAndGun_SuperKillCheck', 0, eCheck_Exact,,,'AA_RunAndGunUsed');
+	ValueCondition.AddCheckValue('Reaper_SuperKillCheck', 0, eCheck_Exact,,,'AA_ReaperUsed');
+	ValueCondition.AddCheckValue('Serial_SuperKillCheck', 0, eCheck_Exact,,,'AA_SerialUsed');
+	Template.AbilityShooterConditions.AddItem(ValueCondition);
+
+	ValueEffect = new class'X2Effect_SetUnitValue';
+	ValueEffect.UnitName = ThisSuperKill;
+	ValueEffect.NewValueToSet = 1;
+	ValueEffect.CleanupType = eCleanup_BeginTurn;
+	Template.AddShooterEffect(ValueEffect);
+}
+
+DefaultProperties
+{
+	SwordSliceName="SwordSlice"
+}

--- a/X2WOTCCommunityHighlander/Src/XComGame/Classes/X2Ability_RangerAbilitySet.uc
+++ b/X2WOTCCommunityHighlander/Src/XComGame/Classes/X2Ability_RangerAbilitySet.uc
@@ -784,6 +784,7 @@ static function X2AbilityTemplate RapidFire2()
 	Template.AddShooterEffectExclusions();
 
 	Template.AbilityTargetConditions.AddItem(default.LivingHostileTargetProperty);
+	Template.AbilityTargetConditions.AddItem(default.GameplayVisibilityCondition);
 
 	Template.AddTargetEffect(class'X2Ability_GrenadierAbilitySet'.static.HoloTargetEffect());
 	Template.AssociatedPassives.AddItem('HoloTargeting');


### PR DESCRIPTION
The Rapid Fire and Chain Shot second shot abilities did not have the gameplay visibility condition, so their valid targets included every enemy unit on the map, which was causing performance issues in LWOTC. There appears to be no reason for these abilities not to have this condition, so adding them in.

Fixes #1022.
