### PR TITLE
Destroy cosmetic pawns when items are unequipped 

### DIFF
--- a/X2WOTCCommunityHighlander/Src/XComGame/Classes/UIPawnMgr.uc
+++ b/X2WOTCCommunityHighlander/Src/XComGame/Classes/UIPawnMgr.uc
@@ -259,6 +259,54 @@ simulated function XComUnitPawn GetCosmeticPawnInternal(out array<PawnInfo> Pawn
 	return PawnStore[StoreIdx].Cosmetics[CosmeticSlot].Pawn;
 }
 
+/// Start issue #1108 - new function to destroy cosmetic pawns.  INTERNAL CHL API, not covered by BC policy.
+simulated final function bool DestroyCosmeticPawn_CH(int CosmeticSlot, int UnitRef, bool bUsePhotoboothPawns = false)
+{
+	local int PawnInfoIndex;
+
+	if (bUsePhotoboothPawns)
+	{
+		PawnInfoIndex = PhotoboothPawns.Find('PawnRef', UnitRef);
+		if (PawnInfoIndex != -1)
+		{
+			return DestroyCosmeticPawnInternal_CH(PhotoboothPawns, CosmeticSlot, PawnInfoIndex);
+		}
+	}
+	else
+	{
+		PawnInfoIndex = Pawns.Find('PawnRef', UnitRef);
+		if (PawnInfoIndex != -1)
+		{
+			return DestroyCosmeticPawnInternal_CH(Pawns, CosmeticSlot, PawnInfoIndex);
+		}
+
+		PawnInfoIndex = CinematicPawns.Find('PawnRef', UnitRef);
+		if (PawnInfoIndex != -1)
+		{
+			return DestroyCosmeticPawnInternal_CH(CinematicPawns, CosmeticSlot, PawnInfoIndex);
+		}
+	}
+
+	return false;
+}
+
+// Helper function used by DestroyCosmeticPawn_CH. Also internal only, and not covered by BC policy.
+simulated final function bool DestroyCosmeticPawnInternal_CH(out array<PawnInfo> PawnStore, int CosmeticSlot, int StoreIdx)
+{
+	local bool bSuccess;
+
+	if (CosmeticSlot >= PawnStore[StoreIdx].Cosmetics.Length)
+		return false;
+
+	PawnStore[StoreIdx].Cosmetics[CosmeticSlot].Pawn.StopSounds();
+	bSuccess = PawnStore[StoreIdx].Cosmetics[CosmeticSlot].Pawn.Destroy();
+	PawnStore[StoreIdx].Cosmetics[CosmeticSlot].Pawn = none;
+	PawnStore[StoreIdx].Cosmetics[CosmeticSlot].ArchetypePawn = None;
+
+	return bSuccess;
+}
+// End issue #1108
+
 simulated function AssociateWeaponPawn(int CosmeticSlot, Actor WeaponPawn, int UnitRef,  XComUnitPawn OwningPawn, bool bUsePhotoboothPawns = false)
 {
 	local int PawnInfoIndex;

--- a/X2WOTCCommunityHighlander/Src/XComGame/Classes/UIPawnMgr.uc
+++ b/X2WOTCCommunityHighlander/Src/XComGame/Classes/UIPawnMgr.uc
@@ -259,7 +259,8 @@ simulated function XComUnitPawn GetCosmeticPawnInternal(out array<PawnInfo> Pawn
 	return PawnStore[StoreIdx].Cosmetics[CosmeticSlot].Pawn;
 }
 
-/// Start issue #1108 - new function to destroy cosmetic pawns.  INTERNAL CHL API, not covered by BC policy.
+// Start issue #1108
+// Destroy a cosmetic pawn associated with a particular inventory slot on a particular unit, if there is one.
 simulated final function bool DestroyCosmeticPawn_CH(int CosmeticSlot, int UnitRef, bool bUsePhotoboothPawns = false)
 {
 	local int PawnInfoIndex;
@@ -290,8 +291,7 @@ simulated final function bool DestroyCosmeticPawn_CH(int CosmeticSlot, int UnitR
 	return false;
 }
 
-// Helper function used by DestroyCosmeticPawn_CH. Also internal only, and not covered by BC policy.
-simulated final function bool DestroyCosmeticPawnInternal_CH(out array<PawnInfo> PawnStore, int CosmeticSlot, int StoreIdx)
+simulated private function bool DestroyCosmeticPawnInternal_CH(out array<PawnInfo> PawnStore, int CosmeticSlot, int StoreIdx)
 {
 	local bool bSuccess;
 

--- a/X2WOTCCommunityHighlander/Src/XComGame/Classes/XComGameState_Unit.uc
+++ b/X2WOTCCommunityHighlander/Src/XComGame/Classes/XComGameState_Unit.uc
@@ -8485,9 +8485,6 @@ simulated function bool RemoveItemFromInventory(XComGameState_Item Item, optiona
 	local X2ArmorTemplate ArmorTemplate;
 	local int RemoveIndex;
 
-	// Variable for Issue #1108
-	local UIPawnMgr PawnMgr;
-
 	if (CanRemoveItemFromInventory(Item, ModifyGameState))
 	{				
 		RemoveIndex = InventoryItems.Find('ObjectID', Item.ObjectID);
@@ -8512,15 +8509,14 @@ simulated function bool RemoveItemFromInventory(XComGameState_Item Item, optiona
 			{
 				`RedScreen("Attempt to remove item" @ Item.GetMyTemplateName() @ "properly may have failed due to OnUnequippedFn -jbouscher @gameplay");
 			}
-		}		
+		}	
+		
+		/// HL-Docs: ref:Bugfixes; issue:1108
+		/// If there is a cosmetic pawn associated with the unequipped item item, remove it.
+		`PRESBASE.GetUIPawnMgr().DestroyCosmeticPawn_CH(Item.InventorySlot, self.ObjectID);
 
 		if (RemoveIndex != INDEX_NONE)
 		{
-			// Start Issue #1108
-			// Remove Cosmetic Unit when the item is removed, using newly created function in UIPawnMgr.
-			PawnMgr = `HQPRES.GetUIPawnMgr();
-			PawnMgr.DestroyCosmeticPawn_CH(Item.InventorySlot, self.ObjectID);
-			// End Issue #1108
 			InventoryItems.Remove(RemoveIndex, 1);
 		}
 

--- a/X2WOTCCommunityHighlander/Src/XComGame/Classes/XComGameState_Unit.uc
+++ b/X2WOTCCommunityHighlander/Src/XComGame/Classes/XComGameState_Unit.uc
@@ -8485,6 +8485,9 @@ simulated function bool RemoveItemFromInventory(XComGameState_Item Item, optiona
 	local X2ArmorTemplate ArmorTemplate;
 	local int RemoveIndex;
 
+	// Variable for Issue #1108
+	local UIPawnMgr PawnMgr;
+
 	if (CanRemoveItemFromInventory(Item, ModifyGameState))
 	{				
 		RemoveIndex = InventoryItems.Find('ObjectID', Item.ObjectID);
@@ -8512,7 +8515,14 @@ simulated function bool RemoveItemFromInventory(XComGameState_Item Item, optiona
 		}		
 
 		if (RemoveIndex != INDEX_NONE)
+		{
+			// Start Issue #1108
+			// Remove Cosmetic Unit when the item is removed, using newly created function in UIPawnMgr.
+			PawnMgr = `HQPRES.GetUIPawnMgr();
+			PawnMgr.DestroyCosmeticPawn_CH(Item.InventorySlot, self.ObjectID);
+			// End Issue #1108
 			InventoryItems.Remove(RemoveIndex, 1);
+		}
 
 		Item.OwnerStateObject.ObjectID = 0;
 


### PR DESCRIPTION
Fixes Issue #1108 by creating a new function `DestroyCosmeticPawn_CH` that is modeled on the existing `GetCosmeticPawn` function, but destroys the requested cosmetic pawn instead of returning it.  This function is now called by `RemoveItemFromInventory` on `XComGameState_Unit`

New PR to use proper rebased branch with cleaned up commits.