### PR TITLE
Issue #1140 - fix bugs introduced by Issue #783

### DIFF
--- a/X2WOTCCommunityHighlander/Src/XComGame/Classes/XGCharacterGenerator.uc
+++ b/X2WOTCCommunityHighlander/Src/XComGame/Classes/XGCharacterGenerator.uc
@@ -399,9 +399,17 @@ function TSoldier CreateTSoldier( optional name CharacterTemplateName, optional 
 
 	SetVoice(CharacterTemplateName, nmCountry);
 	SetAttitude();
-	GenerateName( kSoldier.kAppearance.iGender, kSoldier.nmCountry, kSoldier.strFirstName, kSoldier.strLastName, kSoldier.kAppearance.iRace );
 
-	BioCountryName = kSoldier.nmCountry;
+	// Start Issue #1140
+	// Pass nmCountry to GenerateName and BioCountryName instead of kSoldier.nmCountry.
+	// This is done to fix the bug caused by #783, which refactored XGCharacterGenerator classes for faction heroes,
+	// which resulted in using their faction countries to generate character name and biography as opposed to using
+	// a random country, like they did before #783 was implemented.
+	GenerateName( kSoldier.kAppearance.iGender, nmCountry, kSoldier.strFirstName, kSoldier.strLastName, kSoldier.kAppearance.iRace );
+	//GenerateName( kSoldier.kAppearance.iGender, kSoldier.nmCountry, kSoldier.strFirstName, kSoldier.strLastName, kSoldier.kAppearance.iRace );
+	BioCountryName = nmCountry;
+	//BioCountryName = kSoldier.nmCountry;
+	// End Issue #1140
 
 	// Start issue #783
 	ModifyGeneratedUnitAppearance(CharacterTemplateName, eForceGender, nmCountry, iRace, ArmorName);

--- a/X2WOTCCommunityHighlander/Src/XComGame/Classes/XGCharacterGenerator.uc
+++ b/X2WOTCCommunityHighlander/Src/XComGame/Classes/XGCharacterGenerator.uc
@@ -373,7 +373,8 @@ function TSoldier CreateTSoldier( optional name CharacterTemplateName, optional 
 		nmCountry = PickOriginCountry();
 	
 	SetCountry(nmCountry);
-	SetRace(iRace);
+	//SetRace(iRace);
+	SetRace_CH(iRace, nmCountry); // Issue #1140 - use randomly generated country to generate unit's race.
 	SetGender(eForceGender);
 	kSoldier.iRank = 0;
 	
@@ -675,6 +676,17 @@ function SetRace(int iRace)
 	else
 		kSoldier.kAppearance.iRace = iRace;
 }
+
+// Start Issue #1140
+// Add a function that will set unit's race based on nmCountry given as a function argument rather than on kSoldier.nmCountry.
+function SetRace_CH(int iRace, name nmCountry)
+{
+	if (iRace == -1)
+		kSoldier.kAppearance.iRace = GetRandomRaceByCountry(nmCountry);
+	else
+		kSoldier.kAppearance.iRace = iRace;
+}
+// End Issue #1140
 
 function SetGender(EGender eForceGender)
 {

--- a/X2WOTCCommunityHighlander/Src/XComGame/Classes/XGCharacterGenerator_Reaper.uc
+++ b/X2WOTCCommunityHighlander/Src/XComGame/Classes/XGCharacterGenerator_Reaper.uc
@@ -47,7 +47,7 @@ function GenerateName(int iGender, name CountryName, out string strFirst, out st
 	local X2SoldierClassTemplateManager ClassMgr;
 	local X2SoldierClassTemplate ClassTemplate;
 
-	super.GenerateName(kSoldier.kAppearance.iGender, kSoldier.nmCountry, kSoldier.strFirstName, kSoldier.strLastName, kSoldier.kAppearance.iRace);
+	super.GenerateName(iGender, CountryName, strFirst, strLast, iRace);
 
 	ClassMgr = class'X2SoldierClassTemplateManager'.static.GetSoldierClassTemplateManager();
 	ClassTemplate = ClassMgr.FindSoldierClassTemplate('Reaper');

--- a/X2WOTCCommunityHighlander/Src/XComGame/Classes/XGCharacterGenerator_Skirmisher.uc
+++ b/X2WOTCCommunityHighlander/Src/XComGame/Classes/XGCharacterGenerator_Skirmisher.uc
@@ -40,7 +40,7 @@ function GenerateName( int iGender, name CountryName, out string strFirst, out s
 	local X2SoldierClassTemplateManager ClassMgr;
 	local X2SoldierClassTemplate ClassTemplate;
 
-	super.GenerateName( kSoldier.kAppearance.iGender, kSoldier.nmCountry, kSoldier.strFirstName, kSoldier.strLastName, kSoldier.kAppearance.iRace );
+	super.GenerateName(iGender, CountryName, strFirst, strLast, iRace);
 
 	ClassMgr = class'X2SoldierClassTemplateManager'.static.GetSoldierClassTemplateManager();
 	ClassTemplate = ClassMgr.FindSoldierClassTemplate('Skirmisher');

--- a/X2WOTCCommunityHighlander/Src/XComGame/Classes/XGCharacterGenerator_Templar.uc
+++ b/X2WOTCCommunityHighlander/Src/XComGame/Classes/XGCharacterGenerator_Templar.uc
@@ -42,7 +42,7 @@ function GenerateName( int iGender, name CountryName, out string strFirst, out s
 	local X2SoldierClassTemplateManager ClassMgr;
 	local X2SoldierClassTemplate ClassTemplate;
 
-	super.GenerateName( kSoldier.kAppearance.iGender, kSoldier.nmCountry, kSoldier.strFirstName, kSoldier.strLastName, kSoldier.kAppearance.iRace );
+	super.GenerateName(iGender, CountryName, strFirst, strLast, iRace);
 
 	ClassMgr = class'X2SoldierClassTemplateManager'.static.GetSoldierClassTemplateManager();
 	ClassTemplate = ClassMgr.FindSoldierClassTemplate('Templar');


### PR DESCRIPTION
Fixes #1140

A slight refactor to the code of XGCharacterGenerator to address the issue introduced by #783.

An explanation on what is being changed and why.

# No Highlander

When the game generates a faction hero, the code is being called in this order:

`XGCharacterGenerator_Reaper::CreateTSoldier()` calls `XGCharacterGenerator::CreateTSoldier()`, which does the following:

1. Generate a random country and set it to the TSoldier using `SetCountry()` function.
2. Generate other soldier's properties based on that country, like Race, Voice, Name and BioCountryName, which will be stored to be used later when generating unit's bio.
3. The created TSoldier struct is then returned to the `XGCharacterGenerator_Reaper::CreateTSoldier()`, which calls `SetCountry()` again, this time with the faction country, replacing the values in `kSoldier.nmCountry` and `kSoldier.kAppearance.nmFlag` with the faction country, (but not BioCountryName, which still stores the previously randomly generated country), and generates a new nickname, appropriate for the faction.

The result is a soldier whose first and last name, as well as their BioCountry are randomly generated, but the flag country and nickname are appropriate for their faction country.

# With Highlander

Highlander overrides the `SetCountry()` function in faction hero character generators, so when the `XGCharacterGenerator::CreateTSoldier()` calls it with the randomly generated country, the `SetCountry()` sets a faction country anyway, which is then used to generate Race, Voice, Name and is set to BioCountryName. 

This creates a lot of issues; the generated name always defaults to USA names, and the country name is entirely absent from the generated unit's bio, presumably because faction countries are missing localized name.

# Proposed Fix

Refactor the `XGCharacterGenerator::CreateTSoldier()` so it uses the randomly generated country for the purposes of generating Race, Voice, Name and BioCountryName. It will still call the overridden `XGCharacterGenerator_Reaper::SetCountry()`, which will assign the faction country to `kSoldier.nmCountry` and `kSoldier.kAppearance.nmFlag`, achieving the desired result. 

The only hiccup in this plan is that without the Highlander, the randomly generated country is used for the `SetRace()` function, while with the proposed fix it will be called with the faction country.

So the bandaid solution is to add a `SetRace_CH()` function which takes the randomly generated country as an argument.
