### PR TITLE
Issue #1084 - Allow choosing target tile for meleeing adjacent targets

### DIFF
--- a/X2WOTCCommunityHighlander/Src/XComGame/Classes/CHHelpers.uc
+++ b/X2WOTCCommunityHighlander/Src/XComGame/Classes/CHHelpers.uc
@@ -945,7 +945,6 @@ static function name GetPlaceEvacZoneAbilityName()
 // End Issue #855
 
 // Start Issue #1084
-// This helper function is covered by Backwards Compatibility policy and is safe for use in mods.
 static final function array<TTile> GetTilesAdjacentToTile(const TTile SourceTile)
 {	
 	local array<TTile> AdjacentTiles;
@@ -955,18 +954,25 @@ static final function array<TTile> GetTilesAdjacentToTile(const TTile SourceTile
 	AdjacentTile.X--;
 	AdjacentTile.Y--;
 	AdjacentTiles.AddItem(AdjacentTile);
+
 	AdjacentTile.X++;
 	AdjacentTiles.AddItem(AdjacentTile);
+
 	AdjacentTile.X++;
 	AdjacentTiles.AddItem(AdjacentTile);
+
 	AdjacentTile.Y++;
 	AdjacentTiles.AddItem(AdjacentTile);
+
 	AdjacentTile.Y++;
 	AdjacentTiles.AddItem(AdjacentTile);
+
 	AdjacentTile.X--;
 	AdjacentTiles.AddItem(AdjacentTile);
+
 	AdjacentTile.X--;
 	AdjacentTiles.AddItem(AdjacentTile);
+
 	AdjacentTile.Y--;
 	AdjacentTiles.AddItem(AdjacentTile);
 

--- a/X2WOTCCommunityHighlander/Src/XComGame/Classes/CHHelpers.uc
+++ b/X2WOTCCommunityHighlander/Src/XComGame/Classes/CHHelpers.uc
@@ -943,39 +943,3 @@ static function name GetPlaceEvacZoneAbilityName()
 	return default.PlaceEvacZoneAbilityName != '' ? default.PlaceEvacZoneAbilityName : 'PlaceEvacZone';
 }
 // End Issue #855
-
-// Start Issue #1084
-static final function array<TTile> GetTilesAdjacentToTile(const TTile SourceTile)
-{	
-	local array<TTile> AdjacentTiles;
-	local TTile AdjacentTile;
-	
-	AdjacentTile = SourceTile;
-	AdjacentTile.X--;
-	AdjacentTile.Y--;
-	AdjacentTiles.AddItem(AdjacentTile);
-
-	AdjacentTile.X++;
-	AdjacentTiles.AddItem(AdjacentTile);
-
-	AdjacentTile.X++;
-	AdjacentTiles.AddItem(AdjacentTile);
-
-	AdjacentTile.Y++;
-	AdjacentTiles.AddItem(AdjacentTile);
-
-	AdjacentTile.Y++;
-	AdjacentTiles.AddItem(AdjacentTile);
-
-	AdjacentTile.X--;
-	AdjacentTiles.AddItem(AdjacentTile);
-
-	AdjacentTile.X--;
-	AdjacentTiles.AddItem(AdjacentTile);
-
-	AdjacentTile.Y--;
-	AdjacentTiles.AddItem(AdjacentTile);
-
-	return AdjacentTiles;
-}
-// End Issue #1084

--- a/X2WOTCCommunityHighlander/Src/XComGame/Classes/CHHelpers.uc
+++ b/X2WOTCCommunityHighlander/Src/XComGame/Classes/CHHelpers.uc
@@ -943,3 +943,33 @@ static function name GetPlaceEvacZoneAbilityName()
 	return default.PlaceEvacZoneAbilityName != '' ? default.PlaceEvacZoneAbilityName : 'PlaceEvacZone';
 }
 // End Issue #855
