### PR TITLE
Fix reinforcement flare appearing on loading a save

### DIFF
--- a/X2WOTCCommunityHighlander/Src/XComGame/Classes/XComGameState_AIReinforcementSpawner.uc
+++ b/X2WOTCCommunityHighlander/Src/XComGame/Classes/XComGameState_AIReinforcementSpawner.uc
@@ -837,14 +837,14 @@ function AppendAdditionalSyncActions( out VisualizationActionMetadata ActionMeta
 		return; // we've completed the reinforcement and the effect was stopped
 	}
 
-	// Start Issue #448 (addendum)
+	// Start Issue #1097
 	// This fixes the issue where reinforcement flares were still visible when
 	// loading a save.
 	if (TriggerOverrideDisableReinforcementsFlare(self))
 	{
 		return;
 	}
-	// End Issue #448
+	// End Issue #1097
 
 	RevealAreaAction = X2Action_RevealArea(class'X2Action_RevealArea'.static.AddToVisualizationTree(ActionMetadata, GetParentGameState().GetContext() ) );
 	RevealAreaAction.TargetLocation = SpawnInfo.SpawnLocation;


### PR DESCRIPTION
This is a fix for issue #1097 where a mod could override the reinforcement flare behavior (hiding them rather than showing them), but the flare would reappear on loading a saved game from that same turn.

The implementation of #448 was just missing the override event in `AppendAdditionalSyncActions` that Long War 2 had.

Fixes #1097 