### PR TITLE
Prevent built-in hit and crit modifiers from applying against non-units

### DIFF
--- a/X2WOTCCommunityHighlander/Src/XComGame/Classes/X2AbilityToHitCalc_StandardAim.uc
+++ b/X2WOTCCommunityHighlander/Src/XComGame/Classes/X2AbilityToHitCalc_StandardAim.uc
@@ -362,8 +362,9 @@ protected function int GetHitChance(XComGameState_Ability kAbility, AvailableTar
 		AddModifier(100, AbilityTemplate.LocFriendlyName, m_ShotBreakdown, eHit_Success, bDebugLog);
 	}
 
-	AddModifier(BuiltInHitMod, AbilityTemplate.LocFriendlyName, m_ShotBreakdown, eHit_Success, bDebugLog);
-	AddModifier(BuiltInCritMod, AbilityTemplate.LocFriendlyName, m_ShotBreakdown, eHit_Crit, bDebugLog);
+	// Issue #346: AddModifier(BuiltIn...Mod) block moved later in method.
+	/// HL-Docs: ref:Bugfixes; issue:346
+	/// Prevent `X2AbilityToHitCalc_StandardAim` from applying BuiltInHitMod and BuiltInCritMod against non-units.
 
 	if (UnitState != none && TargetState == none)
 	{
@@ -374,6 +375,11 @@ protected function int GetHitChance(XComGameState_Ability kAbility, AvailableTar
 	}
 	else if (UnitState != none && TargetState != none)
 	{				
+		// Start Issue #346: Block moved from earlier.
+		AddModifier(BuiltInHitMod, AbilityTemplate.LocFriendlyName, m_ShotBreakdown, eHit_Success, bDebugLog);
+		AddModifier(BuiltInCritMod, AbilityTemplate.LocFriendlyName, m_ShotBreakdown, eHit_Crit, bDebugLog);
+		// End Issue #346
+
 		if (!bIndirectFire)
 		{
 			// StandardAim (with direct fire) will require visibility info between source and target (to check cover). 


### PR DESCRIPTION
Fixes #346 

Per RM's suggestion, just moved the two  `AddModifier(BuiltIn...Mod)` functions lower in the code, where we know we're dealing with a unit target.

Tested and working. Logs of using Rapid Fire on a non-unit target, pre change:
```

[0461.36] XCom_HitRolls: =GetHitChance=
[0461.36] XCom_HitRolls: Modifying eHit_Success -15 (Rapid Fire), New hit chance: -15
[0461.36] XCom_HitRolls: Modifying eHit_Crit +0 (Rapid Fire), New hit chance: -15
[0461.36] XCom_HitRolls: Modifying eHit_Success +100 (Aim), New hit chance: 85
[0461.36] XCom_HitRolls: ==FinalizeHitChance==

[0461.36] XCom_HitRolls: Starting values...
[0461.36] XCom_HitRolls: eHit_Success: 85
[0461.36] XCom_HitRolls: eHit_Crit: 0
[0461.36] XCom_HitRolls: eHit_Graze: 0
[0461.36] XCom_HitRolls: eHit_Miss: 0
[0461.36] XCom_HitRolls: eHit_LightningReflexes: 0
[0461.36] XCom_HitRolls: eHit_Untouchable: 0
[0461.36] XCom_HitRolls: eHit_CounterAttack: 0
[0461.36] XCom_HitRolls: eHit_Parry: 0
[0461.36] XCom_HitRolls: eHit_Deflect: 0
[0461.36] XCom_HitRolls: eHit_Reflect: 0
[0461.36] XCom_HitRolls: Calculated values...
[0461.36] XCom_HitRolls: eHit_Success: 85
[0461.36] XCom_HitRolls: eHit_Crit: 0
[0461.37] XCom_HitRolls: eHit_Graze: 0
[0461.37] XCom_HitRolls: eHit_Miss: 15
[0461.37] XCom_HitRolls: eHit_LightningReflexes: 0
[0461.37] XCom_HitRolls: eHit_Untouchable: 0
[0461.37] XCom_HitRolls: eHit_CounterAttack: 0
[0461.37] XCom_HitRolls: eHit_Parry: 0
[0461.37] XCom_HitRolls: eHit_Deflect: 0
[0461.37] XCom_HitRolls: eHit_Reflect: 0
[0461.37] XCom_HitRolls: Final hit chance (success + crit + graze) = 85
[0461.37] XCom_HitRolls: =InternalRollForAbilityHit=
[0461.37] XCom_HitRolls: Final hit chance: 85
[0461.37] XCom_HitRolls: Random roll: 38
[0461.37] XCom_HitRolls: Checking table eHit_Success (85)...
[0461.37] XCom_HitRolls: MATCH!
[0461.37] XCom_HitRolls: ***HIT eHit_Success
[0461.37] XCom_HitRolls: ===CalculateDamageAmount===
[0461.37] XCom_HitRolls: Attacker ID: 2078 With Item ID: 2084 Target ID: 2627
[0461.37] XCom_HitRolls: bIgnoreBaseDamage:'False' DamageTag:'None'
[0461.37] XCom_HitRolls: Weapon damage: 5 Potential spread: 1
[0461.37] XCom_HitRolls: Damage with spread: 6
[0461.37] XCom_HitRolls: Total Damage: 6

```

Logs after change:

```

[0403.66] XCom_HitRolls: =GetHitChance=
[0403.66] XCom_HitRolls: Modifying eHit_Success +100 (Aim), New hit chance: 100
[0403.66] XCom_HitRolls: ==FinalizeHitChance==

[0403.66] XCom_HitRolls: Starting values...
[0403.66] XCom_HitRolls: eHit_Success: 100
[0403.66] XCom_HitRolls: eHit_Crit: 0
[0403.66] XCom_HitRolls: eHit_Graze: 0
[0403.66] XCom_HitRolls: eHit_Miss: 0
[0403.66] XCom_HitRolls: eHit_LightningReflexes: 0
[0403.66] XCom_HitRolls: eHit_Untouchable: 0
[0403.66] XCom_HitRolls: eHit_CounterAttack: 0
[0403.66] XCom_HitRolls: eHit_Parry: 0
[0403.66] XCom_HitRolls: eHit_Deflect: 0
[0403.66] XCom_HitRolls: eHit_Reflect: 0
[0403.66] XCom_HitRolls: Calculated values...
[0403.66] XCom_HitRolls: eHit_Success: 100
[0403.66] XCom_HitRolls: eHit_Crit: 0
[0403.66] XCom_HitRolls: eHit_Graze: 0
[0403.66] XCom_HitRolls: eHit_Miss: 0
[0403.66] XCom_HitRolls: eHit_LightningReflexes: 0
[0403.66] XCom_HitRolls: eHit_Untouchable: 0
[0403.66] XCom_HitRolls: eHit_CounterAttack: 0
[0403.66] XCom_HitRolls: eHit_Parry: 0
[0403.66] XCom_HitRolls: eHit_Deflect: 0
[0403.66] XCom_HitRolls: eHit_Reflect: 0
[0403.66] XCom_HitRolls: Final hit chance (success + crit + graze) = 100
[0403.66] XCom_HitRolls: =InternalRollForAbilityHit=
[0403.66] XCom_HitRolls: Final hit chance: 100
[0403.66] XCom_HitRolls: Random roll: 44
[0403.66] XCom_HitRolls: Checking table eHit_Success (100)...
[0403.66] XCom_HitRolls: MATCH!
[0403.66] XCom_HitRolls: ***HIT eHit_Success
[0403.68] XCom_HitRolls: ===CalculateDamageAmount===
[0403.68] XCom_HitRolls: Attacker ID: 2079 With Item ID: 2085 Target ID: 2829
[0403.68] XCom_HitRolls: bIgnoreBaseDamage:'False' DamageTag:'None'
[0403.68] XCom_HitRolls: Weapon damage: 5 Potential spread: 1
[0403.68] XCom_HitRolls: Damage with spread: 5
[0403.68] XCom_HitRolls: Total Damage: 5
```