### PR TITLE
Add straightforward introduction to run order popups

### DIFF
--- a/X2WOTCCommunityHighlander/Localization/X2WOTCCommunityHighlander.int
+++ b/X2WOTCCommunityHighlander/Localization/X2WOTCCommunityHighlander.int
@@ -15,18 +15,17 @@ ModIncompatible="Please DEACTIVATE the following mods and restart or %s will not
 DisablePopup="DO NOT SHOW ME THIS AGAIN"
 
 [X2WOTCCH_UIScreenListener_ShellPopup]
-CycleErrorTitle="Cycle in Run Order detected"
-GroupErrorTitle="Conflicting Run Order data"
+ErrorTitle="Mod Configuration Error"
 
-HardErrorText="Things will behave unpredictably. Proceed at your own risk."
-PotentialErrorText="Things will behave predictably, but potentially not in the way the author intended."
+AdviceText="The following mods have incorrect configuration: %BLAME. Show the error report to the respective authors to help them fix it."
 
-AdviceText="If you are a mod user, please forward this message to the authors of the following mods: %BLAME. Only they can fix the cause of the problem."
+HardErrorText="You can continue playing but mods will behave unpredictably. Proceed at your own risk."
+PotentialErrorText="You can continue playing and mods will behave predictably, but potentially not in the way their authors intended."
 
 CycleErrorText="Mods specified a cyclic run order:\n\n%FACTS\n...completing the cycle. Until this is corrected, run order will be undefined."
 GroupErrorText="Mods specified conflicting run order information:\n\n%FACTS\nThis behavior is specified, but may indicate a configuration error."
 
-BlameText="The following DLCIdentifiers provided config that lead to this problem: %BLAME"
+BlameText="The following DLCIdentifiers provided config in XComGame.ini that lead to this problem: %BLAME."
 
 [X2WOTCCH_UIScreenListener_Shell_DLCIntro]
 strDLC2HLIntroduction_Title="Alien Hunters Community Highlander"

--- a/X2WOTCCommunityHighlander/Localization/X2WOTCCommunityHighlander.int
+++ b/X2WOTCCommunityHighlander/Localization/X2WOTCCommunityHighlander.int
@@ -15,11 +15,18 @@ ModIncompatible="Please DEACTIVATE the following mods and restart or %s will not
 DisablePopup="DO NOT SHOW ME THIS AGAIN"
 
 [X2WOTCCH_UIScreenListener_ShellPopup]
-CycleErrorTitle="Cycle in Run Order Detected"
-CycleErrorText="Mods specified a cyclic run order:\n\n%FACTS\n...completing the cycle. Until this is corrected, run order will be undefined."
+CycleErrorTitle="Cycle in Run Order detected"
 GroupErrorTitle="Conflicting Run Order data"
+
+HardErrorText="Things will behave unpredictably. Proceed at your own risk."
+PotentialErrorText="Things will behave predictably, but potentially not in the way the author intended."
+
+AdviceText="If you are a mod user, please forward this message to the authors of the following mods: %BLAME. Only they can fix the cause of the problem."
+
+CycleErrorText="Mods specified a cyclic run order:\n\n%FACTS\n...completing the cycle. Until this is corrected, run order will be undefined."
 GroupErrorText="Mods specified conflicting run order information:\n\n%FACTS\nThis behavior is specified, but may indicate a configuration error."
-BlameText="The following DLCIdentifiers provided config that lead to this problem: %BLAME\n\nPlease inform the respective mod authors about this problem."
+
+BlameText="The following DLCIdentifiers provided config that lead to this problem: %BLAME"
 
 [X2WOTCCH_UIScreenListener_Shell_DLCIntro]
 strDLC2HLIntroduction_Title="Alien Hunters Community Highlander"

--- a/X2WOTCCommunityHighlander/Src/X2WOTCCommunityHighlander/Classes/X2WOTCCH_UIScreenListener_ShellPopup.uc
+++ b/X2WOTCCommunityHighlander/Src/X2WOTCCommunityHighlander/Classes/X2WOTCCH_UIScreenListener_ShellPopup.uc
@@ -13,8 +13,9 @@ var X2WOTCCH_ModDependencies DependencyChecker;
 
 var config array<string> HideGroupWarnings;
 
-var localized string CycleErrorTitle, CycleErrorText, HardErrorText;
-var localized string GroupErrorTitle, GroupErrorText, PotentialErrorText;
+var localized string ErrorTitle;
+var localized string CycleErrorText, HardErrorText;
+var localized string GroupErrorText, PotentialErrorText;
 var localized string AdviceText, BlameText;
 
 event OnInit(UIScreen Screen)
