### PR TITLE
Properly trigger unit concealment loss when bForceNoSquadConcealment flag is set instead of not concealing in the first place.

### DIFF
--- a/X2WOTCCommunityHighlander/Src/XComGame/Classes/X2TacticalGameRuleset.uc
+++ b/X2WOTCCommunityHighlander/Src/XComGame/Classes/X2TacticalGameRuleset.uc
@@ -1271,17 +1271,19 @@ function ApplyStartOfMatchConditions()
 	{		
 		// Start Issue #1319
 		/// HL-Docs: ref:Bugfixes; issue:1319
-		/// If concealment is forced off using BattleData's bForceNoSquadConcealment flag, trigger the SquadConcealmentBroken event on mission start.
-		/// In the base game, only the 'High Alert' dark event sets this flag. Firing the event manually fixes the issue on supply extraction missions with High Alert active,
-		/// where ADVENT never starts collecting any crates, since mission kismet triggers the start of crate collection when the SquadConcealmentBroken event is fired.
+		/// If mission start concealment is disabled by `bForceNoSquadConcealment` flag in BattleData, 
+		/// trigger the `SquadConcealmentBroken` event on mission start. 
+		/// In the base game, this flag is set only by the "High Alert" Dark Event.
+		/// Triggering the event fixes the bug on Supply Extraction missions,
+		/// where ADVENT never starts collecting supply crates if XCOM starts unconcealed,
+		/// because the mission kismet starts the crate collection when the `SquadConcealmentBroken` event is triggered.
 		if (BattleDataState.bForceNoSquadConcealment)
 		{
 			foreach History.IterateByClassType(class'XComGameState_Player', PlayerState)
 			{
-				if( PlayerState.GetTeam() == eTeam_XCom )
+				if (PlayerState.GetTeam() == eTeam_XCom)
 				{
-					ConcealmentBrokenGameState = class'XComGameStateContext_ChangeContainer'.static.CreateChangeState("Silent conceal break");
-					// Trigger the concealment broken event
+					ConcealmentBrokenGameState = class'XComGameStateContext_ChangeContainer'.static.CreateChangeState("Break Mission Start Concealment");
 					`XEVENTMGR.TriggerEvent('SquadConcealmentBroken', PlayerState, PlayerState, ConcealmentBrokenGameState);
 					`TACTICALRULES.SubmitGameState(ConcealmentBrokenGameState);				
 				}


### PR DESCRIPTION
Fixes #1319 

This is a preliminary fix for review & likely will need some changes but just creating a PR for review / conversation.

The code adjustment fixes the problem by starting the squad in concealment and then breaking it if the dark event / battledata flag bForceNoSquadConcealment is set, instead of not setting concealment on the squad in the first place. It works properly with phantom & reaper shadow but at the moment it creates a lot of flyovers on mission start which I suspect which looks a bit messy & I suspect will prevent this from being merged directly - I haven't sorted the comments out yet either!

Basically, on missions where the squad starts concealed and high alert is active you now get the following situation:
"High Alert Flyover"
"Concealed Flyover"
"Revealed Flyover"
(Optional if you have a ranger) "Phantom Ranger Concealed Flyover"

Normal mission start flyovers are not affected.

It would be ideal if we could come up with a way to suppress the visualiser when we use the SetSquadConcealment function but I don't really know how to do that at this point. Advice welcome!