### PR TITLE
Make FinalizePlayerStateForTacticalMusic event use Tuple

### DIFF
--- a/X2WOTCCommunityHighlander/Src/XComGame/Classes/XComTacticalSoundManager.uc
+++ b/X2WOTCCommunityHighlander/Src/XComGame/Classes/XComTacticalSoundManager.uc
@@ -435,7 +435,7 @@ function EvaluateTacticalMusicState()
 ///
 /// To allow for better compatibility between mods which manage player activity
 /// and mods which manage sound options, there is one event which will allow 
-/// to override the player state or it's parameters.
+/// to override the player state or its parameters.
 ///
 /// ```event
 /// EventID: FinalizePlayerStateForTacticalMusic,

--- a/X2WOTCCommunityHighlander/Src/XComGame/Classes/XComTacticalSoundManager.uc
+++ b/X2WOTCCommunityHighlander/Src/XComGame/Classes/XComTacticalSoundManager.uc
@@ -439,20 +439,27 @@ function EvaluateTacticalMusicState()
 ///
 /// ```event
 /// EventID: FinalizePlayerStateForTacticalMusic,
-/// EventData: XComGameState_Player (LocalPlayerState),
+/// EventData: [
+///     inout XComGameState_Player PlayerState
+/// ],
 /// EventSource: XComTacticalSoundManager (SoundManager),
 /// NewGameState: none
 /// ```
 private function XComGameState_Player TriggerFinalizePlayerStateForTacticalMusic(XComGameState_Player LocalPlayerState)
 {
-	local XComGameState_Player EventData;
+	local XComLWTuple Tuple;
 
-	EventData = LocalPlayerState;
+	Tuple = new class'XComLWTuple';
+	Tuple.Id = 'FinalizePlayerStateForTacticalMusic';
+	Tuple.Data.Add(1);
+	Tuple.Data[0].kind = XComLWTVObject;
+	Tuple.Data[0].o = LocalPlayerState;
 
-	`XEVENTMGR.TriggerEvent('FinalizePlayerStateForTacticalMusic', EventData, self, none);
+	`XEVENTMGR.TriggerEvent(Tuple.Id, Tuple, self, none);
 
-	return EventData;
+	return Tuple.Data[0].o;
 }
+// End Issue #1153
 
 event OnActiveUnitChanged(XComGameState_Unit NewActiveUnit)
 {


### PR DESCRIPTION
Issue #1153

PR #1154 added an event that was supposed to allow listeners to override the Player State in `XComTacticalSoundManager::EvaluateTacticalMusicState()` by using EventData, but since it's not an `out` parameter, this turned out to be impossible, so I refactored the event trigger so it uses an LWTuple to hold the reference to override player state.