### PR TITLE
Fix X2Effect_Brutal by using GetCurrentStat() instead of GetBaseStat()

### DIFF
--- a/X2WOTCCommunityHighlander/Src/XComGame/Classes/X2Effect_Brutal.uc
+++ b/X2WOTCCommunityHighlander/Src/XComGame/Classes/X2Effect_Brutal.uc
@@ -1,0 +1,42 @@
+class X2Effect_Brutal extends X2Effect;
+
+var localized string WillChangeMessage;
+var int WillMod;
+
+simulated protected function OnEffectAdded(const out EffectAppliedData ApplyEffectParameters, XComGameState_BaseObject kNewTargetState, XComGameState NewGameState, XComGameState_Effect NewEffectState)
+{
+	local XComGameState_Unit TargetUnit;
+	local int CurrentWill;
+
+	TargetUnit = XComGameState_Unit(kNewTargetState);
+	if (TargetUnit != none)
+	{
+		CurrentWill = TargetUnit.GetBaseStat(eStat_Will);
+		if (CurrentWill + WillMod <= 0)
+			TargetUnit.SetCurrentStat(eStat_Will, 1);
+		else
+			TargetUnit.SetCurrentStat(eStat_Will, CurrentWill + WillMod);
+	}
+}
+
+simulated function AddX2ActionsForVisualization(XComGameState VisualizeGameState, out VisualizationActionMetadata ActionMetadata, const name EffectApplyResult)
+{
+	local XComGameState_Unit OldUnit, NewUnit;
+	local X2Action_PlaySoundAndFlyOver SoundAndFlyOver;
+	local int WillChange;
+	local string Msg;
+
+	OldUnit = XComGameState_Unit(ActionMetadata.StateObject_OldState);
+	NewUnit = XComGameState_Unit(ActionMetadata.StateObject_NewState);
+
+	if (OldUnit != none && NewUnit != None)
+	{
+		WillChange = NewUnit.GetBaseStat(eStat_Will) - OldUnit.GetBaseStat(eStat_Will);
+		if (WillChange != 0)
+		{
+			SoundAndFlyOver = X2Action_PlaySoundAndFlyOver(class'X2Action_PlaySoundAndFlyOver'.static.AddToVisualizationTree(ActionMetadata, VisualizeGameState.GetContext(), false, ActionMetadata.LastActionAdded));
+			Msg = Repl(default.WillChangeMessage, "<WillChange/>", WillChange);
+			SoundAndFlyOver.SetSoundAndFlyOverParameters(None, Msg, '', eColor_Bad);
+		}
+	}
+}

--- a/X2WOTCCommunityHighlander/Src/XComGame/Classes/X2Effect_Brutal.uc
+++ b/X2WOTCCommunityHighlander/Src/XComGame/Classes/X2Effect_Brutal.uc
@@ -11,7 +11,10 @@ simulated protected function OnEffectAdded(const out EffectAppliedData ApplyEffe
 	TargetUnit = XComGameState_Unit(kNewTargetState);
 	if (TargetUnit != none)
 	{
-		CurrentWill = TargetUnit.GetBaseStat(eStat_Will);
+		/// HL-Docs: ref:Bugfixes; issue:1389
+		/// Make `X2Effect_Brutal` use unit's current Will instead of base Will so it can properly reduce and display it.
+		// Single line for Issue #1389 - use GetCurrentStat() instead of GetBaseStat() to reduce will.
+		CurrentWill = TargetUnit.GetCurrentStat(eStat_Will);
 		if (CurrentWill + WillMod <= 0)
 			TargetUnit.SetCurrentStat(eStat_Will, 1);
 		else
@@ -31,7 +34,8 @@ simulated function AddX2ActionsForVisualization(XComGameState VisualizeGameState
 
 	if (OldUnit != none && NewUnit != None)
 	{
-		WillChange = NewUnit.GetBaseStat(eStat_Will) - OldUnit.GetBaseStat(eStat_Will);
+		// Single line for Issue #1389 - use GetCurrentStat() instead of GetBaseStat() to display will loss.
+		WillChange = NewUnit.GetCurrentStat(eStat_Will) - OldUnit.GetCurrentStat(eStat_Will);
 		if (WillChange != 0)
 		{
 			SoundAndFlyOver = X2Action_PlaySoundAndFlyOver(class'X2Action_PlaySoundAndFlyOver'.static.AddToVisualizationTree(ActionMetadata, VisualizeGameState.GetContext(), false, ActionMetadata.LastActionAdded));

--- a/X2WOTCCommunityHighlander/X2WOTCCommunityHighlander.x2proj
+++ b/X2WOTCCommunityHighlander/X2WOTCCommunityHighlander.x2proj
@@ -1042,6 +1042,9 @@
     <Content Include="Src\XComGame\Classes\XGWeapon.uc">
       <SubType>Content</SubType>
     </Content>
+    <Content Include="Src\XComGame\Classes\X2Effect_Brutal.uc">
+      <SubType>Content</SubType>
+    </Content>
   </ItemGroup>
   <PropertyGroup>
     <SolutionRoot>$(MSBuildProjectDirectory)\..\</SolutionRoot>


### PR DESCRIPTION
Fixes #1389

Fixes Brutal effect by using GetCurrentStat() instead of GetBaseStat().