### PR TITLE
Fix plots not being marked used for CAD and UFO avenger missions

### DIFF
--- a/X2WOTCCommunityHighlander/Src/XComGame/Classes/UIPawnMgr.uc
+++ b/X2WOTCCommunityHighlander/Src/XComGame/Classes/UIPawnMgr.uc
@@ -594,6 +594,10 @@ simulated function DestroyPawns(int StoreIdx, out array<PawnInfo> PawnStore)
 	// Added variable for Issue #885
 	local int i;
 
+	// Start Issue #1192 - Add call to StopSounds to remove sound effects for destroyed pawns.
+	PawnStore[StoreIdx].Pawn.StopSounds();
+	// End Issue #1192
+
 	PawnStore[StoreIdx].Pawn.Destroy();
 	PawnStore[StoreIdx].Pawn = none;
 	for ( idx = 0; idx < PawnStore[StoreIdx].Cosmetics.Length; ++idx )
@@ -637,6 +641,10 @@ simulated function ReleasePawnInternal(Actor referrer, int UnitRef, out array<Pa
 {
 	local int PawnInfoIndex;
 
+	// Added variables for Issue #1192
+	local XComUnitPawn CosmeticPawn;
+	local int CosmeticPawnIndex;
+
 	PawnInfoIndex = PawnStore.Find('PawnRef', UnitRef);
 	if (PawnInfoIndex == -1)
 	{
@@ -644,15 +652,49 @@ simulated function ReleasePawnInternal(Actor referrer, int UnitRef, out array<Pa
 	}
 	else if(bForce) // don't remove the entry from the array to preserve the Referrers
 	{
+
+		// Start Issue #1192 - gremlin/bit section
+		CosmeticPawn = GetCosmeticPawn(eInvSlot_SecondaryWeapon, UnitRef);
+
+		//use similar code to rest of function, but for the Cosmetic pawn
+		if (CosmeticPawn!= none)
+		{
+			CosmeticPawnIndex = PawnStore.Find('PawnRef', CosmeticPawn.ObjectId);
+
+			if (CosmeticPawnIndex!= -1)
+			{
+				DestroyPawns(CosmeticPawnIndex, PawnStore);
+				PawnStore[CosmeticPawnIndex].bPawnRemoved = true;
+			}
+		}
+		// End issue #1192
+
 		PawnStore[PawnInfoIndex].Referrers.RemoveItem(referrer);
 		DestroyPawns(PawnInfoIndex, PawnStore);
 		PawnStore[PawnInfoIndex].bPawnRemoved = true;
 	}
 	else
-	{		
+	{
 		PawnStore[PawnInfoIndex].Referrers.RemoveItem(referrer);
 		if(PawnStore[PawnInfoIndex].Referrers.Length == 0)
 		{
+
+			// Start Issue #1192 - gremlin/bit section - repeat of above code but in other part of if/else block
+			CosmeticPawn = GetCosmeticPawn(eInvSlot_SecondaryWeapon, UnitRef);
+
+			//use similar code to rest of function, but for the Cosmetic pawn
+			if (CosmeticPawn!= none)
+			{
+				CosmeticPawnIndex = PawnStore.Find('PawnRef', CosmeticPawn.ObjectId);
+
+				if (CosmeticPawnIndex!= -1)
+				{
+				DestroyPawns(CosmeticPawnIndex, PawnStore);
+					PawnStore[CosmeticPawnIndex].bPawnRemoved = true;
+				}
+			}
+			// End issue #1192
+
 			DestroyPawns(PawnInfoIndex, PawnStore);
 			PawnStore.Remove(PawnInfoIndex, 1);
 		}

--- a/X2WOTCCommunityHighlander/Src/XComGame/Classes/UIPawnMgr.uc
+++ b/X2WOTCCommunityHighlander/Src/XComGame/Classes/UIPawnMgr.uc
@@ -594,10 +594,6 @@ simulated function DestroyPawns(int StoreIdx, out array<PawnInfo> PawnStore)
 	// Added variable for Issue #885
 	local int i;
 
-	// Start Issue #1192 - Add call to StopSounds to remove sound effects for destroyed pawns.
-	PawnStore[StoreIdx].Pawn.StopSounds();
-	// End Issue #1192
-
 	PawnStore[StoreIdx].Pawn.Destroy();
 	PawnStore[StoreIdx].Pawn = none;
 	for ( idx = 0; idx < PawnStore[StoreIdx].Cosmetics.Length; ++idx )
@@ -641,10 +637,6 @@ simulated function ReleasePawnInternal(Actor referrer, int UnitRef, out array<Pa
 {
 	local int PawnInfoIndex;
 
-	// Added variables for Issue #1192
-	local XComUnitPawn CosmeticPawn;
-	local int CosmeticPawnIndex;
-
 	PawnInfoIndex = PawnStore.Find('PawnRef', UnitRef);
 	if (PawnInfoIndex == -1)
 	{
@@ -652,49 +644,15 @@ simulated function ReleasePawnInternal(Actor referrer, int UnitRef, out array<Pa
 	}
 	else if(bForce) // don't remove the entry from the array to preserve the Referrers
 	{
-
-		// Start Issue #1192 - gremlin/bit section
-		CosmeticPawn = GetCosmeticPawn(eInvSlot_SecondaryWeapon, UnitRef);
-
-		//use similar code to rest of function, but for the Cosmetic pawn
-		if (CosmeticPawn!= none)
-		{
-			CosmeticPawnIndex = PawnStore.Find('PawnRef', CosmeticPawn.ObjectId);
-
-			if (CosmeticPawnIndex!= -1)
-			{
-				DestroyPawns(CosmeticPawnIndex, PawnStore);
-				PawnStore[CosmeticPawnIndex].bPawnRemoved = true;
-			}
-		}
-		// End issue #1192
-
 		PawnStore[PawnInfoIndex].Referrers.RemoveItem(referrer);
 		DestroyPawns(PawnInfoIndex, PawnStore);
 		PawnStore[PawnInfoIndex].bPawnRemoved = true;
 	}
 	else
-	{
+	{		
 		PawnStore[PawnInfoIndex].Referrers.RemoveItem(referrer);
 		if(PawnStore[PawnInfoIndex].Referrers.Length == 0)
 		{
-
-			// Start Issue #1192 - gremlin/bit section - repeat of above code but in other part of if/else block
-			CosmeticPawn = GetCosmeticPawn(eInvSlot_SecondaryWeapon, UnitRef);
-
-			//use similar code to rest of function, but for the Cosmetic pawn
-			if (CosmeticPawn!= none)
-			{
-				CosmeticPawnIndex = PawnStore.Find('PawnRef', CosmeticPawn.ObjectId);
-
-				if (CosmeticPawnIndex!= -1)
-				{
-				DestroyPawns(CosmeticPawnIndex, PawnStore);
-					PawnStore[CosmeticPawnIndex].bPawnRemoved = true;
-				}
-			}
-			// End issue #1192
-
 			DestroyPawns(PawnInfoIndex, PawnStore);
 			PawnStore.Remove(PawnInfoIndex, 1);
 		}

--- a/X2WOTCCommunityHighlander/Src/XComGame/Classes/X2TacticalGameRuleset.uc
+++ b/X2WOTCCommunityHighlander/Src/XComGame/Classes/X2TacticalGameRuleset.uc
@@ -2974,7 +2974,7 @@ Begin:
 			sleep(0.0f);
 		}
 
-		MarkPlotUsed();
+		//MarkPlotUsed(); // Tedster - commented out for Issue #1082
 
 		`log("CreateTacticalGame: Dropship loaded");
 		
@@ -2999,6 +2999,10 @@ Begin:
 		//Will stop the HQ launch music if it is still playing ( which it should be, if we seamless traveled )
 		`XTACTICALSOUNDMGR.StopHQMusicEvent();
 	}
+
+	// Start Issue #1082 - Move the MarkPlotUsed call outside of the if block so that missions that don't show the dropship interior are also handled
+	MarkPlotUsed();
+	// End Issue #1082
 
 	//Generate the map and wait for it to complete
 	GenerateMap();


### PR DESCRIPTION
Fixes Issue #1082.

Since nothing uses Seamless traveling anymore (per a discord message from robojumper), Missions that don't involve a dropship travel animation don't mark plots as used, leading to all UFOs and Chosen Avenger Defenses for a campaign being on the same plot.  This PR moves the MarkPlotsUsed code outside of the `bShowDropshipInteriorWhileGeneratingMap` check so that all missions have plots marked as used properly.