### PR TITLE
Fix wrong stack sizes being displayed in armory for modified finite items

### DIFF
--- a/X2WOTCCommunityHighlander/Src/XComGame/Classes/UIArmory_LoadoutItem.uc
+++ b/X2WOTCCommunityHighlander/Src/XComGame/Classes/UIArmory_LoadoutItem.uc
@@ -60,7 +60,12 @@ simulated function UIArmory_LoadoutItem InitLoadoutItem(XComGameState_Item Item,
 			}
 			else
 			{
-				SetCount(class'UIUtilities_Strategy'.static.GetXComHQ().GetNumItemInInventory(ItemTemplate.DataName));
+				// Start Issue #1065
+				/// HL-Docs: ref:Bugfixes; issue:1065
+				/// `UIArmory_LoadoutItem` now shows the correct stack counts for modified finite items.
+				// SetCount(class'UIUtilities_Strategy'.static.GetXComHQ().GetNumItemInInventory(ItemTemplate.DataName));
+				SetCount(Item.Quantity);
+				// End Issue #1065
 			}
 		}
 	}


### PR DESCRIPTION
Fixes #1065. I'm going to argue that this change is correct on the grounds of the calling code doing this:

```unrealscript
    Inventory = class'UIUtilities_Strategy'.static.GetXComHQ().Inventory;
	foreach Inventory(ItemRef)
	{
		Item = GetItemFromHistory(ItemRef.ObjectID);
		if(ShowInLockerList(Item, SelectedSlot))
		{
			LockerItem.Item = Item;
			LockerItem.DisabledReason = GetDisabledReason(Item, SelectedSlot);
			LockerItem.CanBeEquipped = LockerItem.DisabledReason == ""; // sorting optimization
			LockerItems.AddItem(LockerItem);
		}
	}

	LockerList.ClearItems();

	LockerItems.Sort(SortLockerListByUpgrades);
	LockerItems.Sort(SortLockerListByTier);
	LockerItems.Sort(SortLockerListByEquip);

	foreach LockerItems(LockerItem)
	{
		UIArmory_LoadoutItem(LockerList.CreateItem(class'UIArmory_LoadoutItem')).InitLoadoutItem(LockerItem.Item, SelectedSlot, false, LockerItem.DisabledReason);
	}
```
i.e. every locker entry corresponds to one item state object, so the quantities on the state object *must* be correct -- there's no need to look at the whole inventory and perform a count.