@@ -178,7 +179,7 @@ simulated function CyclePopup(CHDLCRunOrderDiagnostic Diag)
 {
 	local TDialogueBoxData kDialogData;
 
-	kDialogData.strTitle = default.CycleErrorTitle;
+	kDialogData.strTitle = default.ErrorTitle;
 	kDialogData.eType = eDialog_Warning;
 	kDialogData.strText = GetCycleText(Diag);
 	kDialogData.strCancel = class'UIUtilities_Text'.default.m_strGenericAccept;
@@ -193,8 +194,9 @@ function string GetCycleText(CHDLCRunOrderDiagnostic Diag)
 
 	JoinArray(Diag.Blame(), BlameBuf, ", ");
 
-	Fmt = default.HardErrorText;
-	Fmt @= Repl(default.AdviceText, "%BLAME", BlameBuf);
+	Fmt = Repl(default.AdviceText, "%BLAME", BlameBuf);
+	Fmt $= "\n";
+	Fmt $= default.HardErrorText;
 	Fmt $= "\n\n";
 
 	Facts = Diag.FormatEdgeFacts();
@@ -214,7 +216,7 @@ simulated function GroupPopup(CHDLCRunOrderDiagnostic Diag)
 	CallbackData = new class'X2WOTCCH_DialogCallbackData';
 	CallbackData.Diag = Diag;
 
-	kDialogData.strTitle = default.GroupErrorTitle;
+	kDialogData.strTitle = default.ErrorTitle;
 	kDialogData.eType = eDialog_Alert;
 	kDialogData.strText = GetGroupText(Diag);
 	kDialogData.fnCallbackEx = GroupPopupCB;
@@ -232,8 +234,9 @@ function string GetGroupText(CHDLCRunOrderDiagnostic Diag)
 
 	JoinArray(Diag.Blame(), BlameBuf, ", ");
 
-	Fmt = default.PotentialErrorText;
-	Fmt @= Repl(default.AdviceText, "%BLAME", BlameBuf);
+	Fmt = Repl(default.AdviceText, "%BLAME", BlameBuf);
+	Fmt $= "\n";
+	Fmt $= default.PotentialErrorText;
 	Fmt $= "\n\n";
 
 	Facts.AddItem(Diag.FormatSingleFact());

--- a/X2WOTCCommunityHighlander/Src/X2WOTCCommunityHighlander/Classes/X2WOTCCH_UIScreenListener_ShellPopup.uc
+++ b/X2WOTCCommunityHighlander/Src/X2WOTCCommunityHighlander/Classes/X2WOTCCH_UIScreenListener_ShellPopup.uc
@@ -13,9 +13,9 @@ var X2WOTCCH_ModDependencies DependencyChecker;
 
 var config array<string> HideGroupWarnings;
 
-var localized string CycleErrorTitle, CycleErrorText;
-var localized string GroupErrorTitle, GroupErrorText;
-var localized string BlameText;
+var localized string CycleErrorTitle, CycleErrorText, HardErrorText;
+var localized string GroupErrorTitle, GroupErrorText, PotentialErrorText;
+var localized string AdviceText, BlameText;
 
 event OnInit(UIScreen Screen)
 {
@@ -191,11 +191,16 @@ function string GetCycleText(CHDLCRunOrderDiagnostic Diag)
 	local string Fmt, BlameBuf;
 	local array<string> Facts;
 
+	JoinArray(Diag.Blame(), BlameBuf, ", ");
+
+	Fmt = default.HardErrorText;
+	Fmt @= Repl(default.AdviceText, "%BLAME", BlameBuf);
+	Fmt $= "\n\n";
+
 	Facts = Diag.FormatEdgeFacts();
 
-	Fmt = Repl(default.CycleErrorText, "%FACTS", MakeBulletList(Facts));
+	Fmt $= Repl(default.CycleErrorText, "%FACTS", MakeBulletList(Facts));
 	Fmt $= "\n\n";
-	JoinArray(Diag.Blame(), BlameBuf, ", ");
 	Fmt $= Repl(default.BlameText, "%BLAME", BlameBuf);
 
 	return Fmt;
@@ -210,7 +215,7 @@ simulated function GroupPopup(CHDLCRunOrderDiagnostic Diag)
 	CallbackData.Diag = Diag;
 
 	kDialogData.strTitle = default.GroupErrorTitle;
-	kDialogData.eType = eDialog_Warning;
+	kDialogData.eType = eDialog_Alert;
 	kDialogData.strText = GetGroupText(Diag);
 	kDialogData.fnCallbackEx = GroupPopupCB;
 	kDialogData.strAccept = class'X2WOTCCH_ModDependencies'.default.DisablePopup;
@@ -225,12 +230,17 @@ function string GetGroupText(CHDLCRunOrderDiagnostic Diag)
 	local string Fmt, BlameBuf;
 	local array<string> Facts;
 
+	JoinArray(Diag.Blame(), BlameBuf, ", ");
+
+	Fmt = default.PotentialErrorText;
+	Fmt @= Repl(default.AdviceText, "%BLAME", BlameBuf);
+	Fmt $= "\n\n";
+
 	Facts.AddItem(Diag.FormatSingleFact());
 	Facts.AddItem(Diag.FormatGroups());
 
-	Fmt = Repl(default.GroupErrorText, "%FACTS", MakeBulletList(Facts));
+	Fmt $= Repl(default.GroupErrorText, "%FACTS", MakeBulletList(Facts));
 	Fmt $= "\n\n";
-	JoinArray(Diag.Blame(), BlameBuf, ", ");
 	Fmt $= Repl(default.BlameText, "%BLAME", BlameBuf);
 	return Fmt;
 }


### PR DESCRIPTION
Fixes #1040.

This is the RPGO + LW2SW case:
![groups popup](https://user-images.githubusercontent.com/14299449/126078674-c24fe684-0345-4261-a123-05ff0ec9c56c.png)

And this is the cycle case, which we haven't observed in the wild yet:
![cycle popup](https://user-images.githubusercontent.com/14299449/126078694-a52bc6a3-db32-4582-9c0a-048c19b9cf2a.png)
