### PR TITLE
Add event for overriding resistance faction icon #1134

### DIFF
--- a/X2WOTCCommunityHighlander/Src/XComGame/Classes/UIAfterAction_ListItem.uc
+++ b/X2WOTCCommunityHighlander/Src/XComGame/Classes/UIAfterAction_ListItem.uc
@@ -63,13 +63,14 @@ simulated function UpdateData(optional StateObjectReference UnitRef)
 	local XComGameState_Unit Unit, Bondmate;
 	local SoldierBond BondData;
 	local StateObjectReference BondmateRef;
-	local XComGameState_ResistanceFaction FactionState;
+	//local XComGameState_ResistanceFaction FactionState; //Issue #1134, not needed
+	local StackedUIIconData StackedClassIcon; // Variable for issue #1134
 
 	UnitReference = UnitRef;
 
 	Unit = XComGameState_Unit(`XCOMHISTORY.GetGameStateForObjectID(UnitRef.ObjectID));
-	
-	FactionState = Unit.GetResistanceFaction();
+
+	//FactionState = Unit.GetResistanceFaction(); //Issue #1134, not needed
 
 	if(Unit.bCaptured)
 	{
@@ -154,7 +155,11 @@ simulated function UpdateData(optional StateObjectReference UnitRef)
 		AS_SetUnitWill(-1, "");
 	}
 
-	AS_SetFactionIcon(FactionState.GetFactionIcon());
+	// Start Issue #1134
+	StackedClassIcon = Unit.GetStackedClassIcon();
+	if (StackedClassIcon.Images.Length > 0)
+		AS_SetFactionIcon(StackedClassIcon);
+	// End Issue #1134
 
 	EnableNavigation(); // bsg-nlong (1.24.17): We will always want navigation now that the bond icon is a thing
 	if( bCanPromote )

--- a/X2WOTCCommunityHighlander/Src/XComGame/Classes/UIAlert.uc
+++ b/X2WOTCCommunityHighlander/Src/XComGame/Classes/UIAlert.uc
@@ -2855,9 +2855,10 @@ simulated function BuildTrainingCompleteAlert(string TitleLabel)
 	local array<SoldierClassAbilityType> AbilityTree;
 	local X2AbilityTemplateManager AbilityTemplateManager;
 	local XGParamTag kTag;
-	local XComGameState_ResistanceFaction FactionState;
+	//local XComGameState_ResistanceFaction FactionState; //Issue #1134, not needed
 	local int i;
 	local string AbilityIcon, AbilityName, AbilityDescription, ClassIcon, ClassName, RankName;
+	local StackedUIIconData StackedClassIcon; // Variable for issue #1134
 	
 	if( LibraryPanel == none )
 	{
@@ -2873,7 +2874,7 @@ simulated function BuildTrainingCompleteAlert(string TitleLabel)
 	// End Issue #106
 	RankName = Caps(UnitState.GetSoldierRankName()); // Issue #408
 	
-	FactionState = UnitState.GetResistanceFaction();
+	//FactionState = UnitState.GetResistanceFaction(); //Issue #1134, not needed
 
 	kTag = XGParamTag(`XEXPANDCONTEXT.FindTag("XGParam"));
 	kTag.StrValue0 = "";
@@ -2932,8 +2933,11 @@ simulated function BuildTrainingCompleteAlert(string TitleLabel)
 		Button1.DisableNavigation();
 	}
 
-	if (FactionState != none)
-		SetFactionIcon(FactionState.GetFactionIcon());
+	// Start Issue #1134
+	StackedClassIcon = UnitState.GetStackedClassIcon();
+	if (StackedClassIcon.Images.Length > 0)
+		SetFactionIcon(StackedClassIcon);
+	// End Issue #1134
 }
 
 //bsg-crobinson (5.17.17): Realize the buttons need to be in a different place for this alert
@@ -3603,10 +3607,11 @@ simulated function BuildNewStaffAvailableAlert()
 	local XComGameState_HeadquartersRoom Room;
 	local XComGameState_FacilityXCom Facility;
 	local array<XComGameState_StaffSlot> arrStaffSlots;
-	local XComGameState_ResistanceFaction FactionState;
+	//local XComGameState_ResistanceFaction FactionState; //Issue #1134, not needed
 	local string StaffAvailableTitle, StaffAvailableStr, StaffBonusStr, UnitTypeIcon;
 	local float BonusAmt;
 	local bool bWoundRecovery;
+	local StackedUIIconData StackedClassIcon; // Variable for issue #1134
 
 	if( LibraryPanel == none )
 	{
@@ -3619,8 +3624,8 @@ simulated function BuildNewStaffAvailableAlert()
 		class'X2StrategyGameRulesetDataStructures'.static.GetDynamicIntProperty(DisplayPropertySet, 'UnitRef')));
 	bWoundRecovery = class'X2StrategyGameRulesetDataStructures'.static.GetDynamicBoolProperty(DisplayPropertySet, 'WoundRecovery');
 	arrStaffSlots = XCOMHQ().GetAllEmptyStaffSlotsForUnit(UnitState);
