### PR TITLE
IsIncapacitated check to GatherUnitsToMove #1193

### DIFF
--- a/X2WOTCCommunityHighlander/Src/XComGame/Classes/XGAIPlayer.uc
+++ b/X2WOTCCommunityHighlander/Src/XComGame/Classes/XGAIPlayer.uc
@@ -897,7 +897,7 @@ simulated function GatherUnitsToMove()
 		//
 		// Issue #510 - Removed the DecisionStartHistoryIndex check as it prevents pod leaders from using
 		// any reflex actions they may have been granted.
-		// Issue #1193
+		
 		/// HL-Docs: ref:Bugfixes; issue:1193
 		/// Added `IsUnconcious` and `IsBleedingOut` check to skip AI units in group who are Unconcious or Bleeding out
 		/// as the AI processing hangs here until it times out, which causes the rest of the group to be skipped.

--- a/X2WOTCCommunityHighlander/Src/XComGame/Classes/XGAIPlayer.uc
+++ b/X2WOTCCommunityHighlander/Src/XComGame/Classes/XGAIPlayer.uc
@@ -899,7 +899,7 @@ simulated function GatherUnitsToMove()
 		// any reflex actions they may have been granted.
 		// Issue #1193 - Added IsIncapacitated check to skip units in group who are either Unconcious or Bleeding out
 		// as the AI processing hangs here until timeout and so the whole group gets skipped.
-		if(bDead || UnitState.bRemovedFromPlay || UnitState.NumAllActionPoints() == 0 || UnitState.IsIncapacitated()) // || kBehavior == None || kBehavior.DecisionStartHistoryIndex > kAIPlayerData.m_iLastEndTurnHistoryIndex)
+		if(bDead || UnitState.bRemovedFromPlay || UnitState.NumAllActionPoints() == 0 || UnitState.IsUnconscious() || UnitState.IsBleedingOut()) // || kBehavior == None || kBehavior.DecisionStartHistoryIndex > kAIPlayerData.m_iLastEndTurnHistoryIndex)
 		{
 			continue;
 		}

--- a/X2WOTCCommunityHighlander/Src/XComGame/Classes/XGAIPlayer.uc
+++ b/X2WOTCCommunityHighlander/Src/XComGame/Classes/XGAIPlayer.uc
@@ -897,7 +897,9 @@ simulated function GatherUnitsToMove()
 		//
 		// Issue #510 - Removed the DecisionStartHistoryIndex check as it prevents pod leaders from using
 		// any reflex actions they may have been granted.
-		if(bDead || UnitState.bRemovedFromPlay || UnitState.NumAllActionPoints() == 0) // || kBehavior == None || kBehavior.DecisionStartHistoryIndex > kAIPlayerData.m_iLastEndTurnHistoryIndex)
+		// Issue #1193 - Added IsIncapacitated check to skip units in group who are either Unconcious or Bleeding out
+		// as the AI processing hangs here until timeout and so the whole group gets skipped.
+		if(bDead || UnitState.bRemovedFromPlay || UnitState.NumAllActionPoints() == 0 || UnitState.IsIncapacitated()) // || kBehavior == None || kBehavior.DecisionStartHistoryIndex > kAIPlayerData.m_iLastEndTurnHistoryIndex)
 		{
 			continue;
 		}

--- a/X2WOTCCommunityHighlander/Src/XComGame/Classes/XGAIPlayer.uc
+++ b/X2WOTCCommunityHighlander/Src/XComGame/Classes/XGAIPlayer.uc
@@ -897,8 +897,10 @@ simulated function GatherUnitsToMove()
 		//
 		// Issue #510 - Removed the DecisionStartHistoryIndex check as it prevents pod leaders from using
 		// any reflex actions they may have been granted.
-		// Issue #1193 - Added IsIncapacitated check to skip units in group who are either Unconcious or Bleeding out
-		// as the AI processing hangs here until timeout and so the whole group gets skipped.
+		// Issue #1193
+		/// HL-Docs: ref:Bugfixes; issue:1193
+		/// Added `IsUnconcious` and `IsBleedingOut` check to skip AI units in group who are Unconcious or Bleeding out
+		/// as the AI processing hangs here until it times out, which causes the rest of the group to be skipped.
 		if(bDead || UnitState.bRemovedFromPlay || UnitState.NumAllActionPoints() == 0 || UnitState.IsUnconscious() || UnitState.IsBleedingOut()) // || kBehavior == None || kBehavior.DecisionStartHistoryIndex > kAIPlayerData.m_iLastEndTurnHistoryIndex)
 		{
 			continue;


### PR DESCRIPTION
This allows the AI to skip incapacitated units in a group which has other units able to act.

fixes #1193 