### PR TITLE
Use writable state for units spawned from Avenger (#1029)

### DIFF
--- a/X2WOTCCommunityHighlander/Src/XComGame/Classes/SeqAct_SpawnUnitFromAvenger.uc
+++ b/X2WOTCCommunityHighlander/Src/XComGame/Classes/SeqAct_SpawnUnitFromAvenger.uc
@@ -197,6 +197,16 @@ private static function XComGameState_Unit AddStrategyUnitToBoard(XComGameState_
 	// Must happen after unit is submitted, or it gets confused about when the unit is in play or not 
 	NewGameState = class'XComGameStateContext_ChangeContainer'.static.CreateChangeState("Adding Reserve Unit Abilities");
 
+	// Start Issue #1029
+	/// HL-Docs: ref:Bugfixes; issue:1029
+	/// Units spawned from the Avenger would sometimes not be able to take actions
+	/// because their abilities weren't initialized properly. This is now fixed.
+	//
+	// Make sure we have a writeable copy of the unit state before initializing
+	// its abilities.
+	Unit = XComGameState_Unit(NewGameState.ModifyStateObject(class'XComGameState_Unit', Unit.ObjectID));
+	// End Issue #1029
+
 	Rules.InitializeUnitAbilities(NewGameState, Unit);
 
 	// make the unit concealed, if they have Phantom


### PR DESCRIPTION
This specifically fixes the issue where a non-writeable state is currently used for the initialisation of unit abilities. While it mostly
works as it is, there are apparently circumstances in which the changes to the old, read-only unit state are discarded, meaning the abilities don't get initialised properly.

Fixes #1029.