### PR TITLE
Prevent Low Intel warnings if all regions are contacted

### DIFF
--- a/X2WOTCCommunityHighlander/Src/XComGame/Classes/UIUtilities_Strategy.uc
+++ b/X2WOTCCommunityHighlander/Src/XComGame/Classes/UIUtilities_Strategy.uc
@@ -1915,6 +1915,9 @@ simulated static function int GetMinimumContactCost()
 	local XComGameState_WorldRegion RegionState;
 	local int MinContactCost, RegionContactCost;
 
+	// Variable for Issue #1347
+	local bool bRegionContactCostFound;
+
 	History = `XCOMHISTORY;
 	MinContactCost = 9999;
 
@@ -1926,11 +1929,22 @@ simulated static function int GetMinimumContactCost()
 			if (RegionContactCost < MinContactCost)
 			{
 				MinContactCost = RegionContactCost;
+
+				// Single line for Issue #1347
+				bRegionContactCostFound = true;
 			}
 		}
 	}
 
-	return MinContactCost;
+	// Start Issue #1347
+	/// HL-Docs: ref:Bugfixes; issue:1347
+	/// Make `GetMinimumContactCost()` return zero when there are no more uncontacted regions to prevent Low Intel warnings.
+	if (bRegionContactCostFound)
+	{
+		return MinContactCost;
+	}
+	return 0;
+	// End Issue #1347
 }
 
 simulated static function int GetUnitCurrentHealth(XComGameState_Unit UnitState, optional bool bUseLowestHP)


### PR DESCRIPTION
Fixes #1347

Alternative implementation of #1346, which addressed specifically the Low Intel popup, but not Low Intel icon in the lower left corner of the Geoscape, and probably more UI elements that make use of `class'UIUtilities_Strategy'.static.GetMinimumContactCost()` function.

I tested and it works as intended at least for the post-mission popup and the Geoscape icon.