### PR TITLE
Fix PR1401 - Issue with native variable declaration

### DIFF
--- a/X2WOTCCommunityHighlander/Config/XComGame.ini
+++ b/X2WOTCCommunityHighlander/Config/XComGame.ini
@@ -287,3 +287,6 @@ iMixedCharacterPoolChance = 50
 ; Uncomment the following line to disable Aim Assist.
 ; bDisableAimAssist = true
 
+; Issue #1400 - Uncomment to force 24h clock and/or addition of a leading zero to the hours (e.g. to display 03:45 instead of 3:45 on the geoscape)
+;bForce24hClock = true
+;bForce24hClockLeadingZero = true

--- a/X2WOTCCommunityHighlander/Config/XComGameData.ini
+++ b/X2WOTCCommunityHighlander/Config/XComGameData.ini
@@ -7,7 +7,3 @@
 ;+DEBUG_SecondWaveOptions="BetaStrike"
 ;;;
 
-[XComGame.X2StrategyGameRulesetDataStructures]
-; Issue #1400 - Uncomment to force 24h clock and/or addition of a leading zero to the hours (e.g. to display 03:45 instead of 3:45 on the geoscape)
-;bForce24hClock = true
-;bForce24hClockLeadingZero = true

--- a/X2WOTCCommunityHighlander/Src/XComGame/Classes/CHHelpers.uc
+++ b/X2WOTCCommunityHighlander/Src/XComGame/Classes/CHHelpers.uc
@@ -257,6 +257,9 @@ var config bool bUseMinDamageForUnitFlagPreview;
 // Variable for Issue #1228 - disables Aim Assist.
 var config bool bDisableAimAssist;
 
+// Variables for Issue #1400 - forces 24h clock regardless of locale
+var config bool bForce24hClock;
+var config bool bForce24hclockLeadingZero;
 
 // Start Issue #885
 enum EHLDelegateReturn

--- a/X2WOTCCommunityHighlander/Src/XComGame/Classes/X2StrategyGameRulesetDataStructures.uc
+++ b/X2WOTCCommunityHighlander/Src/XComGame/Classes/X2StrategyGameRulesetDataStructures.uc
@@ -1084,9 +1084,6 @@ var config int START_DAY;
 var config int START_MONTH;
 var config int START_YEAR;
 
-// Single Line for Issue #1400
-var config bool bForce24hClock;
-var config bool bForce24hclockLeadingZero;
 // Intro movie narrative moment
 var config string IntroMovie;
 
@@ -1574,7 +1571,7 @@ static function GetTimeStringSeparated(TDateTime kDateTime, out string Hours, ou
 	/// Allow forcing the 24h clock independently of locale and add an option to display leading zeroes for military-style time - e.g. 03:41 instead of 3:41
 
 	// INT and ESN use the 12 hour clock for events, checked with Loc 12/15/2015. -bsteiner 
-	if( !default.bForce24hclock && (Lang == "INT" || Lang == "ESN"))
+	if( !class'CHHelpers'.default.bForce24hclock && (Lang == "INT" || Lang == "ESN"))
 	{		
 		// AM
 		if( iHour < 12 )
@@ -1608,7 +1605,7 @@ static function GetTimeStringSeparated(TDateTime kDateTime, out string Hours, ou
 		Minutes = string(GetMinute(kDateTime));
 	}
 
-	if( default.bForce24hClockLeadingZero && GetHour(kDateTime) < 10 )
+	if( class'CHHelpers'.default.bForce24hClockLeadingZero && GetHour(kDateTime) < 10 )
 	{
 		Hours = "0"$GetHour(kDateTime);
 	}


### PR DESCRIPTION
Fixes an issue with PR #1401 (Additional variable declaration on native class) by moving the offending config variables to CHHelpers.