### PR TITLE
Issue #917 - Update EndTacticalHealthMod() in XCGS_Unit to expose beta strike post mission healing to config

### DIFF
--- a/X2WOTCCommunityHighlander/Config/XComGame.ini
+++ b/X2WOTCCommunityHighlander/Config/XComGame.ini
@@ -256,3 +256,7 @@ bEnableVersionDisplay=true
 ; destroying smoke trails (and similar) prematurely.
 ; Values below 5 (seconds) will be ignored.
 ;ProjectileParticleSystemExpirationDefaultOverride=60
+
+;;; HL-Docs: ref:BetaStrikeEndTacticalHeal
+;;; With Beta Strike enabled, soldiers are normally immediately healed for 50% of their missing HP after a mission. Uncomment this to disable this behavior.
+;bDisableBetaStrikePostMissionHealing=true 

--- a/X2WOTCCommunityHighlander/Src/XComGame/Classes/CHHelpers.uc
+++ b/X2WOTCCommunityHighlander/Src/XComGame/Classes/CHHelpers.uc
@@ -201,6 +201,9 @@ var config name PlaceEvacZoneAbilityName;
 // Variable for Issue #854
 var config float CameraRotationAngle;
 
+// Variable for Issue #917
+var config bool bDisableBetaStrikePostMissionHealing;
+
 // Start Issue #669
 //
 /// HL-Docs: feature:GrenadesRequiringUnitsOnTargetedTiles; issue:669; tags:tactical

--- a/X2WOTCCommunityHighlander/Src/XComGame/Classes/XComGameState_Unit.uc
+++ b/X2WOTCCommunityHighlander/Src/XComGame/Classes/XComGameState_Unit.uc
@@ -2647,13 +2647,16 @@ function EndTacticalHealthMod()
 	local float HealthPercent, NewHealth, SWHeal;
 	local int RoundedNewHealth, HealthLost, NewMissingHP;
 
-	HealthLost = HighestHP - LowestHP;
-
-	if (LowestHP > 0 && `SecondWaveEnabled('BetaStrike'))  // Immediately Heal 1/2 Damage
+	HealthLost = HighestHP - LowestHP;	
+	/// HL-Docs: feature:BetaStrikeEndTacticalHeal; issue:917; tags:
+	if (LowestHP > 0 && `SecondWaveEnabled('BetaStrike'))  // Immediately Heal 1/2 Damage 
 	{
-		SWHeal = FFloor( HealthLost / 2 );
-		LowestHP += SWHeal;
-		HealthLost -= SWHeal;
+		if  (!class'CHHelpers'.default.bDisableBetaStrikePostMissionHealing)
+			{
+				SWHeal = FFloor( HealthLost / 2 );
+				LowestHP += SWHeal;
+				HealthLost -= SWHeal;
+			}
 	}
 
 	// If Dead or never injured, return


### PR DESCRIPTION
Fixes #917

Added a boolean value to CHHelpers & updated code in EndTacticalHealthMod() in XCGS_Unit to allow other mods to set a config variable in XComGame.ini to disable the additional 50% health the game automatically grants to soldiers at the end of a mission when beta strike is active. 

 If the variable is false, or doesn't exist , the base game behaviour is retained.