-
-	FactionState = UnitState.GetResistanceFaction();
+	
+	//FactionState = UnitState.GetResistanceFaction(); //Issue #1134, not needed
 
 	// First set up the string describing the inherent bonus of the new staff member
 	if (UnitState.IsScientist())
@@ -3719,9 +3724,11 @@ simulated function BuildNewStaffAvailableAlert()
 	Button2.DisableNavigation(); 
 	Button2.Hide();
 
-	if(FactionState != none)
-		SetFactionIcon(FactionState.GetFactionIcon());
-
+	// Start Issue #1134
+	StackedClassIcon = UnitState.GetStackedClassIcon();
+	if (StackedClassIcon.Images.Length > 0)
+		SetFactionIcon(StackedClassIcon);
+	// End Issue #1134
 }
 
 simulated function BuildStaffInfoAlert()

--- a/X2WOTCCommunityHighlander/Src/XComGame/Classes/UIArmory_PromotionHero.uc
+++ b/X2WOTCCommunityHighlander/Src/XComGame/Classes/UIArmory_PromotionHero.uc
@@ -133,6 +133,7 @@ simulated function PopulateData()
 	local XComGameState_ResistanceFaction FactionState;
 	local XComGameState_HeadquartersXCom XComHQ;
 	local XComGameState NewGameState;
+	local StackedUIIconData StackedClassIcon; // Variable for issue #1134
 	
 	Unit = GetUnit();
 	ClassTemplate = Unit.GetSoldierClassTemplate();
@@ -186,7 +187,11 @@ simulated function PopulateData()
 
 	AS_SetRank(rankIcon);
 	AS_SetClass(classIcon);
-	AS_SetFaction(FactionState.GetFactionIcon());
+	// Start Issue #1134
+	StackedClassIcon = Unit.GetStackedClassIcon();
+	if (StackedClassIcon.Images.Length > 0)
+		AS_SetFaction(StackedClassIcon);
+	// End Issue #1134
 
 	AS_SetHeaderData(Caps(FactionState.GetFactionTitle()), Caps(Unit.GetName(eNameType_FullNick)), HeaderString, m_strSharedAPLabel, m_strSoldierAPLabel);
 	AS_SetAPData(GetSharedAbilityPoints(), Unit.AbilityPoints);

--- a/X2WOTCCommunityHighlander/Src/XComGame/Classes/UIPersonnel_SoldierListItem.uc
+++ b/X2WOTCCommunityHighlander/Src/XComGame/Classes/UIPersonnel_SoldierListItem.uc
@@ -23,18 +23,19 @@ simulated function InitListItem(StateObjectReference initUnitRef)
 	local string UnitLoc, status, statusTimeLabel, statusTimeValue, classIcon, rankIcon, flagIcon, mentalStatus;	
 	local int iTimeNum;
 	local X2SoldierClassTemplate SoldierClass;
-	local XComGameState_ResistanceFaction FactionState;
+	//local XComGameState_ResistanceFaction FactionState; //Issue #1134, not needed
 	local SoldierBond BondData;
 	local StateObjectReference BondmateRef;
 	local XComGameState_Unit Bondmate;
 	local int BondLevel; 
