### PR TITLE
Cache hit chances and game state for sorting enemies in UITacticalHUD_Enemies

### DIFF
--- a/X2WOTCCommunityHighlander/Src/XComGame/Classes/UITacticalHUD_Enemies.uc
+++ b/X2WOTCCommunityHighlander/Src/XComGame/Classes/UITacticalHUD_Enemies.uc
@@ -478,20 +478,15 @@ function RefreshShine(optional bool bMoveAbovePercent = false)
 	}
 }
 
-// Start Issue #1233 if inheritors of this class still call this function, use a slightly less efficient, but still faster version
 simulated function int SortEnemies(StateObjectReference ObjectA, StateObjectReference ObjectB)
 {
 	local XComGameState_Destructible DestructibleTargetA, DestructibleTargetB;
 	local XComGameStateHistory History;
 	local int HitChanceA, HitChanceB;
-	local StateObjectReferenceHitChange ObjectAHitChange;
-	local StateObjectReferenceHitChange ObjectBHitChange;
 
-	ObjectAHitChange = m_arrTargetsUnsorted[m_arrTargetsUnsorted.Find('Object', ObjectA)];
-	ObjectBHitChange = m_arrTargetsUnsorted[m_arrTargetsUnsorted.Find('Object', ObjectB)];
-
-	DestructibleTargetA = XComGameState_Destructible(ObjectAHitChange.GameState);
-	DestructibleTargetB = XComGameState_Destructible(ObjectBHitChange.GameState);
+	History = `XCOMHISTORY; 
+	DestructibleTargetA = XComGameState_Destructible(History.GetGameStateForObjectID(ObjectA.ObjectID));
+	DestructibleTargetB = XComGameState_Destructible(History.GetGameStateForObjectID(ObjectB.ObjectID));
 
 	//Push the destructible enemies to the back of the list.
 	if( DestructibleTargetA != none && DestructibleTargetB == none ) 
@@ -504,7 +499,9 @@ simulated function int SortEnemies(StateObjectReference ObjectA, StateObjectRefe
 	}
 
 	// push lower-hit chance targets back
-	if( ObjectAHitChange.HitChance < ObjectBHitChange.HitChance )
+	HitChanceA = GetHitChanceForObjectRef(ObjectA);
+	HitChanceB = GetHitChanceForObjectRef(ObjectB);
+	if( HitChanceA < HitChanceB )
 	{
 		return -1;
 	}
@@ -512,7 +509,7 @@ simulated function int SortEnemies(StateObjectReference ObjectA, StateObjectRefe
 	return 1;
 }
 
-// hot path, use cached values only
+// Start Issue #1233 hot path, use cached values only
 simulated function int SortEnemiesImproved(StateObjectReferenceHitChange ObjectA, StateObjectReferenceHitChange ObjectB)
 {
 	local XComGameState_Destructible DestructibleTargetA, DestructibleTargetB;

--- a/X2WOTCCommunityHighlander/Src/XComGame/Classes/UITacticalHUD_Enemies.uc
+++ b/X2WOTCCommunityHighlander/Src/XComGame/Classes/UITacticalHUD_Enemies.uc
@@ -9,15 +9,15 @@
 
 class UITacticalHUD_Enemies extends UIPanel implements(X2VisualizationMgrObserverInterface);
 
-// Start Issue #1233 wrapper for sort delegate
-struct StateObjectReferenceHitChange
+// Start Issue #1233 wrapper for enemy targets sort delegate
+struct StateObjectReferenceHitChance
 {
 	var StateObjectReference Object;
 	var XComGameState_BaseObject GameState;
 	var int HitChance;
 };
 
-var array<StateObjectReferenceHitChange> m_arrTargetsUnsorted;
+var array<StateObjectReferenceHitChance> m_arrTargetsUnsorted;
 // End Issue #1233
 
 var Actor m_kTargetActor;
@@ -317,7 +317,7 @@ simulated function UpdateVisibleEnemies(int HistoryIndex)
 	local int i;
 	local XComGameState_Ability CurrentAbilityState;
 	local X2AbilityTemplate AbilityTemplate;
-	local StateObjectReferenceHitChange TargetWrapper;
+	local StateObjectReferenceHitChance TargetWrapper;
 
 	m_arrSSEnemies.length = 0;
 	m_arrCurrentlyAffectable.length = 0;
@@ -362,11 +362,9 @@ simulated function UpdateVisibleEnemies(int HistoryIndex)
 		
 		iNumVisibleEnemies = m_arrTargets.Length;
 
-		// Start Issue #1233 cache some expensive calls and use that in our custom sort delegate
+		// Start Issue #1233 cache some expensive calls and use that in our custom sort delegate	
 		
-		//m_arrTargets.Sort(SortEnemies);
-
-		m_arrTargetsUnsorted.Length = 0;
+		m_arrTargetsUnsorted.Length = iNumVisibleEnemies;
 		
 		for (i = 0; i < iNumVisibleEnemies; ++i)
 		{			
@@ -374,18 +372,18 @@ simulated function UpdateVisibleEnemies(int HistoryIndex)
 			TargetWrapper.HitChance = GetHitChanceForObjectRef(TargetWrapper.Object);
 			TargetWrapper.GameState = History.GetGameStateForObjectID(TargetWrapper.Object.ObjectID);
 
-			m_arrTargetsUnsorted.AddItem(TargetWrapper);
+			m_arrTargetsUnsorted[i] = TargetWrapper;
 		}
 	
 		// use our improved sort delegate
 		m_arrTargetsUnsorted.Sort(SortEnemiesImproved);
 
-		m_arrTargets.Length = 0;
+		m_arrTargets.Length = iNumVisibleEnemies;
 		for (i = 0; i < iNumVisibleEnemies; ++i)
 		{
-			m_arrTargets.AddItem(m_arrTargetsUnsorted[i].Object);
+			m_arrTargets[i] = m_arrTargetsUnsorted[i].Object;
 		}
-		
+
 		// End Issue #1233
 
 		UpdateVisuals(HistoryIndex);
@@ -510,7 +508,7 @@ simulated function int SortEnemies(StateObjectReference ObjectA, StateObjectRefe
 }
 
 // Start Issue #1233 hot path, use cached values only
-simulated function int SortEnemiesImproved(StateObjectReferenceHitChange ObjectA, StateObjectReferenceHitChange ObjectB)
+simulated function int SortEnemiesImproved(StateObjectReferenceHitChance ObjectA, StateObjectReferenceHitChance ObjectB)
 {
 	local XComGameState_Destructible DestructibleTargetA, DestructibleTargetB;
 


### PR DESCRIPTION
Full implementation for what I mentioned in the issue.

Not sure about the name for 'StateObjectReferenceHitChange'

fixes #1233