### PR TITLE
Fix moving melee hangs

### DIFF
--- a/X2WOTCCommunityHighlander/Src/XComGame/Classes/UITacticalHUD_Ability.uc
+++ b/X2WOTCCommunityHighlander/Src/XComGame/Classes/UITacticalHUD_Ability.uc
@@ -145,9 +145,7 @@ simulated function UpdateData(int NewIndex, const out AvailableAction AvailableA
 		if (IsObjectiveAbility || AbilityTemplate.AbilityIconColor != "")
 		{
 			BackgroundColor = IsObjectiveAbility ? class'UIUtilities_Colors'.const.OBJECTIVEICON_HTML_COLOR : AbilityTemplate.AbilityIconColor;
-
-			// Issue #1031 - temporarily disable the event trigger to prevent moving melee abilities from hard hanging the game.
-			//TriggerOverrideAbilityIconColor(AbilityState, IsObjectiveAbility, BackgroundColor);
+			TriggerOverrideAbilityIconColor(AbilityState, IsObjectiveAbility, BackgroundColor);
 		}
 		else
 		{
@@ -178,8 +176,7 @@ simulated function UpdateData(int NewIndex, const out AvailableAction AvailableA
 
 		ForegroundColor = class'UIUtilities_Colors'.const.BLACK_HTML_COLOR;
 
-		// Issue #1031 - temporarily disable the event trigger to prevent moving melee abilities from hard hanging the game.
-		//TriggerOverrideAbilityIconColorImproved(AbilityState, IsObjectiveAbility, BackgroundColor, ForegroundColor);
+		TriggerOverrideAbilityIconColorImproved(AbilityState, IsObjectiveAbility, BackgroundColor, ForegroundColor);
 
 		Icon.EnableMouseAutomaticColor(BackgroundColor, ForegroundColor);
 		// End Issue #749

--- a/X2WOTCCommunityHighlander/Src/XComGame/Classes/X2AbilityToHitCalc_StandardAim.uc
+++ b/X2WOTCCommunityHighlander/Src/XComGame/Classes/X2AbilityToHitCalc_StandardAim.uc
@@ -318,6 +318,19 @@ protected function int GetHitChance(XComGameState_Ability kAbility, AvailableTar
 	local ECoverType NextTileOverCoverType;
 	local int TileDistance;
 
+	/// HL-Docs: feature:GetHitChanceEvents; issue:1031; tags:tactical
+	/// WARNING! Triggering events in `X2AbilityToHitCalc::GetHitChance()` and other functions called by this function
+	/// may freeze (hard hang) the game under certain circumstances.
+	///
+	/// In our experiments, the game would hang when the player used a moving melee ability when an event was triggered
+	/// in `UITacticalHUD_AbilityContainer::ConfirmAbility()`  right above the 
+	/// `XComPresentationLayer(Owner.Owner).PopTargetingStates();` line or anywhere further down the script trace,
+	/// while another event was also triggered in `GetHitChance()` or anywhere further down the script trace.
+	///
+	/// The game hangs while executing UI code, but it is the event in the To Hit Calculation logic that induces it.
+	/// The speculation is that triggering events in `GetHitChance()` somehow corrupts the event manager, or it
+	/// could be a threading issue.
+
 	`log("=" $ GetFuncName() $ "=", bDebugLog, 'XCom_HitRolls');
 
 	//  @TODO gameplay handle non-unit targets

--- a/X2WOTCCommunityHighlander/Src/XComGame/Classes/XComGameState_Unit.uc
+++ b/X2WOTCCommunityHighlander/Src/XComGame/Classes/XComGameState_Unit.uc
@@ -1108,85 +1108,12 @@ function bool EverHadTrait(name TraitTemplateName)
 simulated function bool HasHeightAdvantageOver(XComGameState_Unit OtherUnit, bool bAsAttacker)
 {
 	local int BonusZ;
-	//	Local variable for Issue #851
-	local bool bHasHeightAdvantageOver;
 
 	if (bAsAttacker)
 		BonusZ = GetHeightAdvantageBonusZ();
 
-	//	Begin Issue #851
-	//	This is vanilla functionality.
-	bHasHeightAdvantageOver = TileLocation.Z + BonusZ >= (OtherUnit.TileLocation.Z + class'X2TacticalGameRuleset'.default.UnitHeightAdvantage);
-
-	return OverrideHasHeightAdvantageOver(OtherUnit, bAsAttacker, bHasHeightAdvantageOver);
-	//	End Issue #851
+	return TileLocation.Z + BonusZ >= (OtherUnit.TileLocation.Z + class'X2TacticalGameRuleset'.default.UnitHeightAdvantage);
 }
-//	Begin Issue #851
-/// HL-Docs: feature:OverrideHasHeightAdvantageOver; issue:851; tags:tactical
-/// This event allows mods to override the standard game's logic for checking
-/// whether one unit has height advantate over another unit.
-///
-///	In order to take advantage of this event, make a listener with the ELD_Immediate deferral, 
-/// and cast EventData to XComLWTuple. `Tuple.Data[0].b` will already contain the bool value
-/// of whether this unit has height advantage over the other unit according to the vanilla logic. 
-/// You can replace the value with your own based on arbitrary parameters,
-/// such as one of the units being affected by a certain effect or having a certain ability.
-///	
-/// ```unrealscript
-/// EventID: OverrideHasHeightAdvantageOver
-/// EventData: XComLWTuple {
-///     Data: [
-///       inout bool HasHeightAdvantageOver,
-///       in bool bAsAttacker,
-///       in XComGameState_Unit OtherUnit
-///     ]
-/// }
-/// EventSource: XComGameState_Unit (of the unit performing the check)
-/// Game State: never.
-/// ```
-/// Example of an Event Listener Function:
-/// ```unrealscript
-/// static function EventListenerReturn ListenerEventFunction(Object EventData, Object EventSource, XComGameState NewGameState, Name Event, Object CallbackData)
-/// {
-/// 	local XComLWTuple			Tuple;
-/// 	local XComGameState_Unit	UnitState;
-/// 
-/// 	Tuple = XComLWTuple(EventData);
-/// 	UnitState = XComGameState_Unit(EventSource);
-/// 	if (Tuple == none || UnitState == none)
-/// 		return ELR_NoInterrupt;
-/// 
-/// 	//	The Unit is an attacker and it does not already have a height advantage.
-/// 	if (Tuple.Data[1].b && !Tuple.Data[0].b)
-/// 	{
-/// 		//	Then we give the unit height advantage if they are affected by the Jet Shot effect.
-/// 		Tuple.Data[0].b = UnitState.IsUnitAffectedByEffectName('IRI_JetShot_Effect');
-/// 	}
-/// 
-/// 	return ELR_NoInterrupt;
-/// }
-/// ```
-
-simulated private function bool OverrideHasHeightAdvantageOver(XComGameState_Unit OtherUnit, bool bAsAttacker, bool bHasHeightAdvantageOver)
-{
-	local XComLWTuple Tuple;
-
-	Tuple = new class'XComLWTuple';
-	Tuple.Id = 'OverrideHasHeightAdvantageOver';
-	Tuple.Data.Add(3);
-	Tuple.Data[0].kind = XComLWTVBool;
-	Tuple.Data[1].kind = XComLWTVBool;
-	Tuple.Data[2].kind = XComLWTVObject;
-
-	Tuple.Data[0].b = bHasHeightAdvantageOver;
-	Tuple.Data[1].b = bAsAttacker;
-	Tuple.Data[2].o = OtherUnit;
-
-	`XEVENTMGR.TriggerEvent('OverrideHasHeightAdvantageOver', Tuple, self, none);
-
-	return Tuple.Data[0].b;
-}
-//	End Issue #851
 
 simulated function int GetHeightAdvantageBonusZ()
 {


### PR DESCRIPTION
Closes #1031 by reverting #852 and adding a warning to `X2AbilityToHitCalc_StandardAim` about the dangers of triggering events in ToHitCalc code. 

Implements #851 through the delegate system instead.

Fixed a bug in #855 (first implementation of the delegate system) and updated its docs while I was a it.
