### PR TITLE
Consider sound from allied units, not just enemies

### DIFF
--- a/X2WOTCCommunityHighlander/Src/XComGame/Classes/CHHelpers.uc
+++ b/X2WOTCCommunityHighlander/Src/XComGame/Classes/CHHelpers.uc
@@ -997,7 +997,7 @@ static final function array<SoldierClassAbilityType> RebuildSoldierClassAbilityT
 
 /// HL-Docs: ref:ConsiderAlliesforSoundAlerts
 // start issue #620
-// Copied from XComGameState_Unit::GetEnemiesInRange, except will include all units on the alien team within
+// Copied from XComGameState_Unit::GetEnemiesInRange, except will include all units within
 // the specified range.
 static function GetUnitsInRange(TTile kLocation, int nMeters, out array<StateObjectReference> OutEnemies)
 {
@@ -1016,7 +1016,7 @@ static function GetUnitsInRange(TTile kLocation, int nMeters, out array<StateObj
 	foreach History.IterateByClassType(class'XComGameState_Unit', kUnit)
 	{
 		Team = kUnit.GetTeam();
-		if( Team != eTeam_Xcom && Team != eTeam_Neutral && kUnit.IsAlive() )
+		if( Team != eTeam_Neutral && kUnit.IsAlive() )
 		{
 			vLoc = `XWORLD.GetPositionFromTileCoordinates(kUnit.TileLocation);
 			UnitHearingRadius = kUnit.GetCurrentStat(eStat_HearingRadius);

--- a/X2WOTCCommunityHighlander/Src/XComGame/Classes/XComGameState_Unit.uc
+++ b/X2WOTCCommunityHighlander/Src/XComGame/Classes/XComGameState_Unit.uc
@@ -9667,7 +9667,18 @@ function EventListenerReturn OnAbilityActivated(Object EventData, Object EventSo
 					GetKeystoneVisibilityLocation(SoundTileLocation);
 				}
 
-				GetEnemiesInRange(SoundTileLocation, SoundRange, Enemies);
+				/// HL-Docs: feature:ConsiderAlliesforSoundAlerts; issue:620; tags:tactical
+				/// use our CHhelpers function GetUnitsInRange
+				/// Gather the units in sound range of this weapon to include sound from allied weapon fire.
+				/// By default the base game code only checks for sound from enemy units
+				/// But it makes sense that sound can be heard from anyone firing a weapon, not just enemies
+				/// Note that this will not have any affect unless a mod has turned on
+				/// yellow alerts in ShouldEnemyFactionsTriggerAlertsOutsidePlayerVision in XComGameState_AIUnitData
+				/// Since by default alert data is not recorded for sound outside of XCom's vision 
+				// start issue #620
+				// GetEnemiesInRange(SoundTileLocation, SoundRange, Enemies); 
+				class'CHHelpers'.static.GetUnitsInRange(SoundTileLocation, SoundRange, Enemies);
+				// end issue #620
 
 				`LogAI("Weapon sound @ Tile("$SoundTileLocation.X$","@SoundTileLocation.Y$","@SoundTileLocation.Z$") - Found"@Enemies.Length@"enemies in range ("$SoundRange$" meters)");
 				foreach Enemies(EnemyRef)

--- a/X2WOTCCommunityHighlander/X2WOTCCommunityHighlander.x2proj
+++ b/X2WOTCCommunityHighlander/X2WOTCCommunityHighlander.x2proj
@@ -754,6 +754,9 @@
     <Content Include="Src\XComGame\Classes\XComUnitPawnNativeBase.uc">
       <SubType>Content</SubType>
     </Content>
+    <Content Include="Src\XComGame\Classes\XGAIPatrolGroup.uc">
+      <SubType>Content</SubType>
+    </Content>
     <Content Include="Src\XComGame\Classes\XGBase.uc">
       <SubType>Content</SubType>
     </Content>

--- a/X2WOTCCommunityHighlander/X2WOTCCommunityHighlander.x2proj
+++ b/X2WOTCCommunityHighlander/X2WOTCCommunityHighlander.x2proj
@@ -754,9 +754,6 @@
     <Content Include="Src\XComGame\Classes\XComUnitPawnNativeBase.uc">
       <SubType>Content</SubType>
     </Content>
-    <Content Include="Src\XComGame\Classes\XGAIPatrolGroup.uc">
-      <SubType>Content</SubType>
-    </Content>
     <Content Include="Src\XComGame\Classes\XGBase.uc">
       <SubType>Content</SubType>
     </Content>


### PR DESCRIPTION
#620
This enhancement replaces the function `GetEnemiesInRange` with `GetUnitsinRange` in `OnAbilityActivated` which retrieves all units in range that are not civilians, so that sound alerts can be added to alert data for any unit with an ability that produces sound, even from those on the same team. Note this change does nothing by itself when the alerted unit is outside of the vision of XCom. If sound alerts are enabled using #1036 then the alert data will be added to the game history when outside the vision of XCom.