### PR TITLE
Limit workflow concurrency, cancel-in-progress

### DIFF
--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -2,6 +2,11 @@ name: docs
 
 on: [push, pull_request]
 
+# Ensures that only one deploy task per branch/environment will run at a time.
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
+
 jobs:
   test:
     runs-on: ubuntu-latest

--- a/.github/workflows/post_patch.yml
+++ b/.github/workflows/post_patch.yml
@@ -10,6 +10,11 @@ on:
     types: 
       - completed
 
+# Ensures that only one deploy task per branch/environment will run at a time.
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
+
 jobs:
   run:
     runs-on: ubuntu-latest


### PR DESCRIPTION
This ensures workflows with side effects that perform potentially destructive actions, such as a force-push or a comment edit don't end up failing because of a failed force push lease or end up de-syncing the comment contents.

See https://discord.com/channels/165245941664710656/273238884433788928/1212024029083467786