### PR TITLE
Implement Better Positive Trait UI

### DIFF
--- a/X2WOTCCommunityHighlander/Config/XComGame.ini
+++ b/X2WOTCCommunityHighlander/Config/XComGame.ini
@@ -290,3 +290,7 @@ iMixedCharacterPoolChance = 50
 ; Issue #1400 - Uncomment to force 24h clock and/or addition of a leading zero to the hours (e.g. to display 03:45 instead of 3:45 on the geoscape)
 ;bForce24hClock = true
 ;bForce24hClockLeadingZero = true
+
+;;; HL-Docs: ref:PositiveTraitUI
+; Uncomment the following line to show UIAlerts at the end of a mission and on campaign start for all Traits instead of just the first one.
+; bShowAllTraitAcquiredPopups = true

--- a/X2WOTCCommunityHighlander/Src/XComGame/Classes/CHHelpers.uc
+++ b/X2WOTCCommunityHighlander/Src/XComGame/Classes/CHHelpers.uc
@@ -207,6 +207,9 @@ var config float CameraRotationAngle;
 // Variable for Issue #917
 var config bool bDisableBetaStrikePostMissionHealing;
 
+// Variable for Issue #1081
+var config bool bShowAllTraitAcquiredPopups;
+
 // Start Issue #669
 //
 /// HL-Docs: feature:GrenadesRequiringUnitsOnTargetedTiles; issue:669; tags:tactical

--- a/X2WOTCCommunityHighlander/Src/XComGame/Classes/UIAvengerHud_SoldierStatusIndicatorContainer.uc
+++ b/X2WOTCCommunityHighlander/Src/XComGame/Classes/UIAvengerHud_SoldierStatusIndicatorContainer.uc
@@ -273,9 +273,11 @@ function OnClickTraitIcon(UITraitIcon Icon)
 	local int UntiID;
 	local XComGameState_Unit Unit;
 	local XComGameState NewGameState;
+	// Issue #1081 - Commented out now unnecessary code from Issue #85. 
+	// The check for the trait template introduced in Issue #85 is no longer needed, as we have now adjusted the UINegativeTraitAlert() function to cover positive traits as well.
 	//start issue #85: variables required to check the trait template of what we've been given
-	local X2EventListenerTemplateManager EventTemplateManager;
-	local X2TraitTemplate TraitTemplate;
+	//local X2EventListenerTemplateManager EventTemplateManager;
+	//local X2TraitTemplate TraitTemplate;
 	//end issue #85
 	
 	UntiID = int(GetRightMost(string(Icon.MCName)));
@@ -284,17 +286,19 @@ function OnClickTraitIcon(UITraitIcon Icon)
 	if(Unit == none) return;
 
 	//start issue #85: init variables here to check for trait template. If Positive, we cancel this callback.
-	EventTemplateManager = class'X2EventListenerTemplateManager'.static.GetEventListenerTemplateManager();
-	TraitTemplate = X2TraitTemplate(EventTemplateManager.FindEventListenerTemplate(Unit.AlertTraits[0]));
+	//EventTemplateManager = class'X2EventListenerTemplateManager'.static.GetEventListenerTemplateManager();
+	//TraitTemplate = X2TraitTemplate(EventTemplateManager.FindEventListenerTemplate(Unit.AlertTraits[0]));
 	//while it's an array, we go with the base game's assumption of having only one trait to worry about when it changes				
-			
-	if(TraitTemplate.bPositiveTrait)
-		return; 
-	//end issue #85
 	
+
+	//if(TraitTemplate.bPositiveTrait)
+	//return; 
+
+	//end issue #85
+		
 	NewGameState = class'XComGameStateContext_ChangeContainer'.static.CreateChangeState("Unit Trait Display Cleanup");
 	Unit = XComGameState_Unit(NewGameState.ModifyStateObject(class'XComGameState_Unit', Unit.ObjectID));
-	XComHQPresentationLayer(Movie.Pres).UINegativeTraitAlert(NewGameState, Unit, Unit.AlertTraits[0]);
+	XComHQPresentationLayer(Movie.Pres).UINegativeTraitAlert(NewGameState, Unit, Unit.AlertTraits[0]);	
 	`XCOMGAME.GameRuleset.SubmitGameState(NewGameState);
 }
 

--- a/X2WOTCCommunityHighlander/Src/XComGame/Classes/XComGameState_HeadquartersXCom.uc
+++ b/X2WOTCCommunityHighlander/Src/XComGame/Classes/XComGameState_HeadquartersXCom.uc
@@ -162,7 +162,7 @@ var() bool							bHasSeenCovertActionRiskIntroPopup;
 var() bool							bHasReceivedResistanceOrderPopup;
 var() bool							bHasSeenCantChangeOrdersPopup;
 var() bool							bHasSeenSoldierBondPopup;
-var() bool							bHasSeenNegativeTraitPopup;
+var() bool							bHasSeenNegativeTraitPopup; // Issue #1081 - Note: this bool now also covers popups for positive traits.
 
 // Tactical Tutorial Flags
 var() bool							bHasSeenTacticalTutorialSoldierBonds;


### PR DESCRIPTION
Fixes #1081 

Summary:

1. Modified UIAlert to use the "TrainingComplete" alert for positive traits - This has the same set of UI elements as Alert_NegativeSoldierEvent for negative traits but with a neutral colour scheme & promotion-icon.

2. Updated XcomHQPresentationLayer to check whether traits are positive or negative before calling the notifybanner function (this is the piece which places the trait notifications on the bottom left of the screen). Adjusted colours and icons to make more sense.

3. Adjusted the UIAvengerHUD OnClickTraitIcon function so that if someone clicks on a soldier walking around the avenger with a negative or positive trait icon (like the bond icon), it takes them to the correct UI Panel for that trait. 

Note that I can't confirm this new code actually does anything - I can't remember seeing anyone walking around with trait icons bobbing around so probably the function is never called for, but anyway, the code now includes positive traits as well in case that behaviour is ever fixed in the future.