### PR TITLE
Resolves #1101

### DIFF
--- a/X2WOTCCommunityHighlander/Src/XComGame/Classes/XComGameState_Item.uc
+++ b/X2WOTCCommunityHighlander/Src/XComGame/Classes/XComGameState_Item.uc
@@ -1533,9 +1533,9 @@ simulated function string AddStatModifier(bool bAddCommaSeparator, string Label,
 	if(bAddCommaSeparator) Result $= ", ";
 	Result $= Label;
 	if(bSymbolOnRight)
-		Result @= Value $ (Value < 0 ? "-" : "+");
+		Result @= Value $ (Value >= 0 ? "+" : "");	//Issue #1101 - Weapon Upgrade with negative stat modifier shows as "--x"
 	else
-		Result @= (Value < 0 ? "-" : "+") $ Value;
+		Result @= (Value >= 0 ? "+" : "") $ Value;	//Issue #1101 - Weapon Upgrade with negative stat modifier shows as "--x"
 	Result = class'UIUtilities_Text'.static.GetColoredText(Result $ PostFix, ColorState);
 	Result = class'UIUtilities_Text'.static.FormatCommaSeparatedNouns(Result);
 	return Result;


### PR DESCRIPTION
Resolves #1101
Minor change to only show "+" when `Value >= 0`
Will never include "-" as that is already in `Value`