### PR TITLE
Allow mods to override which alerts Can be triggered outside of player vision

### DIFF
--- a/X2WOTCCommunityHighlander/Src/XComGame/Classes/XComGameState_AIUnitData.uc
+++ b/X2WOTCCommunityHighlander/Src/XComGame/Classes/XComGameState_AIUnitData.uc
@@ -1047,7 +1047,7 @@ static function bool ShouldEnemyFactionsTriggerAlertsOutsidePlayerVision(EAlertC
 /// EventSource: none,
 /// NewGameState: none
 /// ```
-static function bool OverrideShouldEnemyFactionsTriggerAlertsOutsidePlayerVision(int AlertCause, bool AllowThisCause)
+static function bool OverrideShouldEnemyFactionsTriggerAlertsOutsidePlayerVision(EAlertCause AlertCause, bool AllowThisCause)
 {
 	local XComLWTuple OverrideTuple;
 

--- a/X2WOTCCommunityHighlander/Src/XComGame/Classes/XComGameState_AIUnitData.uc
+++ b/X2WOTCCommunityHighlander/Src/XComGame/Classes/XComGameState_AIUnitData.uc
@@ -1016,7 +1016,7 @@ static function bool IsCauseAbsoluteKnowledge( EAlertCause AlertCause )
 static function bool ShouldEnemyFactionsTriggerAlertsOutsidePlayerVision(EAlertCause AlertCause)
 {
 	local bool bResult;
-
+	local XComLWTuple OverrideTuple;
 	bResult = false;
 	switch( AlertCause )
 	{
@@ -1031,7 +1031,15 @@ static function bool ShouldEnemyFactionsTriggerAlertsOutsidePlayerVision(EAlertC
 		break;
 	}
 
-	return bResult;
+		OverrideTuple = new class'XComLWTuple';
+		OverrideTuple.Id = 'OverrideEnemyFactionsAlertsOutsideVision';
+		OverrideTuple.Data.Add(1);
+		OverrideTuple.Data[0].Kind = XComLWTVBool;
+		OverrideTuple.Data[0].b = bResult;
+	
+		`XEVENTMGR.TriggerEvent('OverrideEnemyFactionsAlertsOutsideVision', OverrideTuple);
+
+	return OverrideTuple.Data[0].b;
 }
 
 static function bool IsCauseAllowedForNonvisibleUnits(EAlertCause AlertCause)

--- a/X2WOTCCommunityHighlander/Src/XComGame/Classes/XComGameState_AIUnitData.uc
+++ b/X2WOTCCommunityHighlander/Src/XComGame/Classes/XComGameState_AIUnitData.uc
@@ -1043,11 +1043,11 @@ static function bool ShouldEnemyFactionsTriggerAlertsOutsidePlayerVision(EAlertC
 /// use this event to allow enemy pods to activate one another outside of XCOM
 /// vision for a given set of alert causes.
 ///
-/// Return `true` in `bResult` if the alert cause can be triggered in such
-/// situations. Leave `bResult` untouched to retain the default behavior.
+/// Return `true` in `AllowThisCause` if the alert cause can be triggered in such
+/// situations. Leave `AllowThisCause` untouched to retain the default behavior.
 /// ```event
 /// EventID: OverrideEnemyFactionsAlertsOutsideVision,
-/// EventData: [ in enum[EAlertCause] AlertCause, inout bool bResult],
+/// EventData: [ in enum[EAlertCause] AlertCause, inout bool AllowThisCause],
 /// EventSource: none,
 /// NewGameState: none
 /// ```

--- a/X2WOTCCommunityHighlander/Src/XComGame/Classes/XComGameState_AIUnitData.uc
+++ b/X2WOTCCommunityHighlander/Src/XComGame/Classes/XComGameState_AIUnitData.uc
@@ -1051,7 +1051,7 @@ static function bool ShouldEnemyFactionsTriggerAlertsOutsidePlayerVision(EAlertC
 /// EventSource: none,
 /// NewGameState: none
 /// ```
-static function bool TriggerOverrideEnemyFactionsAlertsOutsideVision(EAlertCause AlertCause, bool AllowThisCause)
+static private function bool TriggerOverrideEnemyFactionsAlertsOutsideVision(EAlertCause AlertCause, bool AllowThisCause)
 {
 	local XComLWTuple OverrideTuple;
 

--- a/X2WOTCCommunityHighlander/Src/XComGame/Classes/XComGameState_AIUnitData.uc
+++ b/X2WOTCCommunityHighlander/Src/XComGame/Classes/XComGameState_AIUnitData.uc
@@ -1043,7 +1043,7 @@ static function bool ShouldEnemyFactionsTriggerAlertsOutsidePlayerVision(EAlertC
 /// AlertCause Contains the Alert Value, while AllowThisCause boolean Determines if the alert is allowed.
 /// ```event
 /// EventID: OverrideEnemyFactionsAlertsOutsideVision,
-/// EventData: [ in int AlertCause, inout bool bResult],
+/// EventData: [ in enum[EAlertCause] AlertCause, inout bool bResult],
 /// EventSource: none,
 /// NewGameState: none
 /// ```

--- a/X2WOTCCommunityHighlander/Src/XComGame/Classes/XComGameState_AIUnitData.uc
+++ b/X2WOTCCommunityHighlander/Src/XComGame/Classes/XComGameState_AIUnitData.uc
@@ -1031,23 +1031,27 @@ static function bool ShouldEnemyFactionsTriggerAlertsOutsidePlayerVision(EAlertC
 		break;
 	}
 	//Start Issue #1036
-	bResult = OverrideShouldEnemyFactionsTriggerAlertsOutsidePlayerVision(AlertCause, bResult);
+	bResult = TriggerOverrideEnemyFactionsAlertsOutsideVision(AlertCause, bResult);
 	//End Issue #1036
 	return bResult;
 }
 
 // Start Issue #1036
 /// HL-Docs: feature:OverrideEnemyFactionsAlertsOutsideVision; issue:1036; tags:tactical
-/// Fires an event that allows listeners to Override whether an Alert can be triggered by units 
-/// outside of XCOM's Vision.
-/// AlertCause Contains the Alert Value, while AllowThisCause boolean Determines if the alert is allowed.
+/// Fires an event that allows listeners to override whether a given alert cause
+/// can be triggered by AI units outside of XCOM's vision. For example, you could
+/// use this event to allow enemy pods to activate one another outside of XCOM
+/// vision for a given set of alert causes.
+///
+/// Return `true` in `bResult` if the alert cause can be triggered in such
+/// situations. Leave `bResult` untouched to retain the default behavior.
 /// ```event
 /// EventID: OverrideEnemyFactionsAlertsOutsideVision,
 /// EventData: [ in enum[EAlertCause] AlertCause, inout bool bResult],
 /// EventSource: none,
 /// NewGameState: none
 /// ```
-static function bool OverrideShouldEnemyFactionsTriggerAlertsOutsidePlayerVision(EAlertCause AlertCause, bool AllowThisCause)
+static function bool TriggerOverrideEnemyFactionsAlertsOutsideVision(EAlertCause AlertCause, bool AllowThisCause)
 {
 	local XComLWTuple OverrideTuple;
 
@@ -1061,7 +1065,7 @@ static function bool OverrideShouldEnemyFactionsTriggerAlertsOutsidePlayerVision
 
 	`XEVENTMGR.TriggerEvent('OverrideEnemyFactionsAlertsOutsideVision', OverrideTuple);
 
-	return  OverrideTuple.Data[1].b;
+	return OverrideTuple.Data[1].b;
 }
 
 static function bool IsCauseAllowedForNonvisibleUnits(EAlertCause AlertCause)

--- a/X2WOTCCommunityHighlander/Src/XComGame/Classes/XComGameState_AIUnitData.uc
+++ b/X2WOTCCommunityHighlander/Src/XComGame/Classes/XComGameState_AIUnitData.uc
@@ -1016,7 +1016,7 @@ static function bool IsCauseAbsoluteKnowledge( EAlertCause AlertCause )
 static function bool ShouldEnemyFactionsTriggerAlertsOutsidePlayerVision(EAlertCause AlertCause)
 {
 	local bool bResult;
-	local XComLWTuple OverrideTuple;
+
 	bResult = false;
 	switch( AlertCause )
 	{
@@ -1030,16 +1030,38 @@ static function bool ShouldEnemyFactionsTriggerAlertsOutsidePlayerVision(EAlertC
 		bResult = true;
 		break;
 	}
+	//Start Issue #1036
+	bResult = OverrideShouldEnemyFactionsTriggerAlertsOutsidePlayerVision(AlertCause, bResult);
+	//End Issue #1036
+	return bResult;
+}
 
-		OverrideTuple = new class'XComLWTuple';
-		OverrideTuple.Id = 'OverrideEnemyFactionsAlertsOutsideVision';
-		OverrideTuple.Data.Add(1);
-		OverrideTuple.Data[0].Kind = XComLWTVBool;
-		OverrideTuple.Data[0].b = bResult;
-	
-		`XEVENTMGR.TriggerEvent('OverrideEnemyFactionsAlertsOutsideVision', OverrideTuple);
+// Start Issue #1036
+/// HL-Docs: feature:OverrideEnemyFactionsAlertsOutsideVision; issue:1036; tags:tactical
+/// Fires an event that allows listeners to Override whether an Alert can be triggered by units 
+/// outside of XCOM's Vision.
+/// AlertCause Contains the Alert Value, while AllowThisCause boolean Determines if the alert is allowed.
+/// ```event
+/// EventID: OverrideEnemyFactionsAlertsOutsideVision,
+/// EventData: [ in int AlertCause, inout bool bResult],
+/// EventSource: none,
+/// NewGameState: none
+/// ```
+static function bool OverrideShouldEnemyFactionsTriggerAlertsOutsidePlayerVision(int AlertCause, bool AllowThisCause)
+{
+	local XComLWTuple OverrideTuple;
 
-	return OverrideTuple.Data[0].b;
+	OverrideTuple = new class'XComLWTuple';
+	OverrideTuple.Id = 'OverrideEnemyFactionsAlertsOutsideVision';
+	OverrideTuple.Data.Add(2);
+	OverrideTuple.Data[0].Kind = XComLWTVInt;
+	OverrideTuple.Data[0].i = AlertCause;
+	OverrideTuple.Data[1].Kind = XComLWTVBool;
+	OverrideTuple.Data[1].b = AllowThisCause;
+
+	`XEVENTMGR.TriggerEvent('OverrideEnemyFactionsAlertsOutsideVision', OverrideTuple);
+
+	return  OverrideTuple.Data[1].b;
 }
 
 static function bool IsCauseAllowedForNonvisibleUnits(EAlertCause AlertCause)


### PR DESCRIPTION
This implements the hook which allows for that. Solves #1036.