+
+// Start Issue #1084
+// This helper function is covered by Backwards Compatibility policy and is safe for use in mods.
+static final function array<TTile> GetTilesAdjacentToTile(const TTile SourceTile)
+{	
+	local array<TTile> AdjacentTiles;
+	local TTile AdjacentTile;
+	
+	AdjacentTile = SourceTile;
+	AdjacentTile.X--;
+	AdjacentTile.Y--;
+	AdjacentTiles.AddItem(AdjacentTile);
+	AdjacentTile.X++;
+	AdjacentTiles.AddItem(AdjacentTile);
+	AdjacentTile.X++;
+	AdjacentTiles.AddItem(AdjacentTile);
+	AdjacentTile.Y++;
+	AdjacentTiles.AddItem(AdjacentTile);
+	AdjacentTile.Y++;
+	AdjacentTiles.AddItem(AdjacentTile);
+	AdjacentTile.X--;
+	AdjacentTiles.AddItem(AdjacentTile);
+	AdjacentTile.X--;
+	AdjacentTiles.AddItem(AdjacentTile);
+	AdjacentTile.Y--;
+	AdjacentTiles.AddItem(AdjacentTile);
+
+	return AdjacentTiles;
+}
+// End Issue #1084

--- a/X2WOTCCommunityHighlander/Src/XComGame/Classes/X2MeleePathingPawn.uc
+++ b/X2WOTCCommunityHighlander/Src/XComGame/Classes/X2MeleePathingPawn.uc
@@ -161,7 +161,7 @@ simulated function UpdateMeleeTarget(XComGameState_BaseObject Target)
 		// script logic to add more possible attack tiles for adjacent targets.
 		// If there's only one possible melee attack tile and the unit is standing on it,
 		// then the target is directly adjacent.
-		if (PossibleTiles.Length == 1 && UnitState.TileLocation == PossibleTiles[0])
+		if (UnitState.UnitSize == 1 && PossibleTiles.Length == 1 && UnitState.TileLocation == PossibleTiles[0])
 		{
 			UpdatePossibleTilesForAdjacentTarget(Target);
 		}

--- a/X2WOTCCommunityHighlander/Src/XComGame/Classes/X2MeleePathingPawn.uc
+++ b/X2WOTCCommunityHighlander/Src/XComGame/Classes/X2MeleePathingPawn.uc
@@ -197,7 +197,6 @@ simulated function UpdateMeleeTarget(XComGameState_BaseObject Target)
 }
 
 // Start Issue #1084
