### PR TITLE
Simple ability self profiler

### DIFF
--- a/X2WOTCCommunityHighlander/Src/X2WOTCCommunityHighlander/Classes/X2DownloadableContentInfo_X2WOTCCommunityHighlander.uc
+++ b/X2WOTCCommunityHighlander/Src/X2WOTCCommunityHighlander/Classes/X2DownloadableContentInfo_X2WOTCCommunityHighlander.uc
@@ -92,3 +92,29 @@ exec function CHLDumpRunOrderInternals()
 {
 	CHOnlineEventMgr(`ONLINEEVENTMGR).DumpInternals();
 }
+
+exec function CHLBeginAbilityProfiling()
+{
+	if (class'CHProfiler' != none)
+	{
+		class'CHProfiler'.static.ClearAbilityProfile();
+		class'CHProfiler'.static.SetAbilityProfiling(true);
+	}
+	else
+	{
+		`warn("XComGame replacement with CHProfiler missing");
+	}
+}
+
+exec function CHLEndAbilityProfiling()
+{
+	if (class'CHProfiler' != none)
+	{
+		class'CHProfiler'.static.DumpAbilityProfile();
+		class'CHProfiler'.static.SetAbilityProfiling(false);
+	}
+	else
+	{
+		`warn("XComGame replacement with CHProfiler missing");
+	}
+}

--- a/X2WOTCCommunityHighlander/Src/XComGame/Classes/CHHelpers.uc
+++ b/X2WOTCCommunityHighlander/Src/XComGame/Classes/CHHelpers.uc
@@ -833,7 +833,8 @@ simulated function bool ShouldDisplayMultiSlotItemInTactical(XComGameState_Unit 
 
 static function CHHelpers GetCDO()
 {
-	return CHHelpers(class'XComEngine'.static.GetClassDefaultObjectByName(default.Class.Name));
+	// This is hot code, so use an optimized function here
+	return CHHelpers(FindObject("XComGame.Default__CHHelpers", class'CHHelpers'));
 }
 // End Issue #885
 

--- a/X2WOTCCommunityHighlander/Src/XComGame/Classes/CHProfiler.uc
+++ b/X2WOTCCommunityHighlander/Src/XComGame/Classes/CHProfiler.uc
@@ -1,0 +1,121 @@
+/// HL-Docs: feature:CHProfiler; issue:1044; tags:
+/// While you can profile the game's and mods' UnrealScript code with the
+/// [Gameplay Profiler](https://www.reddit.com/r/xcom2mods/wiki/index/profiling),
+/// the profiles lack semantic information. The CHProfiler facilitates recording
+/// and dumping **additional** performance information, usually requiring user
+/// configuration to do so (console commands, config).
+///
+/// ## Ability Profiling
+///
+/// Sometimes, the gameplay profiler may yield performance issues in ability target
+/// collection and condition checking. It's often hard to figure out which ability
+/// in particular is at fault, since all native conditions are usually invisible
+/// in the gameplay profiler and many abilities share conditions.
+///
+/// The ability profiler records the time it takes for an ability to collect
+/// targets and check conditions. The currently used timer has a **millisecond**
+/// resolution due to a missing higher-resolution timer, so it may only be
+/// useful to identify egregious issues.
+///
+/// The console command `CHLBeginAbilityProfiling` begins event collection,
+/// while `CHLEndAbilityProfiling` ends it and prints the collected data
+/// to the log and console.
+/// The resulting string conforms to the following grammar:
+///
+/// ```abnf
+/// <string> ::= <part> | (<part> ";" <string>) | E
+/// <part> ::= <name> ":" <numlist>
+/// <numlist> ::= <number> | (<number> "," <numlist>)
+/// <number> ::= [0-9]+
+/// <name> ::= ([A-Z] | [a-z] | [0-9] | "_")+
+/// ```
+///
+/// i.e. a semicolon-separated list of AbilityName, colon, comma-separated numbers sequences.
+/// Every time the game calls `UpdateAbilityAvailability`, it measures the time it took the call.
+/// Every number in the output corresponds to one call.
+///
+/// You can then analyze the results with an external tool, for example by [visualizing them
+/// using matplotlib](https://gist.github.com/robojumper/1ee2de9bd38377b9c57e6ff684075780):
+///
+/// ![matplotlib ability profile](https://i.imgur.com/VHWJAqs.png)
+///
+/// **The exact output format and the clock resolution are subject to change.**
+class CHProfiler extends Object;
+
+struct AbilityProfile
+{
+	var name AbilityName;
+	var array<int> EventsMillis;
+};
+
+var private array<AbilityProfile> Abilities;
+
+var privatewrite bool bAbilityProfileEnabled;
+
+private static function CHProfiler GetCDO()
+{
+	// This is hot code, so use an optimized function here
+	return CHProfiler(FindObject("XComGame.Default__CHProfiler", class'CHProfiler'));
+}
+
+static function AddAbilityEvent(name AbilityName, int Millis)
+{
+	local int idx;
+	local CHProfiler Prof;
+
+	Prof = static.GetCDO();
+	idx = Prof.Abilities.Find('AbilityName', AbilityName);
+	if (idx == INDEX_NONE)
+	{
+		idx = Prof.Abilities.Length;
+		Prof.Abilities.Add(1);
+		Prof.Abilities[idx].AbilityName = AbilityName;
+	}
+	Prof.Abilities[idx].EventsMillis.AddItem(Millis);
+}
+
+static function ClearAbilityProfile()
+{
+	local CHProfiler Prof;
+	Prof = static.GetCDO();
+	Prof.Abilities.Length = 0;
+}
+
+static function SetAbilityProfiling(bool bEnabled)
+{
+	local CHProfiler Prof;
+	Prof = static.GetCDO();
+	Prof.bAbilityProfileEnabled = bEnabled;
+}
+
+static function DumpAbilityProfile()
+{
+	local CHProfiler Prof;
+	local string DataString;
+	local int idx, eidx;
+
+	Prof = static.GetCDO();
+	DataString = "";
+	
+	for (idx = 0; idx < Prof.Abilities.Length; idx++)
+	{
+		DataString $= Prof.Abilities[idx].AbilityName;
+		DataString $= ":";
+
+		for (eidx = 0; eidx < Prof.Abilities[idx].EventsMillis.Length; eidx++)
+		{
+			DataString $= Prof.Abilities[idx].EventsMillis[eidx];
+
+			if (eidx != Prof.Abilities[idx].EventsMillis.Length - 1)
+			{
+				DataString $= ",";
+			}
+		}
+
+		if (idx != Prof.Abilities.Length - 1)
+		{
+			DataString $= ";";
+		}
+	}
+	class'X2TacticalGameRuleset'.static.ReleaseScriptLog(DataString);
+}

--- a/X2WOTCCommunityHighlander/Src/XComGame/Classes/UITacticalHUD_SoldierInfo.uc
+++ b/X2WOTCCommunityHighlander/Src/XComGame/Classes/UITacticalHUD_SoldierInfo.uc
@@ -7,7 +7,7 @@
 //  Copyright (c) 2016 Firaxis Games, Inc. All rights reserved.
 //--------------------------------------------------------------------------------------- 
 
-class UITacticalHUD_SoldierInfo extends UIPanel implements(X2VisualizationMgrObserverInterface); // Issue #257 -- correct update calls
+class UITacticalHUD_SoldierInfo extends UIPanel;
 
 var string HackingToolTipTargetPath;
 var localized string FocusLevelLabel;
@@ -37,8 +37,6 @@ simulated function OnInit()
 	WorldInfo.MyWatchVariableMgr.RegisterWatchVariable( XComTacticalController(PC), 'm_kActiveUnit', self, UpdateStats);
 	WorldInfo.MyWatchVariableMgr.RegisterWatchVariable( UITacticalHUD(screen), 'm_isMenuRaised', self, UpdateStats);
 	WorldInfo.MyWatchVariableMgr.RegisterWatchVariable( XComPresentationLayer(Movie.Pres), 'm_kInventoryTactical', self, UpdateStats);
-
-	`XCOMVISUALIZATIONMGR.RegisterObserver(self); // Issue #257
 
 	HackingToolTipTargetPath = MCPath$".HackingInfoGroup.HackingInfo";
 	FocusToolTipTargetPath = MCPath$".FocusLevel";
@@ -112,7 +110,7 @@ simulated function UpdateStats()
 	else
 	{
 		//UITacticalHUD(Screen).m_kInventory.m_kBackpack.Update( kActiveUnit );
-		if( LastVisibleActiveUnitID != kActiveUnit.ObjectID )
+		if( /*LastVisibleActiveUnitID != kActiveUnit.ObjectID*/ true ) // Issue #257, this is also called when refreshing after action
 		{
 			SetStats(kActiveUnit);
 			SetHackingInfo(kActiveUnit);
@@ -419,17 +417,6 @@ public function AS_SetBondInfo(int BondLevel, bool bOnMission)
 	MC.QueueBoolean(bOnMission);
 	MC.EndOp();
 }
-
-// Start Issue #257 -- Better update calls
-event OnVisualizationBlockComplete(XComGameState AssociatedGameState)
-{
-	LastVisibleActiveUnitID = 0;
-	UpdateStats();
-}
-
-event OnActiveUnitChanged(XComGameState_Unit NewActiveUnit);
-event OnVisualizationIdle();
-// End Issue #257
 
 defaultproperties
 {


### PR DESCRIPTION
Helps towards #1044.

@Xymanek suggested:
> add an array to CHHelpers for ability templates to force usage of script GAT (XCGS_A_CH), so that we can see what exact part of logic is spending so much time. The DoesBlockUnitPathing calls makes me suspect that we are actually spending the time in X2AbilityTarget_MovingMelee/pathfinding