### PR TITLE
fix ValidateTier1HackRewards/ValidateTier2HackRewards, when HackRewar…

### DIFF
--- a/X2WOTCCommunityHighlander/Src/XComGame/Classes/XComTacticalMissionManager.uc
+++ b/X2WOTCCommunityHighlander/Src/XComGame/Classes/XComTacticalMissionManager.uc
@@ -1745,23 +1745,22 @@ function bool ValidateTier2HackRewards(string CardLabel, Object ValidationData)
 	HackRewardTemplate = HackRewardTemplateManager.FindHackRewardTemplate(Name(CardLabel));
 
 	// Issue #324 - none-check HackRewardTemplate to prevent a log warning.
-	if (HackRewardTemplate != none)
+	if (HackRewardTemplate == none) return false;
+	
+	if( !HackRewardTemplate.bIsTier2Reward )
 	{
-		if( !HackRewardTemplate.bIsTier2Reward )
-		{
-			return false;
-		}
+		return false;
+	}
 
-		if (BuildingChallengeMission && HackRewardTemplate.bIsStrategyReward)
-		{
-			return false;
-		}
+	if (BuildingChallengeMission && HackRewardTemplate.bIsStrategyReward)
+	{
+		return false;
+	}
 
-		// TODO: add additional validation for strategy requirements
-		if( !HackRewardTemplate.IsHackRewardCurrentlyPossible() )
-		{
-			return false;
-		}
+	// TODO: add additional validation for strategy requirements
+	if( !HackRewardTemplate.IsHackRewardCurrentlyPossible() )
+	{
+		return false;
 	}
 
 	return true;
@@ -1776,31 +1775,30 @@ function bool ValidateTier1HackRewards(string CardLabel, Object ValidationData)
 	HackRewardTemplate = HackRewardTemplateManager.FindHackRewardTemplate(Name(CardLabel));
 
 	// Issue #324 - none-check HackRewardTemplate to prevent a log warning.
-	if (HackRewardTemplate != none)
+	if (HackRewardTemplate == none) return false;
+
+	if( !HackRewardTemplate.bIsTier1Reward )
 	{
-		if( !HackRewardTemplate.bIsTier1Reward )
+		return false;
+	}
+
+	if( HackRewardTemplate.LinkedReward != '' )
+	{
+		if( HackRewardTemplate.bPairWithLinkedReward == (HackRewardTemplate.LinkedReward != LastSelectedRewardName) )
 		{
 			return false;
 		}
+	}
 
-		if( HackRewardTemplate.LinkedReward != '' )
-		{
-			if( HackRewardTemplate.bPairWithLinkedReward == (HackRewardTemplate.LinkedReward != LastSelectedRewardName) )
-			{
-				return false;
-			}
-		}
+	if (BuildingChallengeMission && HackRewardTemplate.bIsStrategyReward)
+	{
+		return false;
+	}
 
-		if (BuildingChallengeMission && HackRewardTemplate.bIsStrategyReward)
-		{
-			return false;
-		}
-
-		// TODO: add additional validation for strategy requirements
-		if( !HackRewardTemplate.IsHackRewardCurrentlyPossible() )
-		{
-			return false;
-		}
+	// TODO: add additional validation for strategy requirements
+	if( !HackRewardTemplate.IsHackRewardCurrentlyPossible() )
+	{
+		return false;
 	}
 
 	return true;


### PR DESCRIPTION
…dTemplate is none, it should return false

This was introduced in https://github.com/X2CommunityCore/X2WOTCCommunityHighlander/pull/1226
I commented on it, ~~but Iridar might have missed it.~~ I actually missed his reply!

I don't agree with it being out of scope though. It's uc behavior to fall through that if statement with a warning, and still accesses the variable (returning a default value of false). Changing the behavior to fix a log warning is not supposed to happen here :)