### PR TITLE
Make GetUISummary_UnitStatusIcons() skip empty status icons

### DIFF
--- a/X2WOTCCommunityHighlander/Src/XComGame/Classes/XComGameState_Unit.uc
+++ b/X2WOTCCommunityHighlander/Src/XComGame/Classes/XComGameState_Unit.uc
@@ -14102,7 +14102,9 @@ simulated function array<string> GetUISummary_UnitStatusIcons()
 	{
 		EffectState = XComGameState_Effect(History.GetGameStateForObjectID(EffectRef.ObjectID));
 		Persist = EffectState.GetX2Effect();
-		if( Persist.bDisplayInUI && Persist.IsEffectCurrentlyRelevant(EffectState, self) )
+		if (Persist.bDisplayInUI &&
+			Persist.StatusIcon != "" && // Single line for Issue #1120 - add the status icon only if it's not empty.
+			Persist.IsEffectCurrentlyRelevant(EffectState, self))
 		{
 			List.AddItem(Persist.StatusIcon);
 		}

--- a/X2WOTCCommunityHighlander/Src/XComGame/Classes/XComGameState_Unit.uc
+++ b/X2WOTCCommunityHighlander/Src/XComGame/Classes/XComGameState_Unit.uc
@@ -14102,8 +14102,11 @@ simulated function array<string> GetUISummary_UnitStatusIcons()
 	{
 		EffectState = XComGameState_Effect(History.GetGameStateForObjectID(EffectRef.ObjectID));
 		Persist = EffectState.GetX2Effect();
+
+		/// HL-Docs: ref:Bugfixes; issue:1120
+		/// Add the effect's status icon only if it's not empty.
 		if (Persist.bDisplayInUI &&
-			Persist.StatusIcon != "" && // Single line for Issue #1120 - add the status icon only if it's not empty.
+			Persist.StatusIcon != "" && // Single line for Issue #1120
 			Persist.IsEffectCurrentlyRelevant(EffectState, self))
 		{
 			List.AddItem(Persist.StatusIcon);


### PR DESCRIPTION
Fixes #1120 

This will fix the bug where status icons would not display sometimes.