### PR TITLE
REOPENED - Integrate Revival Protocol Fixes in CHL #1237 

### DIFF
--- a/X2WOTCCommunityHighlander/Src/XComGame/Classes/X2Ability_SpecialistAbilitySet.uc
+++ b/X2WOTCCommunityHighlander/Src/XComGame/Classes/X2Ability_SpecialistAbilitySet.uc
@@ -717,6 +717,8 @@ static function X2AbilityTemplate RevivalProtocol()
 	local X2AbilityCost_ActionPoints        ActionPointCost;
 	local X2AbilityCost_Charges             ChargeCost;
 	local X2AbilityCharges                  Charges;
+	// Variable for Issue #1235
+	local X2Effect_RestoreActionPoints		RestoreAPEffect; 
 
 	`CREATE_X2ABILITY_TEMPLATE(Template, 'RevivalProtocol');
 
@@ -737,12 +739,25 @@ static function X2AbilityTemplate RevivalProtocol()
 
 	Template.AbilityShooterConditions.AddItem(default.LivingShooterProperty);
 	Template.AddShooterEffectExclusions();
-
+	
+	// Start Issue #1235
+	/// HL-Docs: ref:Bugfixes; issue:1235
+	/// Fixes the specialist's Revival Protocol ability to match the intended base-game behaviour outlined in the localization - In summary:
+	/// 1. Adjusts the ability targetting conditions to allow it to target allied (e.g. Resistance) soldiers
+	/// 2. Adds a new condition to prevent the restoration of action points to disoriented units
+	/// 3. Ensures the ability causes the unit to recover from the 'stunned' status effect properly
+	 
 	Template.AbilityTargetConditions.AddItem(new class'X2Condition_RevivalProtocol');
 
-	Template.AddTargetEffect(RemoveAdditionalEffectsForRevivalProtocolAndRestorativeMist());
-	Template.AddTargetEffect(new class'X2Effect_RestoreActionPoints');      //  put the unit back to full actions
+	Template.AddTargetEffect(RemoveAdditionalEffectsForRevivalProtocolAndRestorativeMist());	
 
+	Template.AddTargetEffect(class'X2StatusEffects'.static.CreateStunRecoverEffect());
+	// Restore APs on the unit only if the new X2Condition is met
+	RestoreAPEffect = new class'X2Effect_RestoreActionPoints'; 
+	RestoreAPEffect.TargetConditions.AddItem(new class'X2Condition_RevivalProtocolAP');
+	Template.AddTargetEffect(RestoreAPEffect);
+	// End Issue #1235
+	
 	Template.AbilityTriggers.AddItem(default.PlayerInputTrigger);
 
 	Template.IconImage = "img:///UILibrary_PerkIcons.UIPerk_revivalprotocol";

--- a/X2WOTCCommunityHighlander/Src/XComGame/Classes/X2Condition_RevivalProtocol.uc
+++ b/X2WOTCCommunityHighlander/Src/XComGame/Classes/X2Condition_RevivalProtocol.uc
@@ -1,0 +1,50 @@
+//---------------------------------------------------------------------------------------
+//  FILE:    X2Condition_RevivalProtocol.uc
+//  AUTHOR:  Joshua Bouscher
+//           
+//---------------------------------------------------------------------------------------
+//  Copyright (c) 2016 Firaxis Games, Inc. All rights reserved.
+//---------------------------------------------------------------------------------------
+class X2Condition_RevivalProtocol extends X2Condition;
+
+event name CallMeetsCondition(XComGameState_BaseObject kTarget)
+{
+	local XComGameState_Unit TargetUnit;
+
+	TargetUnit = XComGameState_Unit(kTarget);
+	if (TargetUnit == none)
+		return 'AA_NotAUnit';
+
+	if (!TargetUnit.GetMyTemplate().bCanBeRevived || TargetUnit.IsBeingCarried() )
+		return 'AA_UnitIsImmune';
+	// Add stunned condition for Issue #1235
+		if (TargetUnit.IsPanicked() || TargetUnit.IsUnconscious() || TargetUnit.IsDisoriented() || TargetUnit.IsDazed() || TargetUnit.IsStunned())
+		return 'AA_Success';
+
+	return 'AA_UnitIsNotImpaired';
+}
+
+event name CallMeetsConditionWithSource(XComGameState_BaseObject kTarget, XComGameState_BaseObject kSource)
+{
+	local XComGameState_Unit SourceUnit, TargetUnit;
+	// Start Issue #1235
+	/// Add XCGS_Players for source and target teams
+	local XComGameState_Player SourceTeam, TargetTeam;
+
+	SourceUnit = XComGameState_Unit(kSource);
+	TargetUnit = XComGameState_Unit(kTarget);
+
+	/// Get source & target teams
+	SourceTeam = XComGameState_Player(`XCOMHISTORY.GetGameStateForObjectID(SourceUnit.GetAssociatedPlayerID()));
+	TargetTeam = XComGameState_Player(`XCOMHISTORY.GetGameStateForObjectID(TargetUnit.GetAssociatedPlayerID()));
+
+	if (SourceUnit == none || TargetUnit == none)
+		return 'AA_NotAUnit';
+
+	/// If the source team is not an enemy of the target team then revival protocol can target them
+	if (!SourceTeam.IsEnemyPlayer(TargetTeam))
+		return 'AA_Success';
+	// End Issue #1235
+
+	return 'AA_UnitIsHostile';
+}

--- a/X2WOTCCommunityHighlander/Src/XComGame/Classes/X2Condition_RevivalProtocolAP.uc
+++ b/X2WOTCCommunityHighlander/Src/XComGame/Classes/X2Condition_RevivalProtocolAP.uc
@@ -1,0 +1,38 @@
+class X2Condition_RevivalProtocolAP extends X2Condition;
+
+// Start Issue# 1235
+/// This condition is used for determining the conditions under which revival protocol and restorative mist
+/// grant action points to units - this condition is necessarily different to the targetting conditions used in X2Condition_RevivialProtocol
+/// Specifically, disoriented units should not be granted extra action points when revival protocol is used on them.
+/// Action points will also be restored to other friendly units who are now valid targets for the protocols.
+
+event name CallMeetsCondition(XComGameState_BaseObject kTarget)
+{
+	local XComGameState_Unit TargetUnit;
+
+	TargetUnit = XComGameState_Unit(kTarget);
+	if(TargetUnit != none)
+	{ 
+		if (TargetUnit.IsPanicked() || TargetUnit.IsUnconscious() || TargetUnit.IsDazed())
+			return 'AA_Success';
+	}
+
+    return 'AA_UnitIsNotImpaired';
+}
+
+event name CallMeetsConditionWithSource(XComGameState_BaseObject kTarget, XComGameState_BaseObject kSource)
+{
+	local XComGameState_Unit SourceUnit, TargetUnit;
+
+	SourceUnit = XComGameState_Unit(kSource);
+	TargetUnit = XComGameState_Unit(kTarget);
+
+	if (SourceUnit == none || TargetUnit == none)
+		return 'AA_NotAUnit';	
+
+	if (!SourceUnit.IsEnemyUnit(TargetUnit))
+			return 'AA_Success';
+		
+	return 'AA_UnitIsHostile';
+}
+// End Issue #1235

--- a/X2WOTCCommunityHighlander/X2WOTCCommunityHighlander.x2proj
+++ b/X2WOTCCommunityHighlander/X2WOTCCommunityHighlander.x2proj
@@ -586,6 +586,12 @@
     <Content Include="Src\XComGame\Classes\X2ChosenActionTemplate.uc">
       <SubType>Content</SubType>
     </Content>
+    <Content Include="Src\XComGame\Classes\X2Condition_RevivalProtocol.uc">
+      <SubType>Content</SubType>
+    </Content>
+    <Content Include="Src\XComGame\Classes\X2Condition_RevivalProtocolAP.uc">
+      <SubType>Content</SubType>
+    </Content>
     <Content Include="Src\XComGame\Classes\X2Condition_StasisLanceTarget.uc">
       <SubType>Content</SubType>
     </Content>


### PR DESCRIPTION
Fixes #1235

Reopening accidentally closed request.

Adds custom X2Condition to the RestoreActionPoints effect of Revival Protocol to prevent it from restoring APs to disoriented units. Updated the ability targetting condition to allow revival protocol to target stunned units, remove the stunned status and restore APs properly. Also integrated the additional targeting condition from RMs mod which allows the ability to target resistance soldiers. Discussion to be had over whether this part is required/necessary. 

Still requires finessing & testing before merge.