+	local StackedUIIconData StackedClassIcon; // Variable for issue #1134
 
 	local StackedUIIconData EmptyIconInfo; // Single variable for Issue #295
 	
 	Unit = XComGameState_Unit(`XCOMHISTORY.GetGameStateForObjectID(UnitRef.ObjectID));
 	
 	SoldierClass = Unit.GetSoldierClassTemplate();
-	FactionState = Unit.GetResistanceFaction();
+	//FactionState = Unit.GetResistanceFaction(); //Issue #1134, not needed
 
 	class'UIUtilities_Strategy'.static.GetPersonnelStatusSeparate(Unit, status, statusTimeLabel, statusTimeValue);
 	mentalStatus = "";
@@ -129,16 +130,19 @@ simulated function InitListItem(StateObjectReference initUnitRef)
 					BondLevel);
 	// End Issue #106, #408
 
-	//Issue #295 - Add a 'none' check before accessing FactionState
-	if (FactionState != none)
+	//Issue #295 - Add a 'none' check before accessing FactionState --> Issue #1134 replaces this fix
+	// Start Issue #1134
+	StackedClassIcon = Unit.GetStackedClassIcon();
+	if (StackedClassIcon.Images.Length > 0)
 	{
-		AS_SetFactionIcon(FactionState.GetFactionIcon());
+		AS_SetFactionIcon(StackedClassIcon);
 	}
 	else
 	{
 		// Preserve backwards compatibility in case AS_SetFactionIcon() is overridden via an MCO.
 		AS_SetFactionIcon(EmptyIconInfo);
 	}
+	// End Issue #1134
 }
 
 // Start issue #651

--- a/X2WOTCCommunityHighlander/Src/XComGame/Classes/UISoldierHeader.uc
+++ b/X2WOTCCommunityHighlander/Src/XComGame/Classes/UISoldierHeader.uc
@@ -173,8 +173,9 @@ public function PopulateData(optional XComGameState_Unit Unit, optional StateObj
 	local XComGameState_Item TmpItem;
 	local XComGameStateHistory History;
 	local string StatusValue, StatusLabel, StatusDesc, StatusTimeLabel, StatusTimeValue, DaysValue;
-	local XComGameState_ResistanceFaction FactionState;
+	//local XComGameState_ResistanceFaction FactionState; //Issue #1134, not needed
 	local bool bShouldShowWill;
+	local StackedUIIconData StackedClassIcon; // Variable for issue #1134
 
 	History = `XCOMHISTORY;
 	CheckGameState = NewCheckGameState;
@@ -189,7 +190,7 @@ public function PopulateData(optional XComGameState_Unit Unit, optional StateObj
 
 	SoldierClass = Unit.GetSoldierClassTemplate();
 
-	FactionState = Unit.GetResistanceFaction();
+	//FactionState = Unit.GetResistanceFaction(); //Issue #1134, not needed
 
 	flagIcon  = (Unit.IsSoldier() && !bHideFlag) ? Unit.GetCountryTemplate().FlagImage : "";
 	// Start Issue #408
@@ -241,7 +242,11 @@ public function PopulateData(optional XComGameState_Unit Unit, optional StateObj
 		// End Issue #106, #408
 	}
 
-	SetFactionIcon(FactionState.GetFactionIcon());
+	// Start Issue #1134
+	StackedClassIcon = Unit.GetStackedClassIcon();
+	if (StackedClassIcon.Images.Length > 0)
+		SetFactionIcon(StackedClassIcon);
+	// End Issue #1134
 
 	// Get Unit base stats and any stat modifications from abilities
 	Will = string(int(Unit.GetCurrentStat(eStat_Will)) + Unit.GetUIStatFromAbilities(eStat_Will)) $ "/" $ string(int(Unit.GetMaxStat(eStat_Will)));

--- a/X2WOTCCommunityHighlander/Src/XComGame/Classes/UISquadSelect_ListItem.uc
+++ b/X2WOTCCommunityHighlander/Src/XComGame/Classes/UISquadSelect_ListItem.uc
@@ -141,7 +141,8 @@ simulated function UpdateData(optional int Index = -1, optional bool bDisableEdi
 	local X2AbilityTemplateManager AbilityTemplateManager;
 	local SoldierBond BondData;
 	local StateObjectReference BondmateRef;
-	local XComGameState_ResistanceFaction FactionState;
+	//local XComGameState_ResistanceFaction FactionState; //Issue #1134, not needed
+	local StackedUIIconData StackedClassIcon; // Variable for issue #1134
 
 	// Variables for Issue #118
 	local CHUIItemSlotEnumerator En;
@@ -200,7 +201,7 @@ simulated function UpdateData(optional int Index = -1, optional bool bDisableEdi
 	//	if( Navigator.SelectedIndex == -1 )
 //			Navigator.SelectFirstAvailable();
 
-		FactionState = Unit.GetResistanceFaction();
+		//FactionState = Unit.GetResistanceFaction(); //Issue #1134, not needed
 
 		// Issue #118 Start
 		En = class'CHUIItemSlotEnumerator'.static.CreateEnumerator(Unit, , , true /* UseUnlockHints */);
@@ -325,14 +326,17 @@ simulated function UpdateData(optional int Index = -1, optional bool bDisableEdi
 			AS_SetUnitWill(-1, "");
 		}
 
-		if( FactionState == none )
+		// Start Issue #1134
+		StackedClassIcon = Unit.GetStackedClassIcon();
+		if (StackedClassIcon.Images.Length > 0)
 		{
-			MC.FunctionVoid("clearUnitFactionIcon");
+			AS_SetFactionIcon(StackedClassIcon);
 		}
 		else
 		{
-			AS_SetFactionIcon(FactionState.GetFactionIcon());
+			MC.FunctionVoid("clearUnitFactionIcon");
 		}
+		// End Issue #1134
 
 		if(Unit.BelowReadyWillState())
 		{

--- a/X2WOTCCommunityHighlander/Src/XComGame/Classes/UITacticalHUD_SoldierInfo.uc
+++ b/X2WOTCCommunityHighlander/Src/XComGame/Classes/UITacticalHUD_SoldierInfo.uc
@@ -231,14 +231,15 @@ simulated function SetStats( XGUnit kActiveUnit )
 	local float aimPercent;
 	local array<UISummary_UnitEffect> BonusEffects, PenaltyEffects; 
 	local X2SoldierClassTemplateManager SoldierTemplateManager;
-	local XComGameState_ResistanceFaction FactionState;
+	//local XComGameState_ResistanceFaction FactionState; //Issue #1134, not needed
 	local StateObjectReference BondmateRef;
 	local SoldierBond BondInfo;
 	local XComGameState_HeadquartersXCom XComHQ;
+	local StackedUIIconData StackedClassIcon; // Variable for issue #1134
 
 	StateUnit = XComGameState_Unit(`XCOMHISTORY.GetGameStateForObjectID(kActiveUnit.ObjectID));
-
-	FactionState = StateUnit.GetResistanceFaction();
+	
+	//FactionState = StateUnit.GetResistanceFaction(); //Issue #1134, not needed
 
 	if( StateUnit.GetMyTemplateName() == 'AdvPsiWitchM2' )
 	{
@@ -287,7 +288,11 @@ simulated function SetStats( XGUnit kActiveUnit )
 	showPenalty = (PenaltyEffects.length > 0);
 
 	AS_SetStats(charName, charNickname, charRank, charClass, isLeader, isLeveledUp, aimPercent, showBonus, showPenalty);
-	if (FactionState != none) AS_SetFactionIcon(FactionState.GetFactionIcon());
+	// Start Issue #1134
+	StackedClassIcon = StateUnit.GetStackedClassIcon();
+	if (StackedClassIcon.Images.Length > 0)
+		AS_SetFactionIcon(StackedClassIcon);
+	// End Issue #1134
 
 	if( StateUnit.HasSoldierBond(BondmateRef, BondInfo) )
 	{

--- a/X2WOTCCommunityHighlander/Src/XComGame/Classes/XComGameState_Unit.uc
+++ b/X2WOTCCommunityHighlander/Src/XComGame/Classes/XComGameState_Unit.uc
@@ -15465,6 +15465,64 @@ private function XComLWTuple TriggerSoldierRankEvent(const int Rank, const name 
 }
 // End Issue #408
 
+// Start Issue #1134
+/// HL-Docs: feature:OverrideStackedClassIcon; issue:1134; tags:ui
+/// Function to return the current unit's stacked class icon.
+///
+/// Stacked class icons are generated for faction hero units by default.
+/// Mods may want to manipulate the way a soldier's stacked class icon
+/// is displayed in more dynamic ways, or even add a stacked icon to a non-hero class.
+///
+/// For example, when using custom hero classes such as the Skirmisher Heavy, 
+/// it would be nice to see a custom class image in the soldier list,
+/// promotion screen, and in the tactical UI.
+///
+/// There is one event:
+///
+/// ```event
+/// EventID: OverrideStackedClassIcon,
+/// EventData: [inout array<string> Images, inout bool bInvertImage],
+/// EventSource: XComGameState_Unit (UnitState),
+/// NewGameState: none
+/// ```
+///
+/// Due to the irregularities of how StackedUIIconData is consumed, strings applied to
+/// the Images array should not start with `img:///`.
+function StackedUIIconData GetStackedClassIcon()
+{
+    local int idx;
+    local XComLWTuple Tuple;
+    local XComGameState_ResistanceFaction FactionState;
+    local StackedUIIconData CustomIcon;
+
+    FactionState = GetResistanceFaction();
+    if(FactionState != none)
+    {
+        CustomIcon = FactionState.GetFactionIcon();
+    }
+
+    Tuple = new class'XComLWTuple';
+    Tuple.Id = 'OverrideStackedClassIcon';
+    Tuple.Data.Add(2);
+
+    Tuple.Data[0].kind = XComLWTVArrayStrings;
+    Tuple.Data[0].as = CustomIcon.Images;
+    Tuple.Data[1].kind = XComLWTVBool;
+    Tuple.Data[1].b = CustomIcon.bInvert;
+
+    `XEVENTMGR.TriggerEvent('OverrideStackedClassIcon', Tuple, self, none);
+
+    CustomIcon.bInvert = Tuple.Data[1].b;
+    CustomIcon.Images.Length = 0;
+    for(idx = 0; idx < Tuple.Data[0].as.Length; idx++)
+    {
+        CustomIcon.Images.AddItem(Repl(Tuple.Data[0].as[idx], "img:///", ""));
+    }
+
+    return CustomIcon;
+}
+// End Issue #1134
+
 // Start Issue #171
 // Sets the eStat_UtilityItems of the unit and returns it.
 function int RealizeItemSlotsCount(XComGameState CheckGameState)


### PR DESCRIPTION
This is for issue #1134 which will allow mods to override the resistance faction icon when using custom hero classes.