### PR TITLE
Call OverrideItemImage_Improved from the Item State

### DIFF
--- a/X2WOTCCommunityHighlander/Src/XComGame/Classes/UIArmory_LoadoutItem.uc
+++ b/X2WOTCCommunityHighlander/Src/XComGame/Classes/UIArmory_LoadoutItem.uc
@@ -138,8 +138,6 @@ simulated function UIArmory_LoadoutItem SetImage(XComGameState_Item Item, option
 	local int i;
 	local bool bUpdate;
 	local array<string> NewImages;
-	// Issue #171 variables
-	local array<X2DownloadableContentInfo> DLCInfos;
 
 	if(Item == none)
 	{
@@ -148,15 +146,6 @@ simulated function UIArmory_LoadoutItem SetImage(XComGameState_Item Item, option
 	}
 
 	NewImages = Item.GetWeaponPanelImages();
-
-	// Start Issue #171
-	DLCInfos = `ONLINEEVENTMGR.GetDLCInfos(false);
-	for(i = 0; i < DLCInfos.Length; ++i)
-	{
-		// Single line for Issue #962 - pass on Item State.
-		DLCInfos[i].OverrideItemImage_Improved(NewImages, EquipmentSlot, ItemTemplate, UIArmory(Screen).GetUnit(), Item);
-	}
-	// End Issue #171
 
 	bUpdate = false;
 	for( i = 0; i < NewImages.Length; i++ )

--- a/X2WOTCCommunityHighlander/Src/XComGame/Classes/X2DownloadableContentInfo.uc
+++ b/X2WOTCCommunityHighlander/Src/XComGame/Classes/X2DownloadableContentInfo.uc
@@ -321,9 +321,9 @@ static private function bool CanAddItemToInventory(out int bCanAddItem, const EI
 //end Issue #50
 
 // Start Issue #962
-/// HL-Docs: feature:OverrideItemImage_Improved; issue:962; tags:strategy
-/// The `OverrideItemImage_Improved` X2DLCInfo method is called from `UIArmory_Loadout`.
-/// It allows mods to conditionally override items' inventory image. 
+/// HL-Docs: feature:OverrideItemImage_Improved; issue:962; tags:
+/// The `OverrideItemImage_Improved` X2DLCInfo method is called from `XComGameState_Item::GetWeaponPanelImages()`.
+/// It allows mods to conditionally override item's inventory image. 
 /// It can be used to replace the original image entirely
 /// or to overlay an additional icon on top of it to mark the specific item.
 /// To do so replace the contents of the `imagePath` array or add more image paths to it.
@@ -334,7 +334,7 @@ static function OverrideItemImage_Improved(out array<string> imagePath, const EI
 // End Issue #962
 
 // Start Issue #171
-/// Calls to override item image shown in UIArmory_Loadout
+/// Calls to override item image shown in UI.
 /// For example it allows you to show multiple grenades on grenade slot for someone with heavy ordnance
 /// Just change the value of imagePath
 static function OverrideItemImage(out array<string> imagePath, const EInventorySlot Slot, const X2ItemTemplate ItemTemplate, XComGameState_Unit UnitState)

--- a/X2WOTCCommunityHighlander/Src/XComGame/Classes/XComGameState_Item.uc
+++ b/X2WOTCCommunityHighlander/Src/XComGame/Classes/XComGameState_Item.uc
@@ -1249,6 +1249,10 @@ simulated function array<string> GetWeaponPanelImages()
 	local delegate<X2TacticalGameRulesetDataStructures.CheckUpgradeStatus> ValidateAttachmentFn;
 	local bool bUpgradeImageFound;
 
+	// Variables for Issue #962
+	local array<X2DownloadableContentInfo> DLCInfos;
+	local XComGameState_Unit UnitState;
+
 	GetMyTemplate();
 	if (m_ItemTemplate.IsA('X2WeaponTemplate'))
 	{
@@ -1310,6 +1314,16 @@ simulated function array<string> GetWeaponPanelImages()
 		else if( X2WeaponTemplate(m_ItemTemplate).WeaponPanelImage != "" )
 			Images.AddItem(X2WeaponTemplate(m_ItemTemplate).WeaponPanelImage);
 	}
+
+	// Start Issue #962
+	/// HL-Docs: ref:OverrideItemImage_Improved
+	UnitState = XComGameState_Unit(`XCOMHISTORY.GetGameStateForObjectID(OwnerStateObject.ObjectID));
+	DLCInfos = `ONLINEEVENTMGR.GetDLCInfos(false);
+	for(i = 0; i < DLCInfos.Length; ++i)
+	{
+		DLCInfos[i].OverrideItemImage_Improved(Images, InventorySlot, m_ItemTemplate, UnitState, self);
+	}
+	// End Issue #962
 
 	return Images; 
 }


### PR DESCRIPTION
Fixes #1067

Originally, the `OverrideItemImage()` DLC hook was implemented for Issue #171 purely within UIArmory_Loadout. For Issue #962, I replaced the hook with an Improved version that also passes the Item State, but that also turned out to be unnecessarily restrictive.

To address #1067, I moved the call for the Improved DLC hook from the UIArmory class to the `XComGameState_Item::GetWeaponPanelImages()` itself. This does not break backwards compatibility, because `GetWeaponPanelImages()` is also called from UI classes.