### PR TITLE
Fix disappearing items on TLP missions

### DIFF
--- a/X2WOTCCommunityHighlander/Src/XComGame/Classes/XComGameState_LadderProgress.uc
+++ b/X2WOTCCommunityHighlander/Src/XComGame/Classes/XComGameState_LadderProgress.uc
@@ -920,32 +920,35 @@ private static function SwapItem( XComGameState StartState, XComGameState_Unit U
 
 		ExistingItem = UnitState.GetItemInSlot( WorkingSlot );
 
-		//Issue #295 - Move the 'none' check for ExistingItem above ExistingItem.GetMyTemplate()
+		// Start Issues #295 and #1051
+		// Rework this function to get rid of the 'accessed none' log warnings.
 		if (ExistingItem != none)
 		{
-			if (ExistingItem.GetMyTemplate() != EquipmentTemplate)
-			{
-				`assert( UnitState.CanRemoveItemFromInventory( ExistingItem, StartState ) );
-
-				// Issue #295 - Purge Item State and add new item to inventory only if we successfully unequipped the Existing Item
-				if (UnitState.RemoveItemFromInventory( ExistingItem, StartState ))
-				{
-					`XCOMHISTORY.PurgeObjectIDFromStartState( ExistingItem.ObjectID, false ); // don't refresh the cache every time, we'll do that once after removing all items from all units
-	
-					ItemInstance = EquipmentTemplate.CreateInstanceFromTemplate( StartState );
-					UnitState.AddItemToInventory( ItemInstance, WorkingSlot, StartState );
-				}
-			}
-			else
-			{
-				// propagate this item through to the next start state
+			if (ExistingItem.GetMyTemplate() == EquipmentTemplate)
+			{	
+				// Desired item already equipped on unit.
+				// Propagate this item through to the next start state and exit function.
 				ExistingItem = XComGameState_Item( StartState.ModifyStateObject( class'XComGameState_Item', ExistingItem.ObjectID ) );
 
 				// reset the reference to the cosmetic unit: A) that unit won't be coming along in the transfers, B) and we'll create new ones at the start of the map anyway
 				if (ExistingItem.CosmeticUnitRef.ObjectID > 0)
+				{
 					ExistingItem.CosmeticUnitRef.ObjectID = -1;
+				}
+				return;
+			}
+			else
+			{
+				`assert( UnitState.CanRemoveItemFromInventory( ExistingItem, StartState ) );
+
+				UnitState.RemoveItemFromInventory( ExistingItem, StartState );
+				`XCOMHISTORY.PurgeObjectIDFromStartState( ExistingItem.ObjectID, false ); // don't refresh the cache every time, we'll do that once after removing all items from all units
 			}
 		}
+
+		ItemInstance = EquipmentTemplate.CreateInstanceFromTemplate( StartState );
+		UnitState.AddItemToInventory( ItemInstance, WorkingSlot, StartState );
+		// End Issue #295 and #1051
 	}
 }
 


### PR DESCRIPTION
Closes #1051

The `XComGameState_LadderProgress::SwapItems()` refactor for issue #295 has altered the base game behavior, and caused the function to fail to equip the new item if the slot didn't already contain another item.

This refactors the function again, this time preserving the [original algorithm](https://cdn.discordapp.com/attachments/273238884433788928/873166672549261352/unknown.png). 

In testing this bug has caused soldiers' heavy weapons to not appear when the player selected the EXO / WAR suit TLP mission reward. The fix resolves the issue.

However, workshop users have reported different symptoms, where soldiers' primary weapons and even whole inventories disappeared:

https://i.imgur.com/r4YcRCs.jpg

https://i.imgur.com/mkJNKfk.jpg 

Filing this is a draft for now, pending further investigation.