### PR TITLE
Reset version numbers in Highlander code

### DIFF
--- a/X2WOTCCommunityHighlander/Src/Core/Classes/CHCoreVersion.uc
+++ b/X2WOTCCommunityHighlander/Src/Core/Classes/CHCoreVersion.uc
@@ -9,8 +9,8 @@ var string Commit;
 // AUTO-CODEGEN: Version-Info
 defaultproperties
 {
-	MajorVersion = 1;
-	MinorVersion = 22;
-	PatchVersion = 3;
+	MajorVersion = -1;
+	MinorVersion = -1;
+	PatchVersion = -1;
 	Commit = "";
 }

--- a/X2WOTCCommunityHighlander/Src/Engine/Classes/CHEngineVersion.uc
+++ b/X2WOTCCommunityHighlander/Src/Engine/Classes/CHEngineVersion.uc
@@ -9,8 +9,8 @@ var string Commit;
 // AUTO-CODEGEN: Version-Info
 defaultproperties
 {
-	MajorVersion = 1;
-	MinorVersion = 22;
-	PatchVersion = 3;
+	MajorVersion = -1;
+	MinorVersion = -1;
+	PatchVersion = -1;
 	Commit = "";
 }

--- a/X2WOTCCommunityHighlander/Src/X2WOTCCommunityHighlander/Classes/CHX2WOTCCHVersion.uc
+++ b/X2WOTCCommunityHighlander/Src/X2WOTCCommunityHighlander/Classes/CHX2WOTCCHVersion.uc
@@ -9,8 +9,8 @@ var string Commit;
 // AUTO-CODEGEN: Version-Info
 defaultproperties
 {
-	MajorVersion = 1;
-	MinorVersion = 22;
-	PatchVersion = 3;
+	MajorVersion = -1;
+	MinorVersion = -1;
+	PatchVersion = -1;
 	Commit = "";
 }

--- a/X2WOTCCommunityHighlander/Src/X2WOTCCommunityHighlander/Classes/X2WOTCCH_CHXComGameVersion.uc
+++ b/X2WOTCCommunityHighlander/Src/X2WOTCCommunityHighlander/Classes/X2WOTCCH_CHXComGameVersion.uc
@@ -28,8 +28,8 @@ static function array<X2DataTemplate> CreateTemplates()
 // AUTO-CODEGEN: Version-Info
 defaultproperties
 {
-	MajorVersion = 1;
-	MinorVersion = 22;
-	PatchVersion = 3;
+	MajorVersion = -1;
+	MinorVersion = -1;
+	PatchVersion = -1;
 	Commit = "";
 }

--- a/X2WOTCCommunityHighlander/Src/XComGame/Classes/CHXComGameVersionTemplate.uc
+++ b/X2WOTCCommunityHighlander/Src/XComGame/Classes/CHXComGameVersionTemplate.uc
@@ -91,9 +91,9 @@ function int GetVersionNumber()
 // AUTO-CODEGEN: Version-Info
 defaultproperties
 {
-	MajorVersion = 1;
-	MinorVersion = 22;
-	PatchVersion = 3;
+	MajorVersion = -1;
+	MinorVersion = -1;
+	PatchVersion = -1;
 	Commit = "";
 }
 


### PR DESCRIPTION
Fixes #1049

The version values in Highlander code are replaced by a powershell script during the building process, so specifying them in code doesn't do anything. This PR resets them to `-1` to make it clear that it's unnecessary to modify them by hand.

Note that this doesn't affect versions in components, such as Alien Hunters Highlander, which does require a version be specified in code.