### PR TITLE
Make it so the [!] icon in the PCS tab appears only if a PCS slot is empty.

### DIFF
--- a/X2WOTCCommunityHighlander/Src/XComGame/Classes/UIArmory_MainMenu.uc
+++ b/X2WOTCCommunityHighlander/Src/XComGame/Classes/UIArmory_MainMenu.uc
@@ -177,14 +177,16 @@ simulated function UpdateData()
 
 	if( bEnableImplantsOption )
 	{
-		//Start issue #1348
 		/// HL-Docs: ref:Bugfixes; issue:1348
-		/// Add additional check so NeedsAttention doesn't trigger if a soldier's PCS slots are full with user equipped PCSs already.
+		/// Display the "needs attention" icon on the PCS button only if the soldier has an empty PCS slot.
 		if( PCSAvailabilityData.bHasNeurochipImplantsInInventory && PCSAvailabilityData.bHasCombatSimsSlotsAvailable && PCSAvailabilityData.bHasEmptyCombatSimSlot) 
+    {
 			PCSButton.NeedsAttention(true);
+    }
 		else
+    {
 			PCSButton.NeedsAttention(false);
-		// End Issue #1348
+    }
 	} 
 	else
 	{

--- a/X2WOTCCommunityHighlander/Src/XComGame/Classes/UIArmory_MainMenu.uc
+++ b/X2WOTCCommunityHighlander/Src/XComGame/Classes/UIArmory_MainMenu.uc
@@ -177,10 +177,14 @@ simulated function UpdateData()
 
 	if( bEnableImplantsOption )
 	{
-		if( PCSAvailabilityData.bHasNeurochipImplantsInInventory && PCSAvailabilityData.bHasCombatSimsSlotsAvailable && PCSAvailabilityData.bNoCombatSimsEquipped)
+		//Start issue #1348
+		/// HL-Docs: ref:Bugfixes; issue:1348
+		/// Add additional check so NeedsAttention doesn't trigger if a soldier's PCS slots are full with user equipped PCSs already.
+		if( PCSAvailabilityData.bHasNeurochipImplantsInInventory && PCSAvailabilityData.bHasCombatSimsSlotsAvailable && PCSAvailabilityData.bHasEmptyCombatSimSlot) 
 			PCSButton.NeedsAttention(true);
 		else
 			PCSButton.NeedsAttention(false);
+		// End Issue #1348
 	} 
 	else
 	{

--- a/X2WOTCCommunityHighlander/Src/XComGame/Classes/UIArmory_MainMenu.uc
+++ b/X2WOTCCommunityHighlander/Src/XComGame/Classes/UIArmory_MainMenu.uc
@@ -177,7 +177,7 @@ simulated function UpdateData()
 
 	if( bEnableImplantsOption )
 	{
-		if( PCSAvailabilityData.bHasNeurochipImplantsInInventory && PCSAvailabilityData.bHasCombatSimsSlotsAvailable)
+		if( PCSAvailabilityData.bHasNeurochipImplantsInInventory && PCSAvailabilityData.bHasCombatSimsSlotsAvailable && PCSAvailabilityData.bNoCombatSimsEquipped)
 			PCSButton.NeedsAttention(true);
 		else
 			PCSButton.NeedsAttention(false);

--- a/X2WOTCCommunityHighlander/Src/XComGame/Classes/UIArmory_MainMenu.uc
+++ b/X2WOTCCommunityHighlander/Src/XComGame/Classes/UIArmory_MainMenu.uc
@@ -179,7 +179,7 @@ simulated function UpdateData()
 	{
 		/// HL-Docs: ref:Bugfixes; issue:1348
 		/// Display the "needs attention" icon on the PCS button only if the soldier has an empty PCS slot.
-		if( PCSAvailabilityData.bHasNeurochipImplantsInInventory && PCSAvailabilityData.bHasCombatSimsSlotsAvailable && PCSAvailabilityData.bHasEmptyCombatSimSlot) 
+		if( PCSAvailabilityData.bHasNeurochipImplantsInInventory && PCSAvailabilityData.bHasEmptyCombatSimSlot) 
     {
 			PCSButton.NeedsAttention(true);
     }

--- a/X2WOTCCommunityHighlander/Src/XComGame/Classes/UIArmory_MainMenu.uc
+++ b/X2WOTCCommunityHighlander/Src/XComGame/Classes/UIArmory_MainMenu.uc
@@ -179,7 +179,7 @@ simulated function UpdateData()
 	{
 		/// HL-Docs: ref:Bugfixes; issue:1348
 		/// Display the "needs attention" icon on the PCS button only if the soldier has an empty PCS slot.
-		if( PCSAvailabilityData.bHasNeurochipImplantsInInventory && PCSAvailabilityData.bHasEmptyCombatSimSlot) 
+		if (PCSAvailabilityData.bHasNeurochipImplantsInInventory && PCSAvailabilityData.bHasEmptyCombatSimSlot) 
     {
 			PCSButton.NeedsAttention(true);
     }

--- a/X2WOTCCommunityHighlander/Src/XComGame/Classes/UIUtilities_Strategy.uc
+++ b/X2WOTCCommunityHighlander/Src/XComGame/Classes/UIUtilities_Strategy.uc
@@ -16,6 +16,7 @@ struct TWeaponUpgradeAvailabilityData
 	var bool bHasWeaponUpgrades;
 	var bool bHasWeaponUpgradeSlotsAvailable;
 	var bool bCanWeaponBeUpgraded;
+	var bool bNoCombatSimsEquipped;
 };
 
 struct TPCSAvailabilityData
@@ -1717,6 +1718,7 @@ simulated static function GetPCSAvailability(XComGameState_Unit Unit, out TPCSAv
 	PCSAvailabilityData.bHasAchievedCombatSimsRank = Unit.IsSufficientRankToEquipPCS();
 	PCSAvailabilityData.bHasGTS = XComHQ.HasFacilityByName('OfficerTrainingSchool');
 	PCSAvailabilityData.bCanEquipCombatSims = (AvailableSlots > 0);
+	PCSAvailabilityData.bNoCombatSimsEquipped = ( AvailableSlots > EquippedImplants.Length );
 }
 
 // Used in UIArmory_MainMenu and UIArmory_Promotion

--- a/X2WOTCCommunityHighlander/Src/XComGame/Classes/UIUtilities_Strategy.uc
+++ b/X2WOTCCommunityHighlander/Src/XComGame/Classes/UIUtilities_Strategy.uc
@@ -25,7 +25,7 @@ struct TPCSAvailabilityData
 	var bool bHasNeurochipImplantsInInventory;
 	var bool bHasCombatSimsSlotsAvailable;
 	var bool bCanEquipCombatSims;
-	var bool bHasEmptyCombatSimSlot; // Variable declaration for Issue #1348
+	var bool bHasEmptyCombatSimSlot; // Variable for Issue #1348
 };
 
 var localized string m_strCreditsPrefix;
@@ -1718,7 +1718,7 @@ simulated static function GetPCSAvailability(XComGameState_Unit Unit, out TPCSAv
 	PCSAvailabilityData.bHasAchievedCombatSimsRank = Unit.IsSufficientRankToEquipPCS();
 	PCSAvailabilityData.bHasGTS = XComHQ.HasFacilityByName('OfficerTrainingSchool');
 	PCSAvailabilityData.bCanEquipCombatSims = (AvailableSlots > 0);
-	PCSAvailabilityData.bHasEmptyCombatSimSlot = ( AvailableSlots > EquippedImplants.Length ); // Same as bHasCombatSimsSlotsAvailable but ignoring Reuse PCS research for Issue #1348
+	PCSAvailabilityData.bHasEmptyCombatSimSlot = ( AvailableSlots > EquippedImplants.Length ); // Issue #1348 - same as bHasCombatSimsSlotsAvailable, but without Reuse PCS flag.
 }
 
 // Used in UIArmory_MainMenu and UIArmory_Promotion

--- a/X2WOTCCommunityHighlander/Src/XComGame/Classes/UIUtilities_Strategy.uc
+++ b/X2WOTCCommunityHighlander/Src/XComGame/Classes/UIUtilities_Strategy.uc
@@ -16,7 +16,6 @@ struct TWeaponUpgradeAvailabilityData
 	var bool bHasWeaponUpgrades;
 	var bool bHasWeaponUpgradeSlotsAvailable;
 	var bool bCanWeaponBeUpgraded;
-	var bool bNoCombatSimsEquipped;
 };
 
 struct TPCSAvailabilityData
@@ -26,6 +25,7 @@ struct TPCSAvailabilityData
 	var bool bHasNeurochipImplantsInInventory;
 	var bool bHasCombatSimsSlotsAvailable;
 	var bool bCanEquipCombatSims;
+	var bool bHasEmptyCombatSimSlot; // Variable declaration for Issue #1348
 };
 
 var localized string m_strCreditsPrefix;
@@ -1718,7 +1718,7 @@ simulated static function GetPCSAvailability(XComGameState_Unit Unit, out TPCSAv
 	PCSAvailabilityData.bHasAchievedCombatSimsRank = Unit.IsSufficientRankToEquipPCS();
 	PCSAvailabilityData.bHasGTS = XComHQ.HasFacilityByName('OfficerTrainingSchool');
 	PCSAvailabilityData.bCanEquipCombatSims = (AvailableSlots > 0);
-	PCSAvailabilityData.bNoCombatSimsEquipped = ( AvailableSlots > EquippedImplants.Length );
+	PCSAvailabilityData.bHasEmptyCombatSimSlot = ( AvailableSlots > EquippedImplants.Length ); // Same as bHasCombatSimsSlotsAvailable but ignoring Reuse PCS research for Issue #1348
 }
 
 // Used in UIArmory_MainMenu and UIArmory_Promotion


### PR DESCRIPTION
Fixes #1348 
For the weapon mods the little [!] icon appears in a soldier's list only if there's an empty slot for a mod.
The same isn't true for the PCS tab. After researching "Interchangeable PCSs" the orange [!] will remain there permanently for every soldier that can equip PCSs.
This isn't exactly a bug but it's not useful to have the game constantly tell the player that they can swap a soldier's equipped PCS with one that might even be worse, just because there is an unused PCS in the player's inventory.