### PR TITLE
Issue #1299 - remove unused local variable

### DIFF
--- a/X2WOTCCommunityHighlander/Src/XComGame/Classes/X2Effect_ApplyWeaponDamage.uc
+++ b/X2WOTCCommunityHighlander/Src/XComGame/Classes/X2Effect_ApplyWeaponDamage.uc
@@ -752,13 +752,16 @@ simulated function int CalculateDamageAmount(const out EffectAppliedData ApplyEf
 	local X2Effect_Persistent EffectTemplate;
 	local WeaponDamageValue BaseDamageValue, ExtraDamageValue, BonusEffectDamageValue, AmmoDamageValue, UpgradeTemplateBonusDamage, UpgradeDamageValue;
 	local X2AmmoTemplate AmmoTemplate;
-	local int RuptureCap, RuptureAmount, OriginalMitigation, UnconditionalShred;
+	local int RuptureAmount, OriginalMitigation, UnconditionalShred;
 	local int EnvironmentDamage, TargetBaseDmgMod;
 	local XComDestructibleActor kDestructibleActorTarget;
 	local array<X2WeaponUpgradeTemplate> WeaponUpgradeTemplates;
 	local X2WeaponUpgradeTemplate WeaponUpgradeTemplate;
 	local DamageModifierInfo ModifierInfo;
 	local bool bWasImmune, bHadAnyDamage;
+
+	// Issue #1299 - comment out unused Rupture Cap.
+	//local int RuptureCap;
 
 	ArmorMitigation = 0;
 	NewRupture = 0;
@@ -914,7 +917,9 @@ simulated function int CalculateDamageAmount(const out EffectAppliedData ApplyEf
 	ArmorPiercing = BaseDamageValue.Pierce + ExtraDamageValue.Pierce + BonusEffectDamageValue.Pierce + AmmoDamageValue.Pierce + UpgradeDamageValue.Pierce;
 	NewRupture = BaseDamageValue.Rupture + ExtraDamageValue.Rupture + BonusEffectDamageValue.Rupture + AmmoDamageValue.Rupture + UpgradeDamageValue.Rupture;
 	NewShred = BaseDamageValue.Shred + ExtraDamageValue.Shred + BonusEffectDamageValue.Shred + AmmoDamageValue.Shred + UpgradeDamageValue.Shred;
-	RuptureCap = WeaponDamage;
+
+	// Issue #1299 - comment out unused Rupture Cap.
+	//RuptureCap = WeaponDamage;
 
 	`log(`ShowVar(bIgnoreBaseDamage) @ `ShowVar(DamageTag), true, 'XCom_HitRolls');
 	`log("Weapon damage:" @ WeaponDamage @ "Potential spread:" @ DamageSpread, true, 'XCom_HitRolls');


### PR DESCRIPTION
Addendum for Issue #1299 - forgot to comment out the local variable `RuptureCap` which no longer has a use.