-// This is an internal CHL API. It is not intended for use by mods and is not covered by Backwards Compatibility policy.
 private function UpdatePossibleTilesForAdjacentTarget(XComGameState_BaseObject Target)
 {
 	local array<TTile>               TilesForMeleeAttack;
@@ -223,11 +222,18 @@ private function UpdatePossibleTilesForAdjacentTarget(XComGameState_BaseObject T
 	{
 		TargetObject = XComGameState_Destructible(Target);
 		if (TargetObject == none)
+		{
+			`LOG(self.Class.Name @ GetFuncName() @ ":: WARNING, target is not a unit and not a destructible object! Its class is:" @ Target.Class.Name @ ", unable to detect additional tiles to melee attack from. Attacking unit:" @ UnitState.GetFullName());
 			return;
+		}
 
 		DestructibleActor = XComDestructibleActor(TargetObject.GetVisualizer());
 		if (DestructibleActor == none)
+		if (TargetObject == none)
+		{
+			`LOG(self.Class.Name @ GetFuncName() @ ":: WARNING, no visualizer found for destructible object with ID:" @ TargetObject.ObjectID @ ", unable to detect additional tiles to melee attack from. Attacking unit:" @ UnitState.GetFullName());
 			return;
+		}
 	
 		// AssociatedTiles is the array of tiles occupied by the destructible object.
 		// In theory, every tile from that array can be targeted by a melee attack

--- a/X2WOTCCommunityHighlander/Src/XComGame/Classes/X2MeleePathingPawn.uc
+++ b/X2WOTCCommunityHighlander/Src/XComGame/Classes/X2MeleePathingPawn.uc
@@ -330,7 +330,7 @@ simulated event Tick(float DeltaTime)
 				   // If the cursor is hovering above the tile occupied by a unit, the CursorTile.Z is increased by 1,
 				   // so the direct comparison "PossibleTile == CursorTile" will always fail.
 				   // So for the possible attack tile occupied by the attacker unit, we compare to cursor's Z location - 1.
-				   PossibleTile == UnitState.TileLocation && CursorTile.X == PossibleTile.X && PossibleTile.Y == CursorTile.Y && PossibleTile.Z == CursorTile.Z - 1
+				   (PossibleTile == UnitState.TileLocation && CursorTile.X == PossibleTile.X && PossibleTile.Y == CursorTile.Y && PossibleTile.Z == CursorTile.Z - 1)
 				   // End issue #1084
 				   )
 				{

--- a/X2WOTCCommunityHighlander/Src/XComGame/Classes/X2MeleePathingPawn.uc
+++ b/X2WOTCCommunityHighlander/Src/XComGame/Classes/X2MeleePathingPawn.uc
@@ -256,33 +256,16 @@ private function GatherTilesOccupiedByUnit(const XComGameState_Unit TargetUnit, 
 	local XComWorldData      WorldData;
 	local array<TilePosPair> TilePosPairs;
 	local TilePosPair        TilePair;
-	local vector             Minimum;
-	local vector             Maximum;
-	local float              UnitSize;
-	local array<StateObjectReference> UnitsOnTile;
+	local Box                VisibilityExtents;
+
+	TargetUnit.GetVisibilityExtents(VisibilityExtents);
 	
 	WorldData = `XWORLD;
-	UnitSize = WorldData.WORLD_StepSize * (TargetUnit.UnitSize - 1);
-
-	Minimum = WorldData.GetPositionFromTileCoordinates(TargetUnit.TileLocation);
-	Maximum = Minimum;
-	
-	Minimum.X -= UnitSize;
-	Minimum.Y -= UnitSize;
-
-	Maximum.X += UnitSize;
-	Maximum.Y += UnitSize;
-	Maximum.Z += WorldData.WORLD_FloorHeight * (TargetUnit.UnitHeight - 1);
-
-	WorldData.CollectTilesInBox(TilePosPairs, Minimum, Maximum);
+	WorldData.CollectTilesInBox(TilePosPairs, VisibilityExtents.Min, VisibilityExtents.Max);
 
 	foreach TilePosPairs(TilePair)
 	{
-		UnitsOnTile = WorldData.GetUnitsOnTile(TilePair.Tile);
-		if (UnitsOnTile.Find('ObjectID', TargetUnit.ObjectID) != INDEX_NONE)
-		{
-			OccupiedTiles.AddItem(TilePair.Tile);
-		}
+		OccupiedTiles.AddItem(TilePair.Tile);
 	}
 }
 

--- a/X2WOTCCommunityHighlander/Src/XComGame/Classes/X2MeleePathingPawn.uc
+++ b/X2WOTCCommunityHighlander/Src/XComGame/Classes/X2MeleePathingPawn.uc
@@ -327,7 +327,7 @@ simulated event Tick(float DeltaTime)
 			{
 				if(PossibleTile == CursorTile || 
 				   // Start Issue #1084
-				   // If the cursor is hovering above the tile occupied by a unit, the CursorTile.Z is increased by 1,
+				   // If the cursor is hovering above the tile occupied by the unit, the CursorTile.Z is increased by 1,
 				   // so the direct comparison "PossibleTile == CursorTile" will always fail.
 				   // So for the possible attack tile occupied by the attacker unit, we compare to cursor's Z location - 1.
 				   (PossibleTile == UnitState.TileLocation && CursorTile.X == PossibleTile.X && PossibleTile.Y == CursorTile.Y && PossibleTile.Z == CursorTile.Z - 1)


### PR DESCRIPTION
Fixes #1084

Also adds a couple helper methods into CHHelpers to be used by this issue or mods.

----

I've traced the problem to `X2MeleePathingPawn::UpdateMeleeTarget()`, which calls very native `class'X2AbilityTarget_MovingMelee'.static.SelectAttackTile()`. 

When melee-ing adjacent targets, `SelectAttackTile()` only writes one tile into the `PossibleTiles` out array. 

I suggest addressing this issue by inserting custom unreal script logic that will run in case `SelectAttackTile()` gives only one tile. Said custom logic will simply take a look at the target, and insert more tiles into the `PossibleTiles` array.

If it sounds good, I could use some help in setting up that custom logic so that we only insert tiles that are actually reachable by the soldier. 