### PR TITLE
Adding new inventory slot for Viper spit items

### DIFF
--- a/X2WOTCCommunityHighlander/Src/XComGame/Classes/X2TacticalGameRulesetDataStructures.uc
+++ b/X2WOTCCommunityHighlander/Src/XComGame/Classes/X2TacticalGameRulesetDataStructures.uc
@@ -111,6 +111,7 @@ enum EInventorySlot
 	eInvSlot_TacticalGadget,
 	eInvSlot_MZAux,
 	eInvSlot_TemplateMaster,
+	eInvSlot_ViperMAW,
 
 	// Marker slot, don't use
 	eInvSlot_END_TEMPLATED_SLOTS,


### PR DESCRIPTION
Adds one new entry allowing the use of spits for vipers without using a utility slot (And consequently, allowing Non-Vipers equipping the item) and allowing it to be switched out for a different item that grants a different type of spit for them.