### PR TITLE
Set a unit's lowest HP value to 1 if they activate sustain

### DIFF
--- a/X2WOTCCommunityHighlander/Src/XComGame/Classes/X2Effect_Sustain.uc
+++ b/X2WOTCCommunityHighlander/Src/XComGame/Classes/X2Effect_Sustain.uc
@@ -1,0 +1,76 @@
+class X2Effect_Sustain extends X2Effect_Persistent config(GameData_SoldierSkills);
+
+struct SustainTriggerUnitCheck
+{
+	var name UnitType;
+	var int PercentChance;
+};
+
+var config array<SustainTriggerUnitCheck> SUSTAINTRIGGERUNITCHECK_ARRAY;
+
+var privatewrite name SustainUsed;
+var privatewrite name SustainEvent, SustainTriggeredEvent;
+
+function bool PreDeathCheck(XComGameState NewGameState, XComGameState_Unit UnitState, XComGameState_Effect EffectState)
+{
+	local X2EventManager EventMan;
+	local UnitValue SustainValue;
+	local int Index, PercentChance, RandRoll;
+
+	if( !UnitState.IsAbleToAct(true) )
+	{
+		// Stunned units may not go into Sustain
+		return false;
+	}
+
+	if (UnitState.GetUnitValue(default.SustainUsed, SustainValue))
+	{
+		if (SustainValue.fValue > 0)
+			return false;
+	}
+
+	Index = default.SUSTAINTRIGGERUNITCHECK_ARRAY.Find('UnitType', UnitState.GetMyTemplateName());
+
+	// If the Unit Type is not in the array, then it always triggers sustain
+	if (Index != INDEX_NONE)
+	{
+		PercentChance = default.SUSTAINTRIGGERUNITCHECK_ARRAY[Index].PercentChance;
+
+		RandRoll = `SYNC_RAND(100);
+		if (RandRoll >= PercentChance)
+		{
+			// RandRoll is greater or equal to the percent chance, so sustain failed
+			return false;
+		}
+	}
+
+	UnitState.SetUnitFloatValue(default.SustainUsed, 1, eCleanup_BeginTactical);
+	UnitState.SetCurrentStat(eStat_HP, 1);
+	EventMan = `XEVENTMGR;
+	EventMan.TriggerEvent(default.SustainEvent, UnitState, UnitState, NewGameState);
+	return true;
+}
+
+function bool PreBleedoutCheck(XComGameState NewGameState, XComGameState_Unit UnitState, XComGameState_Effect EffectState)
+{
+	return PreDeathCheck(NewGameState, UnitState, EffectState);
+}
+
+function RegisterForEvents(XComGameState_Effect EffectGameState)
+{
+	local XComGameState_Unit UnitState;
+	local X2EventManager EventMan;
+	local Object EffectObj;
+
+	UnitState = XComGameState_Unit(`XCOMHISTORY.GetGameStateForObjectID(EffectGameState.ApplyEffectParameters.TargetStateObjectRef.ObjectID));
+	EventMan = `XEVENTMGR;
+	EffectObj = EffectGameState;
+	EventMan.RegisterForEvent(EffectObj, default.SustainTriggeredEvent, class'XComGameState_Effect'.static.SustainActivated, ELD_OnStateSubmitted, , UnitState);
+}
+
+DefaultProperties
+{
+	SustainUsed = "SustainUsed"
+	SustainEvent = "SustainTriggered"
+	SustainTriggeredEvent = "SustainSuccess"
+}

--- a/X2WOTCCommunityHighlander/Src/XComGame/Classes/X2Effect_Sustain.uc
+++ b/X2WOTCCommunityHighlander/Src/XComGame/Classes/X2Effect_Sustain.uc
@@ -46,6 +46,11 @@ function bool PreDeathCheck(XComGameState NewGameState, XComGameState_Unit UnitS
 
 	UnitState.SetUnitFloatValue(default.SustainUsed, 1, eCleanup_BeginTactical);
 	UnitState.SetCurrentStat(eStat_HP, 1);
+
+	/// HL-Docs: ref:Bugfixes; issue:1404
+	/// Update unit's lowest HP value when sustain activates since it wasn't being set properly before.
+	UnitState.LowestHP = 1;
+
 	EventMan = `XEVENTMGR;
 	EventMan.TriggerEvent(default.SustainEvent, UnitState, UnitState, NewGameState);
 	return true;

--- a/X2WOTCCommunityHighlander/X2WOTCCommunityHighlander.x2proj
+++ b/X2WOTCCommunityHighlander/X2WOTCCommunityHighlander.x2proj
@@ -625,6 +625,9 @@
     <Content Include="Src\XComGame\Classes\X2Effect_LaserSight.uc">
       <SubType>Content</SubType>
     </Content>
+    <Content Include="Src\XComGame\Classes\X2Effect_Sustain.uc">
+      <SubType>Content</SubType>
+    </Content>
     <Content Include="Src\XComGame\Classes\X2EncyclopediaTemplate.uc">
       <SubType>Content</SubType>
     </Content>


### PR DESCRIPTION
Fixes issue #1404.

LW also needed to do this for its Emergency Life Support PCS in it's own PreDeathCheck function.

![image](https://github.com/user-attachments/assets/b3a3fd00-1af6-42dd-8abe-3957947ef134)
