### PR TITLE
Fix CHL_Event_Compiletest (handle parameters of type 'Object')

### DIFF
--- a/.scripts/build.ps1
+++ b/.scripts/build.ps1
@@ -69,7 +69,7 @@ if ($compiletest) {
     $builder.AddPreMakeHook({
         Write-Host "Including CHL_Event_Compiletest"
         # n.b. this copies from the `target` directory where it is generated into, see tasks.json
-        Copy-Item "..\target\CHL_Event_Compiletest.uc" "$sdkPath\Development\Src\X2WOTCCommunityHighlander\Classes\" -Force -WarningAction SilentlyContinue
+        Copy-Item ".\target\CHL_Event_Compiletest.uc" "$sdkPath\Development\Src\X2WOTCCommunityHighlander\Classes\" -Force -WarningAction SilentlyContinue
     })
 }
 

--- a/.scripts/make_docs.py
+++ b/.scripts/make_docs.py
@@ -294,7 +294,10 @@ def make_listener_template(sess, spec: dict) -> str:
                     else:
                         unwraps += f"\t{name} = Tuple.Data[{idx}].{tup_prop};\n"
                 else:
-                    unwraps += f"\t{name} = {tup_type}(Tuple.Data[{idx}].o);\n"
+                    if tup_type.lower() == "object":
+                        unwraps += f"\t{name} = Tuple.Data[{idx}].o;\n"
+                    else:
+                        unwraps += f"\t{name} = {tup_type}(Tuple.Data[{idx}].o);\n"
 
             if inoutness.is_out():
                 if tup_prop:


### PR DESCRIPTION
Now handles events with parameters of type 'Object' properly.

One (and the only) example is `AllowOnCovertActionComplete`:

> ...\X2WOTCCommunityHighlander2\X2WOTCCommunityHighlander\Src\X2WOTCCommunityHighlander\Classes\CHL_Event_Compiletest.uc(55) : Error, Cast from 'Object' to 'Object' is unnecessary