### PR TITLE
Add a toggle to disable aim assist

### DIFF
--- a/X2WOTCCommunityHighlander/Config/XComGame.ini
+++ b/X2WOTCCommunityHighlander/Config/XComGame.ini
@@ -282,3 +282,8 @@ iMixedCharacterPoolChance = 50
 ; Uncomment the following line to make the Unit Flag damage preview show minimum damage
 ; rather than maximum damage.
 ; bUseMinDamageForUnitFlagPreview = true
+
+;;; HL-Docs: ref:DisableAimAssist
+; Uncomment the following line to disable Aim Assist.
+; bDisableAimAssist = true
+

--- a/X2WOTCCommunityHighlander/Src/XComGame/Classes/CHHelpers.uc
+++ b/X2WOTCCommunityHighlander/Src/XComGame/Classes/CHHelpers.uc
@@ -254,6 +254,10 @@ var config int iMixedCharacterPoolChance;
 // Variable for Issue #579 - makes UIUnitFlagManager use ability's minimum damage rather than maximum damage for the preview.
 var config bool bUseMinDamageForUnitFlagPreview;
 
+// Variable for Issue #1228 - disables Aim Assist.
+var config bool bDisableAimAssist;
+
+
 // Start Issue #885
 enum EHLDelegateReturn
 {

--- a/X2WOTCCommunityHighlander/Src/XComGame/Classes/X2AbilityToHitCalc_StandardAim.uc
+++ b/X2WOTCCommunityHighlander/Src/XComGame/Classes/X2AbilityToHitCalc_StandardAim.uc
@@ -823,6 +823,15 @@ function int GetModifiedHitChanceForCurrentDifficulty(XComGameState_Player Insti
 	local XComGameState_Unit Unit;
 	local ETeam TargetTeam;
 
+	// Start Issue #1228
+	/// HL-Docs: feature:DisableAimAssist; issue:1228; tags:tactical
+	/// This feature adds a config variable that acts as a master switch for disabling all instances of Aim Assist.
+	if (class'CHHelpers'.default.bDisableAimAssist) 
+	{
+		return BaseHitChance;
+	}
+	// End Issue #1228
+
 	ModifiedHitChance = BaseHitChance;
 
 	History = `XCOMHISTORY;


### PR DESCRIPTION
Fixes #1228 

I found only one place in the entire codebase that's relevant to Aim Assist, though I could have missed something. 

The place in question is the `GetModifiedHitChanceForCurrentDifficulty()` function, which applies some modifications to ability's hit chance based on the in-game circumstances, and then if the team is XCOM and the attack missed, it may be flipped to a hit, and if the team is Alien or Lost, then a hit may be flipped to a miss. 

Both cases will get logged.

This PR just adds one bool switch to CHHelpers which is checked only in `GetModifiedHitChanceForCurrentDifficulty()`, and then the function just returns unmodified hit chance.

I briefly considered also checking the bool switch to bypass the logic that would call `GetModifiedHitChanceForCurrentDifficulty()`, but it shouldn't be necessary. 

Note that the mod Extended Information that has an option to display Aim Assist will be unaffected by the bool switch, and will still display aim assist, because it uses copypasted code from X2AbilityToHitCalc_StandardAim to calculate Aim Assist bonus.