### PR TITLE
Add eInvSlot_ entries for modular sparks.

### DIFF
--- a/X2WOTCCommunityHighlander/Src/XComGame/Classes/X2TacticalGameRulesetDataStructures.uc
+++ b/X2WOTCCommunityHighlander/Src/XComGame/Classes/X2TacticalGameRulesetDataStructures.uc
@@ -112,6 +112,9 @@ enum EInventorySlot
 	eInvSlot_MZAux,
 	eInvSlot_TemplateMaster,
 	eInvSlot_ViperMAW,
+	eInvSlot_SparkComputer,
+	eInvSlot_SparkActuator,
+	eInvSlot_SparkModule,
 
 	// Marker slot, don't use
 	eInvSlot_END_TEMPLATED_SLOTS,


### PR DESCRIPTION
A massive amount of inventory slots (3) to allow a massive stack of equippable items for a SPARK class overhaul.
Will add a comment in #137 once the mod gets to the workshop.
![image](https://user-images.githubusercontent.com/59488828/145067156-6e200ccc-e4fb-49c6-9ffc-989898ea62dc.png)
