### PR TITLE
Proposed fix for the persistent "Low Intel" warning after contacting all regions.

### DIFF
--- a/X2WOTCCommunityHighlander/Src/XComGame/Classes/XComHQPresentationLayer.uc
+++ b/X2WOTCCommunityHighlander/Src/XComGame/Classes/XComHQPresentationLayer.uc
@@ -531,6 +531,7 @@ simulated function DisplayWarningPopups()
 	local XComGameState_HeadquartersXCom XComHQ;
 	local TDateTime StartDateTime, CurrentTime;
 	local int MinStaffRequired, NumStaff, MonthsDifference;
+	local array<XComGameState_WorldRegion> AllRegions; // For Issue #1347 
 
 	XComHQ = XComGameState_HeadquartersXCom(`XCOMHISTORY.GetSingleGameStateObjectForClass(class'XComGameState_HeadquartersXCom'));
 
@@ -543,7 +544,9 @@ simulated function DisplayWarningPopups()
 	{
 		// Start Issue #1347
 		// Show warning only if there are still regions left to be contacted.
-		if(XComHQ.GetCurrentResContacts() < class'X2StrategyElement_DefaultMissionSources'.static.GetAllRegions().Length)
+		AllRegions = class'X2StrategyElement_DefaultMissionSources'.static.GetAllRegions();
+
+		if(XComHQ.GetCurrentResContacts() < AllRegions.Length)
 		{
 			UILowIntel();
 		}


### PR DESCRIPTION
Fixes #1347 
The "Low Intel" warning shows up if your total intel is less than the contact cost of the next closest region. But if you've contacted all regions the cost defaults to 9999 and you get the warning despite not having more regions to contact. I've added an additional check to make sure your current resistance contacts aren't equal to the total number of regions that can be contacted (probably 16 but I didn't want to hardcode it) before the warning is displayed.