### PR TITLE
Issue #1157 - Fix reaper camera zoom-in bug

### DIFF
--- a/X2WOTCCommunityHighlander/Config/XComUI.ini
+++ b/X2WOTCCommunityHighlander/Config/XComUI.ini
@@ -1,0 +1,3 @@
+[XComGame.CHHelpers]
+; Issue #1157 - allow mods to alter the zoom-in distance when doing a Reaper super concealment roll.
+SuperConcealmentRoll_TargetZoomAfterArrival = -0.4f

--- a/X2WOTCCommunityHighlander/Src/XComGame/Classes/CHHelpers.uc
+++ b/X2WOTCCommunityHighlander/Src/XComGame/Classes/CHHelpers.uc
@@ -278,6 +278,8 @@ struct OverrideHasHeightAdvantageStruct
 var protectedwrite array<OverrideHasHeightAdvantageStruct> OverrideHasHeightAdvantageCallbacks;
 // End Issue #851
 
+var config(UI) float SuperConcealmentRoll_TargetZoomAfterArrival; // Issue #1157
+
 delegate EHLDelegateReturn ShouldDisplayMultiSlotItemInStrategyDelegate(XComGameState_Unit UnitState, XComGameState_Item ItemState, out int bDisplayItem, XComUnitPawn UnitPawn, optional XComGameState CheckGameState); // Issue #885
 delegate EHLDelegateReturn ShouldDisplayMultiSlotItemInTacticalDelegate(XComGameState_Unit UnitState, XComGameState_Item ItemState, out int bDisplayItem, XGUnit UnitVisualizer, optional XComGameState CheckGameState); // Issue #885
 delegate EHLDelegateReturn OverrideHasHeightAdvantageDelegate(XComGameState_Unit Attacker, XComGameState_Unit TargetUnit, out int bHasHeightAdvantage); // Issue #851

--- a/X2WOTCCommunityHighlander/Src/XComGame/Classes/XComGameState_Unit.uc
+++ b/X2WOTCCommunityHighlander/Src/XComGame/Classes/XComGameState_Unit.uc
@@ -9954,7 +9954,7 @@ static function SuperConcealmentRollVisualization(XComGameState VisualizeGameSta
 		LookAtAction.LookAtActor = ActionMetadata.VisualizeActor;
 		LookAtAction.BlockUntilActorOnScreen = true;
 		LookAtAction.LookAtDuration = class'X2Ability_ReaperAbilitySet'.default.ShadowRollCameraDelay;
-		LookAtAction.TargetZoomAfterArrival = -0.4f;
+		LookAtAction.TargetZoomAfterArrival = class'CHHelpers'.default.SuperConcealmentRoll_TargetZoomAfterArrival; // Issue #1157 - make this value configurable
 
 		// Jwats: Then update the UI
 		UpdateUIAction = X2Action_UpdateUI(class'X2Action_UpdateUI'.static.AddToVisualizationTree(ActionMetadata, VisualizeGameState.GetContext(), false, LookAtAction));


### PR DESCRIPTION
Fixes #1157 

I can't be bothered to unravel the entire camera zoom code just to fix this one small visual bug.

I propose a simple bandaid solution: make the hardcoded zoom-in value used by `XCGS_Unit::SuperConcealmentRollVisualization()` configurable, so that when a mod or user alter the max camera zoom out value, they can also tweak this.

By default, Free Camera Rotation increases zoom out value roughly by a factor of two, so dividing the default zoom-in value by the same amount prevents the bug from happening.

There is an alternative solution: calculate this multiplier automatically. I'll make a separate PR for that.