### PR TITLE
Apply weapon customization when equipping unmodified weapons

### DIFF
--- a/X2WOTCCommunityHighlander/Src/XComGame/Classes/XComGameState_Unit.uc
+++ b/X2WOTCCommunityHighlander/Src/XComGame/Classes/XComGameState_Unit.uc
@@ -7998,6 +7998,9 @@ function bool AddItemToInventory(XComGameState_Item Item, EInventorySlot Slot, X
 	local array<name> DLCNames; //issue #155 addition
 	local XComLWTuple Tuple; //issue #299 addition
 
+	// Variable for Issue #609
+	local X2WeaponTemplate WeaponTemplate;
+
 	ItemTemplate = Item.GetMyTemplate();
 	
 	// issue #114: pass along item state when possible
@@ -8160,6 +8163,38 @@ function bool AddItemToInventory(XComGameState_Item Item, EInventorySlot Slot, X
 		{
 			`XEVENTMGR.TriggerEvent('EffectBreakUnitConcealment', self, self, NewGameState);
 		}
+
+		// Start Issue #609
+		/// HL-Docs: ref:Bugfixes; issue:609
+		/// Apply weapon customization from soldier appearance when equipping weapons.
+		switch (Slot)
+		{
+			// Being conservative and applying weapon customization only to first three weapon slots,
+			// same as ApplyBestGearLoadout()
+			case eInvSlot_PrimaryWeapon:
+			case eInvSlot_SecondaryWeapon:
+			case eInvSlot_TertiaryWeapon:
+				if (!Item.HasBeenModified())
+				{
+					WeaponTemplate = X2WeaponTemplate(ItemTemplate);
+					if (WeaponTemplate != none)
+					{
+						if (WeaponTemplate.bUseArmorAppearance)
+						{
+							Item.WeaponAppearance.iWeaponTint = kAppearance.iArmorTint;
+						}
+						else
+						{
+							Item.WeaponAppearance.iWeaponTint = kAppearance.iWeaponTint;
+						}
+						Item.WeaponAppearance.nmWeaponPattern = kAppearance.nmWeaponPattern;
+					}
+				}
+				break;
+			default:
+				break;
+		}
+		// End Issue #609
 
 		// Start Issue #694
 		/// HL-Docs: feature:ItemAddedOrRemovedToSlot; issue:694; tags:


### PR DESCRIPTION
Fixes #609 

This PR does fix the outlined issue, but I need more tests to determine it doesn't go overboard. For example, when working with non-infinite weapons that have weapon upgrades applied to them, but no upgrade slots, e.g. TLP weapons or Chosen XCOM weapons.