### PR TITLE
Make guaranteed crit abilities display as having 100% crit chance

### DIFF
--- a/X2WOTCCommunityHighlander/Src/XComGame/Classes/X2AbilityToHitCalc_StandardAim.uc
+++ b/X2WOTCCommunityHighlander/Src/XComGame/Classes/X2AbilityToHitCalc_StandardAim.uc
@@ -373,6 +373,16 @@ protected function int GetHitChance(XComGameState_Ability kAbility, AvailableTar
 		AddModifier(100, AbilityTemplate.LocFriendlyName, m_ShotBreakdown, eHit_Success, bDebugLog);
 	}
 
+	// Start Issue #1298
+	/// HL-Docs: ref:Bugfixes; issue:1298
+	/// Add 100 crit chance to guaranteed crit abilities for the purposes of UI.
+	if (bHitsAreCrits)
+	{
+		//  call the super version to bypass our check to ignore crit chance mods for guaranteed crits
+		super.AddModifier(100, AbilityTemplate.LocFriendlyName, m_ShotBreakdown, eHit_Crit, bDebugLog);
+	}
+	// End Issue #1298
+
 	// Issue #346: AddModifier(BuiltIn...Mod) block moved later in method.
 	/// HL-Docs: ref:Bugfixes; issue:346
 	/// Prevent `X2AbilityToHitCalc_StandardAim` from applying BuiltInHitMod and BuiltInCritMod against non-units.
@@ -909,6 +919,14 @@ protected function AddModifier(const int ModValue, const string ModReason, out S
 		if (ModType != eHit_Crit)             //  for a guaranteed hit, the only possible modifier is to allow for crit
 			return;
 	}
+
+	// Start Issue #1298
+	if (bHitsAreCrits)
+	{
+		if (ModType == eHit_Crit)             //  for a guaranteed crit, do not add modifiers for crit chance
+			return;
+	}
+	// End Issue #1298
 
 	super.AddModifier(ModValue, ModReason, m_ShotBreakdown, ModType, bDebugLog);
 }


### PR DESCRIPTION
Fixes #1298

# The Problem

There are two main components to `X2AbilityToHitCalc_StandardAim`, the `GetHitChance()` which is used both for hit chance preview in UI and in the second component, `InternalRollForAbilityHit()`, which does the actual hit roll. 

The `bHitsAreCrits` bool flag is not processed in `GetHitChance()` at all, only in the roll function, where it will replace `eHit_Success` hit result with `eHit_Crit`. So outside the ability description, the player has no way of knowing that the ability will crit.

Here's how it looks in-game:

![20240503003422_1](https://github.com/X2CommunityCore/X2WOTCCommunityHighlander/assets/3827377/4e585ed1-da27-43b9-a11e-4e9a5031cdfa)
![20240503003420_1](https://github.com/X2CommunityCore/X2WOTCCommunityHighlander/assets/3827377/0b11a487-3e78-41d7-bd65-942e9576d775)

# Proposed Fix

Give the `bHitsAreCrits`  the same treatment as `bGuaranteedHit`:

1. At the start of `GetHitChance()`, `super.AddModifier()` is called to add 100 to crit chance using the super function from `X2AbilityToHitCalc` class.
2. `AddModifier()` function itself in `X2AbilityToHitCalc_StandardAim` is adjusted to disallow adding crit modifiers if the `bHitsAreCrits` flag is set. 

As the result, the ability will have one and only one crit chance modifier that equals to 100, and all other crit chance modifiers, such as from flanking, will be ignored. So in-game UI for `bHitsAreCrits` abilities will always display exactly 100%.

Here's how it looks:

![20240503003043_1](https://github.com/X2CommunityCore/X2WOTCCommunityHighlander/assets/3827377/54fe46bf-9a8b-4c3e-92c2-a4e18397302d)
![20240503003040_1](https://github.com/X2CommunityCore/X2WOTCCommunityHighlander/assets/3827377/2b4ad480-2e30-452d-bae9-58e192b6a1e1)

# Addressing Concerns

This change does not alter handling of `bHitsAreCrits` in `InternalRollForAbilityHit()`, so nothing changes functionality-wise. Custom ToHitCalcs that override `GetHitChance()` or `AddModifier()` , at worst, will display incorrect crit chance, which they would already be doing in regards to `bHitsAreCrits`  abilities.

# Extended Information

Extended Information mod seems to correctly process the changed logic:

![20240503004238_1](https://github.com/X2CommunityCore/X2WOTCCommunityHighlander/assets/3827377/bca86525-5c6c-4354-92be-124ce60a8fb6)
![20240503004235_1](https://github.com/X2CommunityCore/X2WOTCCommunityHighlander/assets/3827377/81ab6671-937f-48f6-9525-c67626c86c1d)
