### PR TITLE
Add MarkPlotUsed call for missions that don't use the dropship

### DIFF
--- a/X2WOTCCommunityHighlander/Src/XComGame/Classes/X2TacticalGameRuleset.uc
+++ b/X2WOTCCommunityHighlander/Src/XComGame/Classes/X2TacticalGameRuleset.uc
@@ -2974,7 +2974,9 @@ Begin:
 			sleep(0.0f);
 		}
 
-		//MarkPlotUsed(); // Tedster - commented out for Issue #1082
+		/// HL-Docs: ref:Bugfixes; issue:1082
+		/// MarkPlotUsed() - commented out original call and moved it outside of the if() statement
+		
 
 		`log("CreateTacticalGame: Dropship loaded");
 		
@@ -3000,9 +3002,9 @@ Begin:
 		`XTACTICALSOUNDMGR.StopHQMusicEvent();
 	}
 
-	// Start Issue #1082 - Move the MarkPlotUsed call outside of the if block so that missions that don't show the dropship interior are also handled
+	// Issue #1082 - moved outside the if() statement.
 	MarkPlotUsed();
-	// End Issue #1082
+
 
 	//Generate the map and wait for it to complete
 	GenerateMap();

--- a/X2WOTCCommunityHighlander/Src/XComGame/Classes/X2TacticalGameRuleset.uc
+++ b/X2WOTCCommunityHighlander/Src/XComGame/Classes/X2TacticalGameRuleset.uc
@@ -2974,7 +2974,7 @@ Begin:
 			sleep(0.0f);
 		}
 
-		MarkPlotUsed();
+		//MarkPlotUsed(); // Tedster - commented out for Issue #1082
 
 		`log("CreateTacticalGame: Dropship loaded");
 		
@@ -2999,6 +2999,10 @@ Begin:
 		//Will stop the HQ launch music if it is still playing ( which it should be, if we seamless traveled )
 		`XTACTICALSOUNDMGR.StopHQMusicEvent();
 	}
+
+	// Start Issue #1082 - Move the MarkPlotUsed call outside of the if block so that missions that don't show the dropship interior are also handled
+	MarkPlotUsed();
+	// End Issue #1082
 
 	//Generate the map and wait for it to complete
 	GenerateMap();


### PR DESCRIPTION
Fixes issue #1082

Since nothing uses Seamless traveling anymore (per a discord message from robojumper), Missions that don't involve a dropship travel animation don't mark plots as used, leading to all UFOs and Chosen Avenger Defenses for a campaign being on the same plot. This PR moves the MarkPlotsUsed code outside of the bShowDropshipInteriorWhileGeneratingMap check so that all missions have plots marked as used properly.