### PR TITLE
Prevent rupture bonus damage from being added to attack that don't deal damage

### DIFF
--- a/X2WOTCCommunityHighlander/Src/XComGame/Classes/X2Effect_ApplyWeaponDamage.uc
+++ b/X2WOTCCommunityHighlander/Src/XComGame/Classes/X2Effect_ApplyWeaponDamage.uc
@@ -967,13 +967,18 @@ simulated function int CalculateDamageAmount(const out EffectAppliedData ApplyEf
 	/// Remove the cap from the amount of bonus damage that can be added to an attack by rupture, and do not add rupture added by this attack to the attack's damage.
 	//RuptureAmount = min(kTarget.GetRupturedValue() + NewRupture, RuptureCap);
 	RuptureAmount = kTarget.GetRupturedValue();
-	// End Issue #1299
 
-	if (RuptureAmount != 0)
+	// While Rupture Cap is removed, we still want to add bonus damage from rupture only if the attack deals damage,
+	// as that was part of of the original functionality of the Rupture Cap.
+	if (WeaponDamage > 0)
 	{
-		WeaponDamage += RuptureAmount;
-		`log("Target is ruptured, increases damage by" @ RuptureAmount $", new damage:" @ WeaponDamage, true, 'XCom_HitRolls');
+		if (RuptureAmount != 0)
+		{
+			WeaponDamage += RuptureAmount;
+			`log("Target is ruptured, increases damage by" @ RuptureAmount $", new damage:" @ WeaponDamage, true, 'XCom_HitRolls');
+		}
 	}
+	// End Issue #1299
 
 	if( kSourceUnit != none)
 	{


### PR DESCRIPTION
Issue #1299

Addendum to #1330, which has removed the cap from bonus damage that can be applied to an attack by rupture, which was previously capped by the attack's base damage. This was deemed a bug, because Rupture's description says "adds +3 damage to following attacks", but in effect this can be +1 or +2 if the following attack did that much damage. 

What has escaped the consideration is that the cap also prevented bonus damage from rupture from applying at all if the damage effect ended up doing zero damage. 

Removing the cap allowed effects that normally don't do damage outside of specific circumstances, such as the Stock Miss Damage effect, to benefit from Rupture, even if the bonus damage from the Stock itself is not applied - because it was set to zero or because the weapon doesn't even have a stock equipped, presumably.