### PR TITLE
Add a check to XCGS_Unit.HasLoadout to verify if the item in the loadout is a valid item

### DIFF
--- a/X2WOTCCommunityHighlander/Src/XComGame/Classes/XComGameState_Unit.uc
+++ b/X2WOTCCommunityHighlander/Src/XComGame/Classes/XComGameState_Unit.uc
@@ -8720,6 +8720,12 @@ simulated function bool HasLoadout(name LoadoutName, optional XComGameState Chec
 	{
 		foreach Loadout.Items(LoadoutItem)
 		{
+			// Issue #1253 skip non-existing items, so that it not fails the HasLoadout test if the item template does not exist
+			if (ItemTemplateManager.FindItemTemplate(LoadoutItem.Item) == none)
+			{
+				continue;
+			}
+
 			if(!HasItemOfTemplateType(LoadoutItem.Item, CheckGameState))
 			{
 				return false;


### PR DESCRIPTION
fixes #1253

Testing method:

I changed the following in LWOTC config:

```
-Loadouts=(LoadoutName="RequiredSoldier", Items[0]=(Item="XPad"))
+Loadouts=(LoadoutName="RequiredSoldier", Items[0]=(Item="XPad"), Items[1]=(Item="EvacFlare"), Items[2]=(Item="ZZDummyItem"))
```

Added two log statements where it is checking the item, and if the item was skipped.

When opening Squad Select, this happens:

![image](https://github.com/X2CommunityCore/X2WOTCCommunityHighlander/assets/130373/3d6fbe12-a2cd-4415-b966-785a00a7acf0)

verified that it skipped the non-existing dummy item.