### PR TITLE
Make Dodge apply to Hit and Crit equally

### DIFF
--- a/X2WOTCCommunityHighlander/Src/XComGame/Classes/X2AbilityToHitCalc.uc
+++ b/X2WOTCCommunityHighlander/Src/XComGame/Classes/X2AbilityToHitCalc.uc
@@ -81,6 +81,9 @@ protected function FinalizeHitChance(out ShotBreakdown m_ShotBreakdown, bool bDe
 	local delegate<OverrideFinalHitChance> OverrideFn;
 	// End Issue #555
 
+	// Variable for Issue #1200
+	local int DodgeModifier;
+
 	// Start Issue #555
 	OverrideHitChanceCalc = false;
 	foreach OverrideFinalHitChanceFns(OverrideFn)
@@ -124,11 +127,13 @@ protected function FinalizeHitChance(out ShotBreakdown m_ShotBreakdown, bool bDe
 			/// Make Dodge apply to Hit and Crit equally to fix Dodge increasing Miss chance.
 			//GrazeScale *= float(m_ShotBreakdown.FinalHitChance);
 			//FinalGraze = Round(GrazeScale);
-			FinalGraze += m_ShotBreakdown.ResultTable[eHit_Success] * GrazeScale;
-			m_ShotBreakdown.ResultTable[eHit_Success] -= m_ShotBreakdown.ResultTable[eHit_Success] * GrazeScale;
+			DodgeModifier = Round(m_ShotBreakdown.ResultTable[eHit_Success] * GrazeScale);
+			m_ShotBreakdown.ResultTable[eHit_Success] -= DodgeModifier;
+			FinalGraze += DodgeModifier;
 
-			FinalGraze += m_ShotBreakdown.ResultTable[eHit_Crit] * GrazeScale;
-			m_ShotBreakdown.ResultTable[eHit_Crit] -= m_ShotBreakdown.ResultTable[eHit_Crit] * GrazeScale;
+			DodgeModifier = Round(m_ShotBreakdown.ResultTable[eHit_Crit] * GrazeScale);
+			m_ShotBreakdown.ResultTable[eHit_Crit] -= DodgeModifier;
+			FinalGraze += DodgeModifier;
 
 			m_ShotBreakdown.ResultTable[eHit_Graze] = FinalGraze;
 			// End Issue #1200

--- a/X2WOTCCommunityHighlander/Src/XComGame/Classes/X2AbilityToHitCalc.uc
+++ b/X2WOTCCommunityHighlander/Src/XComGame/Classes/X2AbilityToHitCalc.uc
@@ -125,8 +125,11 @@ protected function FinalizeHitChance(out ShotBreakdown m_ShotBreakdown, bool bDe
 			// Start Issue #1200
 			/// HL-Docs: ref:Bugfixes; issue:1200
 			/// Make Dodge apply to Hit and Crit equally to fix Dodge increasing Miss chance.
+
 			//GrazeScale *= float(m_ShotBreakdown.FinalHitChance);
 			//FinalGraze = Round(GrazeScale);
+
+			// Use rounding to prevent the resulting chances from not adding up to 100.
 			DodgeModifier = Round(m_ShotBreakdown.ResultTable[eHit_Success] * GrazeScale);
 			m_ShotBreakdown.ResultTable[eHit_Success] -= DodgeModifier;
 			FinalGraze += DodgeModifier;

--- a/X2WOTCCommunityHighlander/Src/XComGame/Classes/X2AbilityToHitCalc.uc
+++ b/X2WOTCCommunityHighlander/Src/XComGame/Classes/X2AbilityToHitCalc.uc
@@ -118,10 +118,20 @@ protected function FinalizeHitChance(out ShotBreakdown m_ShotBreakdown, bool bDe
 		if (m_ShotBreakdown.FinalHitChance < 100)
 		{
 			GrazeScale = float(m_ShotBreakdown.ResultTable[eHit_Graze]) / 100.0f;
-			GrazeScale *= float(m_ShotBreakdown.FinalHitChance);
-			FinalGraze = Round(GrazeScale);
-			m_ShotBreakdown.ResultTable[eHit_Success] -= FinalGraze;
+
+			// Start Issue #1200
+			/// HL-Docs: ref:Bugfixes; issue:1200
+			/// Make Dodge apply to Hit and Crit equally to fix Dodge increasing Miss chance.
+			//GrazeScale *= float(m_ShotBreakdown.FinalHitChance);
+			//FinalGraze = Round(GrazeScale);
+			FinalGraze += m_ShotBreakdown.ResultTable[eHit_Success] * GrazeScale;
+			m_ShotBreakdown.ResultTable[eHit_Success] -= m_ShotBreakdown.ResultTable[eHit_Success] * GrazeScale;
+
+			FinalGraze += m_ShotBreakdown.ResultTable[eHit_Crit] * GrazeScale;
+			m_ShotBreakdown.ResultTable[eHit_Crit] -= m_ShotBreakdown.ResultTable[eHit_Crit] * GrazeScale;
+
 			m_ShotBreakdown.ResultTable[eHit_Graze] = FinalGraze;
+			// End Issue #1200
 		}
 		else
 		{


### PR DESCRIPTION
Fixes #1200 

An alternative fix to #1215. The original PR makes Dodge erode Hit first, and only then Crit, much like Defense does.

This PR makes Dodge apply to Hit and Crit equally, so both remain as possible outcomes as long as Dodge is <100.