### PR TITLE
Add eInv Slots to enable Soldiers to carry multiple unique Proximity-Activated Items for the Requiem Campaign

### DIFF
--- a/X2WOTCCommunityHighlander/Src/XComGame/Classes/X2TacticalGameRulesetDataStructures.uc
+++ b/X2WOTCCommunityHighlander/Src/XComGame/Classes/X2TacticalGameRulesetDataStructures.uc
@@ -116,8 +116,7 @@ enum EInventorySlot
 	eInvSlot_SparkActuator,
 	eInvSlot_SparkModule,
 	eInvSlot_ExtraGrenadePocket,
-	eInvSlot_ExtraLandMine1,
-	eInvSlot_ExtraLandMine2,
+	eInvSlot_ExtraLandMine,
 
 	// Marker slot, don't use
 	eInvSlot_END_TEMPLATED_SLOTS,

--- a/X2WOTCCommunityHighlander/Src/XComGame/Classes/X2TacticalGameRulesetDataStructures.uc
+++ b/X2WOTCCommunityHighlander/Src/XComGame/Classes/X2TacticalGameRulesetDataStructures.uc
@@ -116,6 +116,8 @@ enum EInventorySlot
 	eInvSlot_SparkActuator,
 	eInvSlot_SparkModule,
 	eInvSlot_ExtraGrenadePocket,
+	eInvSlot_ExtraLandMine1,
+	eInvSlot_ExtraLandMine2,
 
 	// Marker slot, don't use
 	eInvSlot_END_TEMPLATED_SLOTS,


### PR DESCRIPTION
To conditionally allow or disallow Soldiers to equip one, or more, unique categories of Proximity-Activated Items.