### PR TITLE
Swap "UI is busy" checks to a more robust function

### DIFF
--- a/Components/DLC2CommunityHighlander/DLC2CommunityHighlander/DLC2CommunityHighlander.x2proj
+++ b/Components/DLC2CommunityHighlander/DLC2CommunityHighlander/DLC2CommunityHighlander.x2proj
@@ -42,6 +42,9 @@
     <Content Include="Src\DLC_2\Classes\X2Ability_DLC_Day60ViperKing.uc">
       <SubType>Content</SubType>
     </Content>
+    <Content Include="Src\DLC_2\Classes\X2DownloadableContentInfo_DLC_Day60.uc">
+      <SubType>Content</SubType>
+    </Content>
     <Content Include="Src\DLC_2\Classes\X2Item_DLC_Day60Armors.uc">
       <SubType>Content</SubType>
     </Content>

--- a/Components/DLC2CommunityHighlander/DLC2CommunityHighlander/Src/DLC_2/Classes/X2DownloadableContentInfo_DLC_Day60.uc
+++ b/Components/DLC2CommunityHighlander/DLC2CommunityHighlander/Src/DLC_2/Classes/X2DownloadableContentInfo_DLC_Day60.uc
@@ -1,0 +1,881 @@
+//---------------------------------------------------------------------------------------
+//  FILE:    X2DownloadableContentInfo_DLC_Day60.uc
+//  AUTHOR:  Ryan McFall
+//           
+//	Installs Day 60 DLC into new campaigns and loaded ones. New armors, weapons, etc
+//
+//---------------------------------------------------------------------------------------
+//  Copyright (c) 2016 Firaxis Games, Inc. All rights reserved.
+//---------------------------------------------------------------------------------------
+
+class X2DownloadableContentInfo_DLC_Day60 extends X2DownloadableContentInfo;
+
+var config array<name> DLCTechs;
+var config array<name> DLCPointsOfInterest;
+var config array<name> DLCObjectives;
+
+var config name DLCAlwaysStartObjective;
+var config name DLCOptionalNarrativeObjective;
+var config name DLCNoNarrativeObjective;
+
+var config name ArmoryUpgradeName;
+var config name HunterWeaponsPOIName;
+var config name AlienNestPOIName;
+var config int AlienNestPOIForceLevel; // The Alien Nest POI should be placed as the mission reward for the last mission BEFORE this force level is hit
+
+var localized string m_strRulerPresentOnMission;
+
+/// <summary>
+/// This method is run if the player loads a saved game that was created prior to this DLC / Mod being installed, and allows the 
+/// DLC / Mod to perform custom processing in response. This will only be called once the first time a player loads a save that was
+/// create without the content installed. Subsequent saves will record that the content was installed.
+/// </summary>
+static event OnLoadedSavedGame()
+{
+	InitializeManagers();
+}
+
+/// <summary>
+/// This method is run when the player loads a saved game directly into Strategy while this DLC is installed
+/// </summary>
+static event OnLoadedSavedGameToStrategy()
+{
+	local XComGameState_AlienRulerManager RulerMgr;
+
+	InitializeManagers(); // Make sure manager classes are initialized
+
+	RulerMgr = XComGameState_AlienRulerManager(`XCOMHISTORY.GetSingleGameStateObjectForClass(class'XComGameState_AlienRulerManager'));
+
+	// If the content check for this DLC has not yet been performed, ask the player whether or not it should be enabled for their campaign
+	if (!RulerMgr.bContentCheckCompleted)
+	{
+		EnableDLCContentPopup();
+	}
+}
+
+static function InitializeManagers()
+{
+	local XComGameStateHistory History;
+	local XComGameState NewGameState;
+	local XComGameState_AlienRulerManager RulerMgr;
+	local XComGameState_HuntersLodgeManager LodgeManager;
+
+	History = `XCOMHISTORY;
+	NewGameState = class'XComGameStateContext_ChangeContainer'.static.CreateChangeState("Adding Day 60 DLC State Objects");
+
+	RulerMgr = XComGameState_AlienRulerManager(History.GetSingleGameStateObjectForClass(class'XComGameState_AlienRulerManager', true));
+	if (RulerMgr == none) // Prevent duplicate Ruler Managers
+	{
+		// Add the manager class
+		RulerMgr = XComGameState_AlienRulerManager(NewGameState.CreateNewStateObject(class'XComGameState_AlienRulerManager'));
+	}
+
+	LodgeManager = XComGameState_HuntersLodgeManager(History.GetSingleGameStateObjectForClass(class'XComGameState_HuntersLodgeManager', true));
+	if (LodgeManager == none) // Prevent duplicate Lodge Managers
+	{
+		// Add Hunter's Lodge manager
+		LodgeManager = XComGameState_HuntersLodgeManager(NewGameState.CreateNewStateObject(class'XComGameState_HuntersLodgeManager'));
+		LodgeManager.CalcKillCount(NewGameState);
+	}
+
+	if (NewGameState.GetNumGameStateObjects() > 0)
+	{
+		History.AddGameStateToHistory(NewGameState);
+	}
+	else
+	{
+		History.CleanupPendingGameState(NewGameState);
+	}
+}
+
+static function AddNewTechGameStates(XComGameState NewGameState)
+{
+	local X2StrategyElementTemplateManager TechMgr;
+	local X2TechTemplate TechTemplate;
+	local int idx;
+
+	TechMgr = class'X2StrategyElementTemplateManager'.static.GetStrategyElementTemplateManager();
+
+	// Iterate through the DLC Techs, find their templates, and build a Tech State Object for each
+	for (idx = 0; idx < default.DLCTechs.Length; idx++)
+	{
+		TechTemplate = X2TechTemplate(TechMgr.FindStrategyElementTemplate(default.DLCTechs[idx]));
+		if (TechTemplate != none)
+		{
+			if (TechTemplate.RewardDeck != '')
+			{
+				class'XComGameState_Tech'.static.SetUpTechRewardDeck(TechTemplate);
+			}
+
+			NewGameState.CreateNewStateObject(class'XComGameState_Tech', TechTemplate);
+		}
+	}
+}
+
+static function AddNewObjectiveGameStates(XComGameState NewGameState)
+{
+	local X2StrategyElementTemplateManager ObjMgr;
+	local XComGameState_Objective ObjectiveState;
+	local X2ObjectiveTemplate ObjectiveTemplate;
+	local int idx;
+
+	ObjMgr = class'X2StrategyElementTemplateManager'.static.GetStrategyElementTemplateManager();
+
+	// Iterate through the DLC Objectives, find their templates, and build and activate the Objective State Object for each
+	for (idx = 0; idx < default.DLCObjectives.Length; idx++)
+	{
+		ObjectiveTemplate = X2ObjectiveTemplate(ObjMgr.FindStrategyElementTemplate(default.DLCObjectives[idx]));
+		if (ObjectiveTemplate != none)
+		{
+			ObjectiveState = ObjectiveTemplate.CreateInstanceFromTemplate(NewGameState);
+		}
+
+		// Start the main DLC objective.
+		if (ObjectiveState.GetMyTemplateName() == default.DLCAlwaysStartObjective)
+		{
+			ObjectiveState.StartObjective(NewGameState);
+		}
+
+		// This is always called from a saved game installation of DLC, so narrative is never enabled
+		if (ObjectiveState.GetMyTemplateName() == default.DLCNoNarrativeObjective)
+		{
+			ObjectiveState.StartObjective(NewGameState);
+		}
+	}
+}
+
+static function AddAchievementTriggers(Object TriggerObj)
+{
+	local X2EventManager EventManager;
+
+	// Set up triggers for achievements
+	EventManager = `XEVENTMGR;
+	EventManager.RegisterForEvent(TriggerObj, 'TacticalGameEnd', class'X2AchievementTracker_DLC_Day60'.static.OnTacticalGameEnd, ELD_OnStateSubmitted, 50, , true);
+	EventManager.RegisterForEvent(TriggerObj, 'UnitDied', class'X2AchievementTracker_DLC_Day60'.static.OnUnitDied, ELD_OnStateSubmitted, 50, , true);
+	EventManager.RegisterForEvent(TriggerObj, 'ItemConstructionCompleted', class'X2AchievementTracker_DLC_Day60'.static.OnItemConstructed, ELD_OnStateSubmitted, 50, , true);
+	EventManager.RegisterForEvent(TriggerObj, 'RulerArmorAbilityActivated', class'X2AchievementTracker_DLC_Day60'.static.OnRulerArmorAbilityActivated, ELD_OnStateSubmitted, 50, , true);
+}
+
+/// <summary>
+/// Called when the player starts a new campaign while this DLC / Mod is installed
+/// </summary>
+static event InstallNewCampaign(XComGameState StartState)
+{
+	local XComGameState_AlienRulerManager RulerMgr;
+	local XComGameState_HuntersLodgeManager LodgeManager;
+	local XComGameState_CampaignSettings CampaignSettings;
+	local XComGameState_Objective ObjectiveState;
+	
+	foreach StartState.IterateByClassType(class'XComGameState_CampaignSettings', CampaignSettings)
+	{
+		break;
+	}
+
+	// Add the alien ruler manager class
+	RulerMgr = XComGameState_AlienRulerManager(StartState.CreateNewStateObject(class'XComGameState_AlienRulerManager'));
+	RulerMgr.SetUpRulers(StartState);
+	RulerMgr.bContentCheckCompleted = true; // No need to ask the player about enabling new content on new games
+	RulerMgr.bContentActivated = true;
+	AddAchievementTriggers(RulerMgr);
+
+	// Add Hunter's Lodge manager
+	LodgeManager = XComGameState_HuntersLodgeManager(StartState.CreateNewStateObject(class'XComGameState_HuntersLodgeManager'));
+	LodgeManager.CalcKillCount(StartState);
+
+	// Setup Narrative mission/objectives based on content enable
+	foreach StartState.IterateByClassType(class'XComGameState_Objective', ObjectiveState)
+	{
+		if (CampaignSettings.HasOptionalNarrativeDLCEnabled(name(default.DLCIdentifier)))
+		{
+			if (ObjectiveState.GetMyTemplateName() == default.DLCOptionalNarrativeObjective)
+			{
+				ObjectiveState.StartObjective(StartState);
+				break;
+			}
+		}
+		else
+		{
+			if (ObjectiveState.GetMyTemplateName() == default.DLCNoNarrativeObjective)
+			{
+				ObjectiveState.StartObjective(StartState);
+				break;
+			}
+		}
+	}
+}
+
+/// <summary>
+/// Called just before the player launches into a tactical a mission while this DLC / Mod is installed.
+/// </summary>
+static event OnPreMission(XComGameState NewGameState, XComGameState_MissionSite MissionState)
+{
+	local XComGameStateHistory History;
+	local XComGameState_PointOfInterest POIState;
+	local XComGameState_HeadquartersXCom XComHQ;
+	local XComGameState_HeadquartersAlien AlienHQ;
+	local XComGameState_HeadquartersResistance ResHQ;
+	local XComGameState_MissionCalendar CalendarState;
+	local XComGameState_CampaignSettings CampaignSettings;
+	local XComGameState_AlienRulerManager RulerMgr;
+	local StateObjectReference POIRef;
+
+	History = `XCOMHISTORY;
+	XComHQ = XComGameState_HeadquartersXCom(History.GetSingleGameStateObjectForClass(class'XComGameState_HeadquartersXCom'));
+	AlienHQ = XComGameState_HeadquartersAlien(History.GetSingleGameStateObjectForClass(class'XComGameState_HeadquartersAlien'));
+	ResHQ = XComGameState_HeadquartersResistance(History.GetSingleGameStateObjectForClass(class'XComGameState_HeadquartersResistance'));
+	CalendarState = XComGameState_MissionCalendar(History.GetSingleGameStateObjectForClass(class'XComGameState_MissionCalendar'));
+	CampaignSettings = XComGameState_CampaignSettings(History.GetSingleGameStateObjectForClass(class'XComGameState_CampaignSettings'));
+	RulerMgr = XComGameState_AlienRulerManager(History.GetSingleGameStateObjectForClass(class'XComGameState_AlienRulerManager'));
+	
+	if (RulerMgr.bContentActivated)
+	{
+		// Update the Alien Rulers
+		class'XComGameState_AlienRulerManager'.static.PreMissionUpdate(NewGameState, MissionState);
+
+		// Only attempt to replace POIs if the player has Narrative content enabled for this DLC, and this mission would have spawned a POI
+		// and the tutorial is completed (or not enabled)
+		if (CampaignSettings.HasOptionalNarrativeDLCEnabled(name(default.DLCIdentifier)) && MissionState.POIToSpawn.ObjectID != 0 && 
+			XComHQ.IsObjectiveCompleted('T0_M10_IntroToBlacksite'))
+		{
+			foreach History.IterateByClassType(class'XComGameState_PointOfInterest', POIState)
+			{
+				POIRef = POIState.GetReference();
+
+				// Always looking for an unactivated POI which has never been spawned before, since each of these are unique one-time spawns
+				if (ResHQ.ActivePOIs.Find('ObjectID', POIRef.ObjectID) == INDEX_NONE && POIState.NumSpawns < 1)
+				{
+					// Try to spawn the Hunter Weapons POI.
+					if (POIState.GetMyTemplateName() == default.HunterWeaponsPOIName)
+					{
+						// Deactivate the POI which was going to be spawned so it can be used again
+						ResHQ.DeactivatePOI(NewGameState, MissionState.POIToSpawn);
+						ResHQ.ActivatePOI(NewGameState, POIRef);
+						MissionState.POIToSpawn = POIRef;
+						break; // Break so that this POI is not replaced by Alien Nest.
+					}
+
+					// Try to spawn the Alien Nest POI if the next mission (after the current one) will be at the next force level,
+					// and that next force level is the one where the Alien Nest POI should appear
+					if (class'XComGameState_HeadquartersXCom'.static.IsObjectiveCompleted('DLC_HunterWeapons') &&
+						class'X2StrategyGameRulesetDataStructures'.static.LessThan(AlienHQ.ForceLevelIntervalEndTime, CalendarState.CurrentMissionMonth[0].SpawnDate)
+						&& (AlienHQ.GetForceLevel() + 1) >= default.AlienNestPOIForceLevel && POIState.GetMyTemplateName() == default.AlienNestPOIName)
+					{
+						// Deactivate the POI which was going to be spawned so it can be used again
+						ResHQ.DeactivatePOI(NewGameState, MissionState.POIToSpawn);
+						ResHQ.ActivatePOI(NewGameState, POIRef);
+						MissionState.POIToSpawn = POIRef;
+						// We don't break here to allow this POI to be overwritten by Hunter Weapons
+					}
+				}
+			}
+		}
+	}
+}
+
+/// <summary>
+/// Called when the player completes a mission while this DLC / Mod is installed.
+/// </summary>
+static event OnPostMission()
+{
+	local XComGameState NewGameState;
+	local XComGameState_AlienRulerManager RulerMgr;
+
+	InitializeManagers(); // Make sure manager classes are initialized
+	
+	RulerMgr = XComGameState_AlienRulerManager(`XCOMHISTORY.GetSingleGameStateObjectForClass(class'XComGameState_AlienRulerManager'));
+
+	if (RulerMgr.bContentActivated)
+	{
+		// Update the Alien Rulers
+		NewGameState = class'XComGameStateContext_ChangeContainer'.static.CreateChangeState("DLC 60 On Post Mission");
+		class'XComGameState_AlienRulerManager'.static.PostMissionUpdate(NewGameState);
+		`XCOMGAME.GameRuleset.SubmitGameState(NewGameState);
+	}
+}
+
+/// <summary>
+/// Called after the player exits the post-mission sequence while this DLC / Mod is installed.
+/// </summary>
+static event OnExitPostMissionSequence()
+{
+	local XComGameState_AlienRulerManager RulerMgr;
+	
+	// Ruler Manager should always exist here, because OnPostMission is called before OnExitPostMissionSequence, and InitializeManagers is called there
+	RulerMgr = XComGameState_AlienRulerManager(`XCOMHISTORY.GetSingleGameStateObjectForClass(class'XComGameState_AlienRulerManager'));
+
+	// If the content check for this DLC has not yet been performed, ask the player whether or not it should be enabled for their campaign
+	if (!RulerMgr.bContentCheckCompleted)
+	{
+		EnableDLCContentPopup();
+	}
+}
+
+/// <summary>
+/// Called after the Templates have been created (but before they are validated) while this DLC / Mod is installed.
+/// </summary>
+static event OnPostTemplatesCreated()
+{
+	class'X2Helpers_DLC_Day60'.static.OnPostAbilityTemplatesCreated();
+	class'X2Helpers_DLC_Day60'.static.OnPostTechTemplatesCreated();
+	class'X2Helpers_DLC_Day60'.static.OnPostCharacterTemplatesCreated();
+}
+
+/// <summary>
+/// Called when the difficulty changes and this DLC is active
+/// </summary>
+static event OnDifficultyChanged()
+{
+	local XComGameState NewGameState;
+	local XComGameState_AlienRulerManager RulerMgr;
+
+	InitializeManagers(); // Make sure manager classes are initialized
+
+	RulerMgr = XComGameState_AlienRulerManager(`XCOMHISTORY.GetSingleGameStateObjectForClass(class'XComGameState_AlienRulerManager'));
+	NewGameState = class'XComGameStateContext_ChangeContainer'.static.CreateChangeState("Alien Hunters Change Difficulty");
+	RulerMgr.UpdateRulerStatsForDifficulty(NewGameState);
+	`XCOMGAME.GameRuleset.SubmitGameState(NewGameState);
+}
+
+
+/// <summary>
+/// Called by the Geoscape tick
+/// </summary>
+static event UpdateDLC()
+{
+	local XComGameStateHistory History;
+	local XComGameState NewGameState;
+	local XComGameState_AlienRulerManager RulerMgr;
+	local UIStrategyMap StrategyMap;
+	local bool bUpdated;
+
+	if (class'X2Helpers_DLC_Day60'.static.IsXPackIntegrationEnabled())
+	{
+		History = `XCOMHISTORY;
+		StrategyMap = `HQPRES.StrategyMap2D;
+		RulerMgr = XComGameState_AlienRulerManager(History.GetSingleGameStateObjectForClass(class'XComGameState_AlienRulerManager'));
+		
+		NewGameState = class'XComGameStateContext_ChangeContainer'.static.CreateChangeState("Update Alien Hunters DLC");
+		RulerMgr = XComGameState_AlienRulerManager(NewGameState.ModifyStateObject(class'XComGameState_AlienRulerManager', RulerMgr.ObjectID));
+		
+		// Don't trigger updates while the Avenger or Skyranger are flying, or if another popup is already being presented
+		if (StrategyMap != none && StrategyMap.m_eUIState != eSMS_Flight && !`HQPRES.ScreenStack.IsCurrentClass(class'UIAlert'))
+		{
+			bUpdated = RulerMgr.ActivateRulerLocations(); // Check for any new rulers getting activated, and set their timers
+			bUpdated = bUpdated || RulerMgr.UpdateRulerLocations();
+		}
+		
+		if (bUpdated)
+		{
+			`XCOMGAME.GameRuleset.SubmitGameState(NewGameState);
+			RulerMgr.DisplayRulerPopup(); // Check to see if any new popups need to be displayed
+		}
+		else
+		{
+			History.CleanupPendingGameState(NewGameState);
+		}
+	}
+}
+
+simulated function EnableDLCContentPopupCallback_Ex(Name eAction)
+{
+	local XComGameStateHistory History;
+	local XComGameState NewGameState;
+	local XComGameState_AlienRulerManager RulerMgr;
+	local XComGameState_CampaignSettings CampaignSettings;
+
+	super.EnableDLCContentPopupCallback_Ex(eAction);
+
+	History = `XCOMHISTORY;
+	RulerMgr = XComGameState_AlienRulerManager(History.GetSingleGameStateObjectForClass(class'XComGameState_AlienRulerManager'));
+	CampaignSettings = XComGameState_CampaignSettings(History.GetSingleGameStateObjectForClass(class'XComGameState_CampaignSettings'));
+	NewGameState = class'XComGameStateContext_ChangeContainer'.static.CreateChangeState("Callback Enable Alien Rulers Content");
+
+	// If enabling DLC content from this popup, it is from a loaded save where the DLC wasn't previously installed
+	// So if narrative content was somehow enabled, it should be turned off
+	if(CampaignSettings.HasOptionalNarrativeDLCEnabled(name(default.DLCIdentifier)))
+	{
+		CampaignSettings = XComGameState_CampaignSettings(NewGameState.ModifyStateObject(class'XComGameState_CampaignSettings', CampaignSettings.ObjectID));
+		CampaignSettings.RemoveOptionalNarrativeDLC(name(default.DLCIdentifier));
+	}
+
+	RulerMgr = XComGameState_AlienRulerManager(NewGameState.ModifyStateObject(class'XComGameState_AlienRulerManager', RulerMgr.ObjectID));
+	RulerMgr.bContentCheckCompleted = true;
+
+	if (eAction == 'eUIAction_Accept')
+	{
+		// Content accepted, initiate activation sequence!
+		RulerMgr.bContentActivated = true;
+		RulerMgr.SetUpRulers(NewGameState);
+		AddNewTechGameStates(NewGameState);
+		AddNewObjectiveGameStates(NewGameState);
+		AddAchievementTriggers(RulerMgr);
+	}
+	
+	`XCOMGAME.GameRuleset.SubmitGameState(NewGameState);
+}
+
+/// <summary>
+/// Called when viewing mission blades, used primarily to modify tactical tags for spawning
+/// Returns true when the mission's spawning info needs to be updated
+/// </summary>
+static function bool ShouldUpdateMissionSpawningInfo(StateObjectReference MissionRef)
+{
+	local XComGameState_MissionSite MissionState;
+
+	MissionState = XComGameState_MissionSite(`XCOMHISTORY.GetGameStateForObjectID(MissionRef.ObjectID));
+	if (MissionState.Source == 'MissionSource_AlienNetwork')
+	{
+		// Force a schedule update when alien facilities are selected, since rulers can be located there
+		return true;
+	}
+}
+
+/// <summary>
+/// Called when viewing mission blades, used primarily to modify tactical tags for spawning
+/// Returns true when the mission's spawning info needs to be updated
+/// </summary>
+static function bool UpdateMissionSpawningInfo(StateObjectReference MissionRef)
+{
+	local XComGameStateHistory History;
+	local XComGameState NewGameState;
+	local XComGameState_AlienRulerManager RulerMgr;
+	local XComGameState_HeadquartersXCom XComHQ;
+	local XComGameState_MissionSite MissionState;
+	local array<name> OldTacticalTags;
+	local int idx, i, EncounterIndex;
+	local bool bMatching;
+	local XComGameState_Unit UnitState;
+	local XComTacticalMissionManager MissionMgr;
+	local array<name> RulerNames;
+
+	History = `XCOMHISTORY;
+	NewGameState = class'XComGameStateContext_ChangeContainer'.static.CreateChangeState("Callback Enable Alien Rulers Content");
+	RulerMgr = XComGameState_AlienRulerManager(History.GetSingleGameStateObjectForClass(class'XComGameState_AlienRulerManager'));
+	RulerMgr = XComGameState_AlienRulerManager(NewGameState.ModifyStateObject(class'XComGameState_AlienRulerManager', RulerMgr.ObjectID));
+	XComHQ = XComGameState_HeadquartersXCom(History.GetSingleGameStateObjectForClass(class'XComGameState_HeadquartersXCom'));
+	XComHQ = XComGameState_HeadquartersXCom(NewGameState.ModifyStateObject(class'XComGameState_HeadquartersXCom', XComHQ.ObjectID));
+	MissionState = XComGameState_MissionSite(History.GetGameStateForObjectID(MissionRef.ObjectID));
+
+	// Store old tactical tags for comparison, remove dupes
+	for(idx = 0; idx < XComHQ.TacticalGameplayTags.Length; idx++)
+	{
+		if(OldTacticalTags.Find(XComHQ.TacticalGameplayTags[idx]) == INDEX_NONE)
+		{
+			OldTacticalTags.AddItem(XComHQ.TacticalGameplayTags[idx]);
+		}
+	}
+
+	OldTacticalTags.Sort(SortTacticalTags);
+	XComHQ.TacticalGameplayTags = OldTacticalTags;
+
+	// Update Spawning data and tags
+	RulerMgr.UpdateRulerSpawningData(NewGameState, MissionState);
+	XComHQ.TacticalGameplayTags.Sort(SortTacticalTags);
+
+	// Check if ruler is in encounter groups when they're not supposed to be (for concurrent missions)
+	if(RulerMgr.RulerOnCurrentMission.ObjectID == 0)
+	{
+		MissionMgr = `TACTICALMISSIONMGR;
+
+		// Grab Ruler Names
+		for(idx = 0; idx < RulerMgr.AllAlienRulers.Length; idx++)
+		{
+			UnitState = XComGameState_Unit(History.GetGameStateForObjectID(RulerMgr.AllAlienRulers[idx].ObjectID));
+
+			if(UnitState != none)
+			{
+				RulerNames.AddItem(UnitState.GetMyTemplateName());
+			}
+		}
+
+		// Check if selected encounters contain a ruler
+		for(idx = 0; idx < MissionState.SelectedMissionData.SelectedEncounters.Length; idx++)
+		{
+			EncounterIndex = MissionMgr.ConfigurableEncounters.Find('EncounterID', MissionState.SelectedMissionData.SelectedEncounters[idx].SelectedEncounterName);
+
+			if(EncounterIndex != INDEX_NONE)
+			{
+				for(i = 0; i < RulerNames.Length; i++)
+				{
+					if(MissionMgr.ConfigurableEncounters[EncounterIndex].ForceSpawnTemplateNames.Find(RulerNames[i]) != INDEX_NONE)
+					{
+						// Ruler is in encounter even though none is set by Ruler Manager
+						`XCOMGAME.GameRuleset.SubmitGameState(NewGameState);
+						return true;
+					}
+				}
+			}
+		}
+	}
+
+	// Compare new tactical tags with old ones
+	if(XComHQ.TacticalGameplayTags.Length == OldTacticalTags.Length)
+	{
+		bMatching = true;
+
+		for(idx = 0; idx < OldTacticalTags.Length; idx++)
+		{
+			if(XComHQ.TacticalGameplayTags[idx] != OldTacticalTags[idx])
+			{
+				bMatching = false;
+				break;
+			}
+		}
+
+		if(bMatching)
+		{
+			History.CleanupPendingGameState(NewGameState);
+			return false;
+		}
+	}
+	
+	`XCOMGAME.GameRuleset.SubmitGameState(NewGameState);
+	return true;
+}
+
+private function int SortTacticalTags(name NameA, name NameB)
+{
+	local string StringA, StringB;
+
+	StringA = string(NameA);
+	StringB = string(NameB);
+
+	if (StringA < StringB)
+	{
+		return 1;
+	}
+	else if (StringA > StringB)
+	{
+		return -1;
+	}
+	else
+	{
+		return 0;
+	}
+}
+
+/// <summary>
+/// Called when viewing mission blades, used to add any additional text to the mission description
+/// </summary>
+static function string GetAdditionalMissionDesc(StateObjectReference MissionRef)
+{
+	local XComGameStateHistory History;
+	local XComGameState_MissionSite MissionState;
+	local XComGameState_AlienRulerManager RulerMgr;
+
+	History = `XCOMHISTORY;
+	RulerMgr = XComGameState_AlienRulerManager(History.GetSingleGameStateObjectForClass(class'XComGameState_AlienRulerManager'));
+	MissionState = XComGameState_MissionSite(History.GetGameStateForObjectID(MissionRef.ObjectID));
+	if (MissionState.Source == 'MissionSource_AlienNetwork' && RulerMgr.AlienRulerLocations.Find('MissionRef', MissionRef) != INDEX_NONE)
+	{
+		return class'UIUtilities_Text'.static.GetColoredText(default.m_strRulerPresentOnMission, eUIState_Warning);
+	}
+}
+
+/// <summary>
+/// Calls DLC specific popup handlers to route messages to correct display functions
+/// </summary>
+static function bool DisplayQueuedDynamicPopup(DynamicPropertySet PropertySet)
+{
+	if (PropertySet.PrimaryRoutingKey == 'UIAlert_DLC_Day60')
+	{
+		CallUIAlert_DLC_Day60(PropertySet);
+		return true;
+	}
+
+	return false;
+}
+
+static function CallUIAlert_DLC_Day60(const out DynamicPropertySet PropertySet)
+{
+	local XComHQPresentationLayer Pres;
+	local UIAlert_DLC_Day60 Alert;
+
+	Pres = `HQPRES;
+
+	Alert = Pres.Spawn(class'UIAlert_DLC_Day60', Pres);
+	Alert.DisplayPropertySet = PropertySet;
+	Alert.eAlertName = PropertySet.SecondaryRoutingKey;
+
+	Pres.ScreenStack.Push(Alert);
+}
+
+/// <summary>
+/// Called after HeadquartersAlien builds a Facility
+/// </summary>
+static event OnPostAlienFacilityCreated(XComGameState NewGameState, StateObjectReference NewFacilityRef)
+{
+	local XComGameState_AlienRulerManager RulerMgr;
+
+	RulerMgr = XComGameState_AlienRulerManager(`XCOMHISTORY.GetSingleGameStateObjectForClass(class'XComGameState_AlienRulerManager'));
+	RulerMgr = XComGameState_AlienRulerManager(NewGameState.ModifyStateObject(class'XComGameState_AlienRulerManager', RulerMgr.ObjectID));	
+	RulerMgr.PlaceRulerAtLocation(NewFacilityRef); // Attempt to place a ruler at the new facility location
+}
+
+/// <summary>
+/// Called after a new Alien Facility's doom generation display is completed
+/// </summary>
+static event OnPostFacilityDoomVisualization()
+{
+	local XComGameState_AlienRulerManager RulerMgr;
+
+	RulerMgr = XComGameState_AlienRulerManager(`XCOMHISTORY.GetSingleGameStateObjectForClass(class'XComGameState_AlienRulerManager'));
+	RulerMgr.DisplayRulerPopup();
+}
+
+
+//---------------------------------------------------------------------------------------
+//-------------------------------- DLC CHEATS -------------------------------------------
+//---------------------------------------------------------------------------------------
+
+//---------------------------------------------------------------------------------------
+// For TQL Testing of Alien Rulers
+// WARNING: DON'T USE IN STRATEGY
+exec function InitAlienRulerManager()
+{
+	local XComGameState NewGameState;
+	local XComGameState_AlienRulerManager RulerMgr;
+
+	NewGameState = class'XComGameStateContext_ChangeContainer'.static.CreateChangeState("CHEAT: InitAlienRulerManager");
+	RulerMgr = XComGameState_AlienRulerManager(NewGameState.CreateNewStateObject(class'XComGameState_AlienRulerManager'));
+	RulerMgr.CreateAlienRulers(NewGameState);
+	RulerMgr.ActiveAlienRulers = RulerMgr.AllAlienRulers;
+	`XCOMGAME.GameRuleset.SubmitGameState(NewGameState);
+
+	SetRulerNumAppearances('ViperKing', 1);
+	SetRulerNumAppearances('BerserkerQueen', 1);
+	SetRulerNumAppearances('ArchonKing', 1);
+
+	AddAchievementTriggers(RulerMgr);
+}
+
+//---------------------------------------------------------------------------------------
+exec function ForceRulerOnNextMission(name RulerTemplateName)
+{
+	local XComGameStateHistory History;
+	local XComGameState NewGameState;
+	local XComGameState_AlienRulerManager RulerMgr;
+	local StateObjectReference RulerRef;
+
+	History = `XCOMHISTORY;
+	RulerMgr = XComGameState_AlienRulerManager(History.GetSingleGameStateObjectForClass(class'XComGameState_AlienRulerManager'));
+	RulerRef = RulerMgr.GetAlienRulerReference(RulerTemplateName);
+
+	if(RulerRef.ObjectID != 0)
+	{
+		NewGameState = class'XComGameStateContext_ChangeContainer'.static.CreateChangeState("CHEAT: ForceRulerOnNextMission");
+		RulerMgr = XComGameState_AlienRulerManager(NewGameState.ModifyStateObject(class'XComGameState_AlienRulerManager', RulerMgr.ObjectID));
+		RulerMgr.ForcedRulerOnNextMission = RulerRef;
+		`XCOMGAME.GameRuleset.SubmitGameState(NewGameState);
+	}
+	else
+	{
+		`log("RulerTemplateName is invalid.\nValid Entries: ViperKing, BerserkerQueen, ArchonKing");
+	}
+}
+
+//---------------------------------------------------------------------------------------
+exec function SetRulerNumAppearances(name RulerTemplateName, int Count)
+{
+	local XComGameStateHistory History;
+	local XComGameState NewGameState;
+	local XComGameState_AlienRulerManager RulerMgr;
+	local XComGameState_Unit UnitState;
+	local StateObjectReference RulerRef;
+
+	History = `XCOMHISTORY;
+	RulerMgr = XComGameState_AlienRulerManager(History.GetSingleGameStateObjectForClass(class'XComGameState_AlienRulerManager'));
+	RulerRef = RulerMgr.GetAlienRulerReference(RulerTemplateName);
+
+	if(RulerRef.ObjectID != 0)
+	{
+		NewGameState = class'XComGameStateContext_ChangeContainer'.static.CreateChangeState("CHEAT: SetRulerNumAppearances");
+		UnitState = XComGameState_Unit(NewGameState.ModifyStateObject(class'XComGameState_Unit', RulerRef.ObjectID));
+		UnitState.SetUnitFloatValue('NumAppearances', float(Count), eCleanup_Never);
+		`XCOMGAME.GameRuleset.SubmitGameState(NewGameState);
+	}
+	else
+	{
+		`log("RulerTemplateName is invalid.\nValid Entries: ViperKing, BerserkerQueen, ArchonKing");
+	}
+}
+
+//---------------------------------------------------------------------------------------
+exec function PrintRulerNumAppearances(name RulerTemplateName)
+{
+	local XComGameStateHistory History;
+	local XComGameState_AlienRulerManager RulerMgr;
+	local XComGameState_Unit UnitState;
+	local StateObjectReference RulerRef;
+	local UnitValue AppearanceValue;
+
+	History = `XCOMHISTORY;
+	RulerMgr = XComGameState_AlienRulerManager(History.GetSingleGameStateObjectForClass(class'XComGameState_AlienRulerManager'));
+	RulerRef = RulerMgr.GetAlienRulerReference(RulerTemplateName);
+
+	if(RulerRef.ObjectID != 0)
+	{
+		UnitState = XComGameState_Unit(History.GetGameStateForObjectID(RulerRef.ObjectID));
+		UnitState.GetUnitValue('NumAppearances', AppearanceValue);
+		`log(string(RulerTemplateName) @ "Appearances:" @ int(AppearanceValue.fValue));
+	}
+	else
+	{
+		`log("RulerTemplateName is invalid.\nValid Entries: ViperKing, BerserkerQueen, ArchonKing");
+	}
+}
+
+//---------------------------------------------------------------------------------------
+exec function SetRulerNumEscapes(name RulerTemplateName, int Count)
+{
+	local XComGameStateHistory History;
+	local XComGameState NewGameState;
+	local XComGameState_AlienRulerManager RulerMgr;
+	local XComGameState_Unit UnitState;
+	local StateObjectReference RulerRef;
+
+	History = `XCOMHISTORY;
+	RulerMgr = XComGameState_AlienRulerManager(History.GetSingleGameStateObjectForClass(class'XComGameState_AlienRulerManager'));
+	RulerRef = RulerMgr.GetAlienRulerReference(RulerTemplateName);
+
+	if(RulerRef.ObjectID != 0)
+	{
+		NewGameState = class'XComGameStateContext_ChangeContainer'.static.CreateChangeState("CHEAT: SetRulerNumAppearances");
+		UnitState = XComGameState_Unit(NewGameState.ModifyStateObject(class'XComGameState_Unit', RulerRef.ObjectID));
+		UnitState.SetUnitFloatValue('NumEscapes', float(Count), eCleanup_Never);
+		`XCOMGAME.GameRuleset.SubmitGameState(NewGameState);
+	}
+	else
+	{
+		`log("RulerTemplateName is invalid.\nValid Entries: ViperKing, BerserkerQueen, ArchonKing");
+	}
+}
+
+//---------------------------------------------------------------------------------------
+exec function PrintRulerNumEscapes(name RulerTemplateName)
+{
+	local XComGameStateHistory History;
+	local XComGameState_AlienRulerManager RulerMgr;
+	local XComGameState_Unit UnitState;
+	local StateObjectReference RulerRef;
+	local UnitValue EscapeValue;
+
+	History = `XCOMHISTORY;
+	RulerMgr = XComGameState_AlienRulerManager(History.GetSingleGameStateObjectForClass(class'XComGameState_AlienRulerManager'));
+	RulerRef = RulerMgr.GetAlienRulerReference(RulerTemplateName);
+
+	if(RulerRef.ObjectID != 0)
+	{
+		UnitState = XComGameState_Unit(History.GetGameStateForObjectID(RulerRef.ObjectID));
+		UnitState.GetUnitValue('NumEscapes', EscapeValue);
+		`log(string(RulerTemplateName) @ "Escapes:" @ int(EscapeValue.fValue));
+	}
+	else
+	{
+		`log("RulerTemplateName is invalid.\nValid Entries: ViperKing, BerserkerQueen, ArchonKing");
+	}
+}
+
+//---------------------------------------------------------------------------------------
+exec function SetRulerEscapeHealth(name RulerTemplateName, int Health)
+{
+	local XComGameStateHistory History;
+	local XComGameState NewGameState;
+	local XComGameState_AlienRulerManager RulerMgr;
+	local XComGameState_Unit UnitState;
+	local StateObjectReference RulerRef;
+
+	History = `XCOMHISTORY;
+	RulerMgr = XComGameState_AlienRulerManager(History.GetSingleGameStateObjectForClass(class'XComGameState_AlienRulerManager'));
+	RulerRef = RulerMgr.GetAlienRulerReference(RulerTemplateName);
+
+	if (RulerRef.ObjectID != 0)
+	{
+		NewGameState = class'XComGameStateContext_ChangeContainer'.static.CreateChangeState("CHEAT: SetRulerEscapeHealth");
+		UnitState = XComGameState_Unit(NewGameState.ModifyStateObject(class'XComGameState_Unit', RulerRef.ObjectID));
+		UnitState.SetUnitFloatValue('EscapeHealth', float(Health), eCleanup_Never);
+		`XCOMGAME.GameRuleset.SubmitGameState(NewGameState);
+	}
+	else
+	{
+		`log("RulerTemplateName is invalid.\nValid Entries: ViperKing, BerserkerQueen, ArchonKing");
+	}
+}
+
+//---------------------------------------------------------------------------------------
+exec function PrintRulerEscapeHealth(name RulerTemplateName)
+{
+	local XComGameStateHistory History;
+	local XComGameState_AlienRulerManager RulerMgr;
+	local XComGameState_Unit UnitState;
+	local StateObjectReference RulerRef;
+	local UnitValue EscapeValue;
+
+	History = `XCOMHISTORY;
+	RulerMgr = XComGameState_AlienRulerManager(History.GetSingleGameStateObjectForClass(class'XComGameState_AlienRulerManager'));
+	RulerRef = RulerMgr.GetAlienRulerReference(RulerTemplateName);
+
+	if (RulerRef.ObjectID != 0)
+	{
+		UnitState = XComGameState_Unit(History.GetGameStateForObjectID(RulerRef.ObjectID));
+		UnitState.GetUnitValue('EscapeHealth', EscapeValue);
+		`log(string(RulerTemplateName) @ "Escape Health:" @ int(EscapeValue.fValue));
+	}
+	else
+	{
+		`log("RulerTemplateName is invalid.\nValid Entries: ViperKing, BerserkerQueen, ArchonKing");
+	}
+}
+
+//---------------------------------------------------------------------------------------
+// Call in strategy to add Central as a normal soldier to your crew
+exec function AddNestCentralToCrew()
+{
+	local XComGameStateHistory History;
+	local XComGameState NewGameState;
+	local XComGameState_HeadquartersXCom XComHQ;
+	local XComGameState_Unit UnitState;
+
+	History = `XCOMHISTORY;
+
+	foreach History.IterateByClassType(class'XComGameState_Unit', UnitState)
+	{
+		if(UnitState.GetMyTemplateName() == 'NestCentral')
+		{
+			NewGameState = class'XComGameStateContext_ChangeContainer'.static.CreateChangeState("CHEAT: AddNestCentralToCrew");
+			UnitState = XComGameState_Unit(NewGameState.ModifyStateObject(class'XComGameState_Unit', UnitState.ObjectID));
+			XComHQ = XComGameState_HeadquartersXCom(History.GetSingleGameStateObjectForClass(class'XComGameState_HeadquartersXCom'));
+			XComHQ = XComGameState_HeadquartersXCom(NewGameState.ModifyStateObject(class'XComGameState_HeadquartersXCom', XComHQ.ObjectID));
+			XComHQ.AddToCrew(NewGameState, UnitState);
+			`XCOMGAME.GameRuleset.SubmitGameState(NewGameState);
+		}
+	}
+}
+
+//---------------------------------------------------------------------------------------
+// Call in strategy to display debug numbers in the Hunters Lodge
+exec function ToggleHuntersLodgeDebug()
+{
+	local XComGameStateHistory History;
+	local XComGameState NewGameState;
+	local XComGameState_HuntersLodgeManager LodgeManager;
+	
+	History = `XCOMHISTORY;
+	NewGameState = class'XComGameStateContext_ChangeContainer'.static.CreateChangeState("CHEAT: Toggle Hunters Lodge Debug Numbers");
+	
+	LodgeManager = XComGameState_HuntersLodgeManager(History.GetSingleGameStateObjectForClass(class'XComGameState_HuntersLodgeManager', true));
+	if (LodgeManager != none)
+	{
+		LodgeManager = XComGameState_HuntersLodgeManager(NewGameState.CreateNewStateObject(class'XComGameState_HuntersLodgeManager'));
+		LodgeManager.bDebugVis = !LodgeManager.bDebugVis;
+	}
+
+	if (NewGameState.GetNumGameStateObjects() > 0)
+	{
+		History.AddGameStateToHistory(NewGameState);
+	}
+	else
+	{
+		History.CleanupPendingGameState(NewGameState);
+	}
+}

--- a/Components/DLC2CommunityHighlander/DLC2CommunityHighlander/Src/DLC_2/Classes/X2DownloadableContentInfo_DLC_Day60.uc
+++ b/Components/DLC2CommunityHighlander/DLC2CommunityHighlander/Src/DLC_2/Classes/X2DownloadableContentInfo_DLC_Day60.uc
@@ -345,20 +345,23 @@ static event UpdateDLC()
 	local XComGameStateHistory History;
 	local XComGameState NewGameState;
 	local XComGameState_AlienRulerManager RulerMgr;
-	local UIStrategyMap StrategyMap;
+	// Issue #1417: no longer used
+	//local UIStrategyMap StrategyMap;
 	local bool bUpdated;
 
 	if (class'X2Helpers_DLC_Day60'.static.IsXPackIntegrationEnabled())
 	{
 		History = `XCOMHISTORY;
-		StrategyMap = `HQPRES.StrategyMap2D;
+		// Issue #1417: no longer used
+		//StrategyMap = `HQPRES.StrategyMap2D;
 		RulerMgr = XComGameState_AlienRulerManager(History.GetSingleGameStateObjectForClass(class'XComGameState_AlienRulerManager'));
 		
 		NewGameState = class'XComGameStateContext_ChangeContainer'.static.CreateChangeState("Update Alien Hunters DLC");
 		RulerMgr = XComGameState_AlienRulerManager(NewGameState.ModifyStateObject(class'XComGameState_AlienRulerManager', RulerMgr.ObjectID));
 		
 		// Don't trigger updates while the Avenger or Skyranger are flying, or if another popup is already being presented
-		if (StrategyMap != none && StrategyMap.m_eUIState != eSMS_Flight && !`HQPRES.ScreenStack.IsCurrentClass(class'UIAlert'))
+		// Issue #1417: Use a more robust check to determine if the game should trigger the update.
+		if (class'CHHelpers'.static.GeoscapeReadyForUpdate())
 		{
 			bUpdated = RulerMgr.ActivateRulerLocations(); // Check for any new rulers getting activated, and set their timers
 			bUpdated = bUpdated || RulerMgr.UpdateRulerLocations();

--- a/X2WOTCCommunityHighlander/Src/XComGame/Classes/CHHelpers.uc
+++ b/X2WOTCCommunityHighlander/Src/XComGame/Classes/CHHelpers.uc
@@ -1130,3 +1130,19 @@ static final function array<SoldierClassAbilityType> RebuildSoldierClassAbilityT
 	return AbilityTypes;
 }
 // End Issue #815
+
+/// HL-Docs: ref:Bugfixes; issue:1417
+/// This helper function uses a more robust check to ensure the geoscape is ready for alerts.
+/// This replaces functions that only check for the presence of a UIAlert screen, which can
+/// result in popups in places such as Squad Select or the Black Market screen if the campaign date lines up with flight time.
+static function bool GeoscapeReadyForUpdate()
+{
+	local UIStrategyMap StrategyMap;
+
+	StrategyMap = `HQPRES.StrategyMap2D;
+
+	return
+		StrategyMap != none &&
+		StrategyMap.m_eUIState != eSMS_Flight &&
+		StrategyMap.Movie.Pres.ScreenStack.GetCurrentScreen() == StrategyMap;
+}

--- a/X2WOTCCommunityHighlander/Src/XComGame/Classes/XComGameState_AdventChosen.uc
+++ b/X2WOTCCommunityHighlander/Src/XComGame/Classes/XComGameState_AdventChosen.uc
@@ -1881,12 +1881,14 @@ function bool IsFavored()
 // THIS FUNCTION SHOULD RETURN TRUE IN ALL THE SAME CASES AS Update
 function bool ShouldUpdate()
 {
-	local UIStrategyMap StrategyMap;
+	// Issue #1417: no longer used
+	//local UIStrategyMap StrategyMap;
 
-	StrategyMap = `HQPRES.StrategyMap2D;
+	//StrategyMap = `HQPRES.StrategyMap2D;
 
 	// Do not trigger anything while the Avenger or Skyranger are flying, or if another popup is already being presented
-	if (StrategyMap != none && StrategyMap.m_eUIState != eSMS_Flight && !`HQPRES.ScreenStack.IsCurrentClass(class'UIAlert'))
+	// Issue #1417: Use a more robust check to determine if the game should trigger the update.
+	if (class'CHHelpers'.static.GeoscapeReadyForUpdate())
 	{
 		if (bMetXCom && !bSeenLocationReveal)
 		{
@@ -1901,14 +1903,17 @@ function bool ShouldUpdate()
 // IF ADDING NEW CASES WHERE bModified = true, UPDATE FUNCTION ShouldUpdate ABOVE
 function bool Update(XComGameState NewGameState)
 {
-	local UIStrategyMap StrategyMap;
+	// Issue #1417: no longer used
+	//local UIStrategyMap StrategyMap;
 	local bool bModified;
 
-	StrategyMap = `HQPRES.StrategyMap2D;
+	// Issue #1417: no longer used
+	//StrategyMap = `HQPRES.StrategyMap2D;
 	bModified = false;
 
 	// Do not trigger anything while the Avenger or Skyranger are flying, or if another popup is already being presented
-	if (StrategyMap != none && StrategyMap.m_eUIState != eSMS_Flight && !`HQPRES.ScreenStack.IsCurrentClass(class'UIAlert'))
+	// Issue #1417: Use a more robust check to determine if the game should trigger the update.
+	if (class'CHHelpers'.static.GeoscapeReadyForUpdate())
 	{
 		if (bMetXCom && !bSeenLocationReveal)
 		{

--- a/X2WOTCCommunityHighlander/Src/XComGame/Classes/XComGameState_AlienNetworkComponent.uc
+++ b/X2WOTCCommunityHighlander/Src/XComGame/Classes/XComGameState_AlienNetworkComponent.uc
@@ -1,0 +1,360 @@
+//---------------------------------------------------------------------------------------
+//  FILE:    XComGameState_AlienNetworkComponent.uc
+//  AUTHOR:  Mark Nauta  --  01/12/2015
+//  PURPOSE: This object represents the instance data for an alien network component
+//			 on the world map
+//           
+//---------------------------------------------------------------------------------------
+//  Copyright (c) 2016 Firaxis Games, Inc. All rights reserved.
+//---------------------------------------------------------------------------------------
+class XComGameState_AlienNetworkComponent extends XComGameState_GeoscapeEntity
+	native(Core) config(GameBoard);
+
+var() StateObjectReference			Mission;
+var() int							Doom;
+
+// Doom Projects
+var() TDateTime						DoomProjectIntervalStartTime;
+var() TDateTime						DoomProjectIntervalEndTime;
+var() float							DoomProjectTimeRemaining;
+var() int							DoomProjectSuccessChance;
+var() bool							bNeedsDoomPopup;
+
+var config int						IntelCost;
+var config int						MinDoomProjectInterval;
+var config int						MaxDoomProjectInterval;
+var config int						StartingSuccessChance;
+var config int						SuccessChanceIncrease;
+var config int						DoomProjectGracePeriod; // On return from Lose phase
+var config int						MaxDoom;
+
+//#############################################################################################
+//----------------   INITIALIZATION   ---------------------------------------------------------
+//#############################################################################################
+
+//---------------------------------------------------------------------------------------
+function PostCreateInit(XComGameState NewGameState, StateObjectReference RegionRef)
+{
+	local XComGameStateHistory History;
+	local XComGameState_Reward RewardState;
+	local X2RewardTemplate RewardTemplate;
+	local X2StrategyElementTemplateManager StratMgr;
+	local array<XComGameState_Reward> MissionRewards;
+	local XComGameState_WorldRegion RegionState;
+	local XComGameState_MissionSite MissionState;
+	local X2MissionSourceTemplate MissionSource;
+	local int HoursToAdd;
+	
+	// Set Region and Location
+	History = `XCOMHISTORY;
+	RegionState = XComGameState_WorldRegion(History.GetGameStateForObjectID(RegionRef.ObjectID));
+	Region = RegionRef;
+	Location = RegionState.GetRandomLocationInRegion(,,self);
+
+	// Set Starting Doom Project Chance
+	DoomProjectSuccessChance = default.StartingSuccessChance;
+		
+	// Start Doom ProjectTimer
+	DoomProjectIntervalStartTime = class'XComGameState_GeoscapeEntity'.static.GetCurrentTime();
+	DoomProjectIntervalEndTime = DoomProjectIntervalStartTime;
+	HoursToAdd = default.MinDoomProjectInterval + `SYNC_RAND(default.MaxDoomProjectInterval - default.MinDoomProjectInterval + 1);
+	class'X2StrategyGameRulesetDataStructures'.static.AddHours(DoomProjectIntervalEndTime, HoursToAdd);
+	DoomProjectTimeRemaining = class'X2StrategyGameRulesetDataStructures'.static.DifferenceInSeconds(DoomProjectIntervalEndTime, DoomProjectIntervalStartTime);
+
+	// Create Mission
+	StratMgr = class'X2StrategyElementTemplateManager'.static.GetStrategyElementTemplateManager();
+	RewardTemplate = X2RewardTemplate(StratMgr.FindStrategyElementTemplate('Reward_None'));
+	RewardState = RewardTemplate.CreateInstanceFromTemplate(NewGameState);
+	MissionRewards.AddItem(RewardState);
+
+	MissionSource = X2MissionSourceTemplate(StratMgr.FindStrategyElementTemplate('MissionSource_AlienNetwork'));
+	MissionState = XComGameState_MissionSite(NewGameState.CreateNewStateObject(class'XComGameState_MissionSite'));
+
+	MissionState.BuildMission(MissionSource, Get2DLocation(), RegionRef, MissionRewards, true, false);
+	Mission = MissionState.GetReference();
+}
+
+//---------------------------------------------------------------------------------------
+function string GetDisplayName()
+{
+	return "";
+}
+
+//---------------------------------------------------------------------------------------
+function string GetSummaryText()
+{
+	return "";
+}
+
+//---------------------------------------------------------------------------------------
+function int GetIntelCost()
+{
+	return default.IntelCost;
+}
+
+//---------------------------------------------------------------------------------------
+function bool CanAffordIntelCost()
+{
+	local XComGameStateHistory History;
+	local XComGameState_HeadquartersXCom XComHQ;
+
+	History = `XCOMHISTORY;
+	XComHQ = XComGameState_HeadquartersXCom(History.GetSingleGameStateObjectForClass(class'XComGameState_HeadquartersXCom'));
+
+	return (XComHQ.CanAffordResourceCost('Intel', GetIntelCost()));
+}
+
+//#############################################################################################
+//----------------   UPDATE   -----------------------------------------------------------------
+//#############################################################################################
+
+//---------------------------------------------------------------------------------------
+function bool Update(XComGameState NewGameState)
+{
+	local XComGameState_HeadquartersAlien AlienHQ;
+	local UIStrategyMap StrategyMap;
+	local bool bUpdated;
+	local int HoursToAdd;
+
+	StrategyMap = `HQPRES.StrategyMap2D;
+	bUpdated = false;
+	
+	// Do not modify doom while the Avenger or Skyranger are flying, or if another popup is already being presented
+	if (StrategyMap != none && StrategyMap.m_eUIState != eSMS_Flight && !`HQPRES.ScreenStack.IsCurrentClass(class'UIAlert'))
+	{
+		if (class'X2StrategyGameRulesetDataStructures'.static.LessThan(DoomProjectIntervalEndTime, `STRATEGYRULES.GameTime))
+		{
+			bUpdated = true;
+			if (class'X2StrategyGameRulesetDataStructures'.static.Roll(DoomProjectSuccessChance))
+			{
+				AlienHQ = XComGameState_HeadquartersAlien(`XCOMHISTORY.GetSingleGameStateObjectForClass(class'XComGameState_HeadquartersAlien'));
+
+				Doom++;
+				DoomProjectSuccessChance = default.StartingSuccessChance;
+				
+				if (!AlienHQ.bHasSeenDoomPopup)
+				{
+					bNeedsDoomPopup = true;
+				}
+				
+				if (Doom > default.MaxDoom)
+				{
+					Doom--;
+					AlienHQ = XComGameState_HeadquartersAlien(NewGameState.ModifyStateObject(class'XComGameState_HeadquartersAlien', AlienHQ.ObjectID));
+					AlienHQ.ModifyDoom(1);
+				}
+
+				class'XComGameState_HeadquartersResistance'.static.RecordResistanceActivity(NewGameState, 'ResAct_AvatarProgress');
+			}
+			else
+			{
+				DoomProjectSuccessChance += default.SuccessChanceIncrease;
+			}
+
+			DoomProjectIntervalStartTime = `STRATEGYRULES.GameTime;
+			DoomProjectIntervalEndTime = DoomProjectIntervalStartTime;
+			HoursToAdd = default.MinDoomProjectInterval + `SYNC_RAND(default.MaxDoomProjectInterval - default.MinDoomProjectInterval + 1);
+			class'X2StrategyGameRulesetDataStructures'.static.AddHours(DoomProjectIntervalEndTime, HoursToAdd);
+			DoomProjectTimeRemaining = class'X2StrategyGameRulesetDataStructures'.static.DifferenceInSeconds(DoomProjectIntervalEndTime, DoomProjectIntervalStartTime);
+		}
+	}
+
+	return bUpdated;
+}
+
+//---------------------------------------------------------------------------------------
+function PauseDoomProjectTimer()
+{
+	// Update Time remaining and set end time to unreachable future
+	DoomProjectTimeRemaining = class'X2StrategyGameRulesetDataStructures'.static.DifferenceInSeconds(DoomProjectIntervalEndTime, `STRATEGYRULES.GameTime);
+	DoomProjectIntervalEndTime.m_iYear = 9999;
+}
+
+//---------------------------------------------------------------------------------------
+function ResumeDoomProjectTimer(optional bool bGracePeriod = false)
+{
+	local float TimeToAdd;
+
+	// Update the start time then calculate the end time using the time remaining
+	DoomProjectIntervalStartTime = `STRATEGYRULES.GameTime;
+	DoomProjectIntervalEndTime = DoomProjectIntervalStartTime;
+	TimeToAdd = DoomProjectTimeRemaining;
+
+	if (bGracePeriod)
+	{
+		TimeToAdd += float(default.DoomProjectGracePeriod) * 3600.0;
+	}
+
+	class'X2StrategyGameRulesetDataStructures'.static.AddTime(DoomProjectIntervalEndTime, TimeToAdd);
+}
+
+//#############################################################################################
+//----------------   GEOSCAPE ENTITY IMPLEMENTATION   -----------------------------------------
+//#############################################################################################
+
+function bool ShouldBeVisible()
+{
+	return true;
+}
+
+//---------------------------------------------------------------------------------------
+function class<UIStrategyMapItem> GetUIClass()
+{
+	return class'UIStrategyMapItem_AlienNetworkComponent';
+}
+
+//---------------------------------------------------------------------------------------
+function string GetUIWidgetFlashLibraryName()
+{
+	return "MI_alienFacility";
+}
+
+//---------------------------------------------------------------------------------------
+function string GetUIPinImagePath()
+{
+	return "";
+}
+
+// The static mesh for this entities 3D UI
+function StaticMesh GetStaticMesh()
+{
+	return StaticMesh'UI_3D.Overworld.Triad_Icon';
+}
+
+// Scale adjustment for the 3D UI static mesh
+function vector GetMeshScale()
+{
+	local vector ScaleVector;
+
+	ScaleVector.X = 2;
+	ScaleVector.Y = 2;
+	ScaleVector.Z = 2;
+
+	return ScaleVector;
+}
+
+//---------------------------------------------------------------------------------------
+function UpdateGameBoard()
+{
+	local XComGameState NewGameState;
+	local XComGameState_AlienNetworkComponent ANCState;
+	local XComGameStateHistory History;
+
+	History = `XCOMHISTORY;
+
+	NewGameState = class'XComGameStateContext_ChangeContainer'.static.CreateChangeState("Update Alien Network");
+
+	ANCState = XComGameState_AlienNetworkComponent(NewGameState.ModifyStateObject(class'XComGameState_AlienNetworkComponent', ObjectID));
+
+	if (!ANCState.Update(NewGameState))
+	{
+		NewGameState.PurgeGameStateForObjectID(ANCState.ObjectID);
+	}
+
+	if (NewGameState.GetNumGameStateObjects() > 0)
+	{
+		`XCOMGAME.GameRuleset.SubmitGameState(NewGameState);
+	}
+	else
+	{
+		History.CleanupPendingGameState(NewGameState);
+	}
+
+	if(bNeedsDoomPopup)
+	{
+		DoomAddedPopup();
+	}
+}
+
+//---------------------------------------------------------------------------------------
+simulated private function IntelUnlockCallback(Name eAction)
+{
+	local XComGameStateHistory History;
+	local XComGameState NewGameState;
+	local XComGameState_HeadquartersXCom XComHQ;
+	local XComGameState_MissionSite MissionState;
+
+	if (eAction == 'eUIAction_Accept')
+	{
+		NewGameState = class'XComGameStateContext_ChangeContainer'.static.CreateChangeState("Unlock Mission");
+
+		// spend the intel
+		History = `XCOMHISTORY;
+		XComHQ = XComGameState_HeadquartersXCom(History.GetSingleGameStateObjectForClass(class'XComGameState_HeadquartersXCom'));
+		XComHQ.AddResource(NewGameState, 'Intel', -GetIntelCost());
+
+		// unlock the mission
+		MissionState = XComGameState_MissionSite(NewGameState.ModifyStateObject(class'XComGameState_MissionSite', Mission.ObjectID));
+		MissionState.Available = true;
+		`XCOMGAME.GameRuleset.SubmitGameState(NewGameState);
+
+		// do not make Skyranger RTB
+		InteractionComplete(false);
+	}
+	else if (eAction == 'eUIAction_Cancel')
+	{
+		InteractionComplete(false);
+	}
+	else
+	{
+		`assert(false);
+	}
+}
+
+//---------------------------------------------------------------------------------------
+simulated public function DoomAddedPopup()
+{
+	local XComGameState NewGameState;
+	local XComGameState_AlienNetworkComponent ANCState;
+	local XComGameState_HeadquartersAlien AlienHQ;
+	local DynamicPropertySet PropertySet;
+
+	NewGameState = class'XComGameStateContext_ChangeContainer'.static.CreateChangeState("Toggle Doom Popup flag");
+	ANCState = XComGameState_AlienNetworkComponent(NewGameState.ModifyStateObject(class'XComGameState_AlienNetworkComponent', self.ObjectID));
+	ANCState.bNeedsDoomPopup = false;
+	
+	AlienHQ = XComGameState_HeadquartersAlien(`XCOMHISTORY.GetSingleGameStateObjectForClass(class'XComGameState_HeadquartersAlien'));
+	AlienHQ = XComGameState_HeadquartersAlien(NewGameState.ModifyStateObject(class'XComGameState_HeadquartersAlien', AlienHQ.ObjectID));
+	AlienHQ.bHasSeenDoomPopup = true; // Ensure the doom popup is only shown to the player once
+	
+	`XEVENTMGR.TriggerEvent('OnDoomPopup', , , NewGameState);
+
+	`XCOMGAME.GameRuleset.SubmitGameState(NewGameState);
+	
+	`GAME.GetGeoscape().Pause();
+
+	class'XComHQPresentationLayer'.static.BuildUIAlert(PropertySet, 'eAlert_Doom', class'XComHQPresentationLayer'.static.DoomAlertCB, '', "Geoscape_DoomIncrease");
+	class'X2StrategyGameRulesetDataStructures'.static.AddDynamicIntProperty(PropertySet, 'MissionRef', Mission.ObjectID);
+	class'X2StrategyGameRulesetDataStructures'.static.AddDynamicIntProperty(PropertySet, 'RegionRef', ANCState.Region.ObjectID);
+	class'XComHQPresentationLayer'.static.QueueDynamicPopup(PropertySet, NewGameState);
+}
+
+//---------------------------------------------------------------------------------------
+function RemoveEntity(XComGameState NewGameState)
+{
+	local bool SubmitLocally;
+
+	if (NewGameState == None)
+	{
+		SubmitLocally = true;
+		NewGameState = class'XComGameStateContext_ChangeContainer'.static.CreateChangeState("Alien Network Component Removed");
+	}
+
+	// remove from the history
+	NewGameState.RemoveStateObject(ObjectID);
+
+	if (`HQPRES != none && `HQPRES.StrategyMap2D != none)
+	{
+		RemoveMapPin(NewGameState);
+	}
+
+	if (SubmitLocally)
+	{
+		`XCOMGAME.GameRuleset.SubmitGameState(NewGameState);
+	}
+}
+
+//---------------------------------------------------------------------------------------
+DefaultProperties
+{
+}

--- a/X2WOTCCommunityHighlander/Src/XComGame/Classes/XComGameState_AlienNetworkComponent.uc
+++ b/X2WOTCCommunityHighlander/Src/XComGame/Classes/XComGameState_AlienNetworkComponent.uc
@@ -112,15 +112,18 @@ function bool CanAffordIntelCost()
 function bool Update(XComGameState NewGameState)
 {
 	local XComGameState_HeadquartersAlien AlienHQ;
-	local UIStrategyMap StrategyMap;
+	// Issue #1417: no longer used
+	//local UIStrategyMap StrategyMap;
 	local bool bUpdated;
 	local int HoursToAdd;
 
-	StrategyMap = `HQPRES.StrategyMap2D;
+	// Issue #1417: no longer used
+	//StrategyMap = `HQPRES.StrategyMap2D;
 	bUpdated = false;
 	
 	// Do not modify doom while the Avenger or Skyranger are flying, or if another popup is already being presented
-	if (StrategyMap != none && StrategyMap.m_eUIState != eSMS_Flight && !`HQPRES.ScreenStack.IsCurrentClass(class'UIAlert'))
+	// Issue #1417: Use a more robust check to determine if the game should trigger the update.
+	if (class'CHHelpers'.static.GeoscapeReadyForUpdate())
 	{
 		if (class'X2StrategyGameRulesetDataStructures'.static.LessThan(DoomProjectIntervalEndTime, `STRATEGYRULES.GameTime))
 		{

--- a/X2WOTCCommunityHighlander/Src/XComGame/Classes/XComGameState_BlackMarket.uc
+++ b/X2WOTCCommunityHighlander/Src/XComGame/Classes/XComGameState_BlackMarket.uc
@@ -606,12 +606,14 @@ function CleanUpForSaleItems(XComGameState NewGameState)
 // THIS FUNCTION SHOULD RETURN TRUE IN ALL THE SAME CASES AS Update
 function bool ShouldUpdate( )
 {
-	local UIStrategyMap StrategyMap;
+	// Issue #1417: no longer used
+	//local UIStrategyMap StrategyMap;
 
-	StrategyMap = `HQPRES.StrategyMap2D;
+	//StrategyMap = `HQPRES.StrategyMap2D;
 
 	// Do not trigger anything while the Avenger or Skyranger are flying, or if another popup is already being presented
-	if (StrategyMap != none && StrategyMap.m_eUIState != eSMS_Flight && !`HQPRES.ScreenStack.IsCurrentClass( class'UIAlert' ))
+	// Issue #1417: Use a more robust check to determine if the game should trigger the update.
+	if (class'CHHelpers'.static.GeoscapeReadyForUpdate())
 	{
 		// Check if making contact is complete
 		if (bNeedsScan && IsScanComplete( ))
@@ -627,14 +629,17 @@ function bool ShouldUpdate( )
 // IF ADDING NEW CASES WHERE bModified = true, UPDATE FUNCTION ShouldUpdate ABOVE
 function bool Update(XComGameState NewGameState)
 {
-	local UIStrategyMap StrategyMap;
+	// Issue #1417: no longer used
+	//local UIStrategyMap StrategyMap;
 	local bool bModified;
 
-	StrategyMap = `HQPRES.StrategyMap2D;
+	// Issue #1417: no longer used
+	//StrategyMap = `HQPRES.StrategyMap2D;
 	bModified = false;
 
 	// Do not trigger anything while the Avenger or Skyranger are flying, or if another popup is already being presented
-	if (StrategyMap != none && StrategyMap.m_eUIState != eSMS_Flight && !`HQPRES.ScreenStack.IsCurrentClass(class'UIAlert'))
+	// Issue #1417: Use a more robust check to determine if the game should trigger the update.
+	if (class'CHHelpers'.static.GeoscapeReadyForUpdate())
 	{
 		// Check if making contact is complete
 		if (bNeedsScan && IsScanComplete())

--- a/X2WOTCCommunityHighlander/Src/XComGame/Classes/XComGameState_CovertAction.uc
+++ b/X2WOTCCommunityHighlander/Src/XComGame/Classes/XComGameState_CovertAction.uc
@@ -1544,13 +1544,17 @@ function bool DidRiskOccur(name RiskName)
 function bool ShouldUpdate()
 {
 	local XComGameState_HeadquartersXCom XComHQ;
-	local UIStrategyMap StrategyMap;
+
+	// Issue #1417: no longer used
+	//local UIStrategyMap StrategyMap;
 
 	XComHQ = class'UIUtilities_Strategy'.static.GetXComHQ();
-	StrategyMap = `HQPRES.StrategyMap2D;
+	// Issue #1417: no longer used
+	//StrategyMap = `HQPRES.StrategyMap2D;
 	
 	// Do not trigger anything while the Avenger or Skyranger are flying, or if another popup is already being presented
-	if (StrategyMap != none && StrategyMap.m_eUIState != eSMS_Flight && !`HQPRES.ScreenStack.IsCurrentClass(class'UIAlert'))
+	// Issue #1417: Use a more robust check to determine if the game should trigger the update.
+	if (class'CHHelpers'.static.GeoscapeReadyForUpdate())
 	{
 		if (!bCompleted)
 		{

--- a/X2WOTCCommunityHighlander/Src/XComGame/Classes/XComGameState_Haven.uc
+++ b/X2WOTCCommunityHighlander/Src/XComGame/Classes/XComGameState_Haven.uc
@@ -1,0 +1,470 @@
+//---------------------------------------------------------------------------------------
+//  FILE:    XComGameState_Haven.uc
+//  AUTHOR:  Mark Nauta
+//           
+//---------------------------------------------------------------------------------------
+//  Copyright (c) 2016 Firaxis Games, Inc. All rights reserved.
+//---------------------------------------------------------------------------------------
+class XComGameState_Haven extends XComGameState_ScanningSite
+	config(GameBoard);
+
+var int									AmountForFlyoverPopup;
+
+var bool								bAlertOnXCOMArrival; // Show the Resistance Goods Available popup on arrival
+var bool								bOpenOnXCOMArrival; // Open the Resistance Goods window on arrival
+
+var StateObjectReference				FactionRef; // Some havens are linked to a faction
+
+var localized string                    m_ResHQString;
+
+var config array<int>					MinScanIntelReward;
+var config array<int>					MaxScanIntelReward;
+var config name							ResHQScanResource; // The name of the resource provided by scanning at the Haven
+
+//#############################################################################################
+//----------------   INTIALIZATION   ----------------------------------------------------------
+//#############################################################################################
+
+//---------------------------------------------------------------------------------------
+static function SetUpHavens(XComGameState StartState)
+{
+	local XComGameState_HeadquartersXCom XComHQ;
+	local XComGameState_Haven HavenState;
+
+	foreach StartState.IterateByClassType(class'XComGameState_HeadquartersXCom', XComHQ)
+	{
+		break;
+	}
+
+	foreach StartState.IterateByClassType(class'XComGameState_Haven', HavenState)
+	{
+		// Initialize the continent this haven lives on
+		if(HavenState.Continent.ObjectID == 0)
+		{
+			HavenState.Continent = HavenState.GetWorldRegion().GetContinent().GetReference();
+		}
+		
+		if(HavenState.Region != XComHQ.StartingRegion)
+		{
+			HavenState.bNeedsLocationUpdate = true;
+		}
+	}
+}
+
+//#############################################################################################
+//----------------   UPDATE   -----------------------------------------------------------------
+//#############################################################################################
+
+// THIS FUNCTION SHOULD RETURN TRUE IN ALL THE SAME CASES AS Update
+function bool ShouldUpdate( )
+{
+	local UIStrategyMap StrategyMap;
+
+	StrategyMap = `HQPRES.StrategyMap2D;
+
+	// Do not trigger anything while the Avenger or Skyranger are flying, or if another popup is already being presented
+	if (StrategyMap != none && StrategyMap.m_eUIState != eSMS_Flight && !`HQPRES.ScreenStack.IsCurrentClass( class'UIAlert' ))
+	{
+		if (IsScanComplete( ))
+		{
+			return true;
+		}
+	}
+
+	return false;
+}
+
+//---------------------------------------------------------------------------------------
+// IF ADDING NEW CASES WHERE bUpdated = true, UPDATE FUNCTION ShouldUpdate ABOVE
+function bool Update(XComGameState NewGameState)
+{
+	local XComGameState_HeadquartersXCom XComHQ;
+	local XComGameState_HeadquartersResistance ResHQ;
+	local UIStrategyMap StrategyMap;
+	local bool bUpdated;
+	local int IntelRewardAmt;
+
+	XComHQ = class'UIUtilities_Strategy'.static.GetXComHQ();
+	ResHQ = class'UIUtilities_Strategy'.static.GetResistanceHQ();
+	StrategyMap = `HQPRES.StrategyMap2D;
+	bUpdated = false;
+
+	// Do not trigger anything while the Avenger or Skyranger are flying, or if another popup is already being presented
+	if (StrategyMap != none && StrategyMap.m_eUIState != eSMS_Flight && !`HQPRES.ScreenStack.IsCurrentClass(class'UIAlert'))
+	{
+		if (IsScanComplete())
+		{
+			if (ResHQ.bIntelMode)
+			{
+				//Give intel reward for scanning
+				IntelRewardAmt = GetScanIntelReward();
+
+				if (IntelRewardAmt > 0)
+				{
+					XComHQ.AddResource(NewGameState, 'Intel', IntelRewardAmt);
+					AmountForFlyoverPopup = IntelRewardAmt;
+				}
+			}
+
+			ResetScan();
+			bUpdated = true;
+
+			`XEVENTMGR.TriggerEvent( 'HavenScanComplete', self, , NewGameState );
+		}
+	}
+
+	return bUpdated;
+}
+
+function HandleResistanceLevelChange(XComGameState NewGameState, EResistanceLevelType NewResLevel, EResistanceLevelType OldResLevel)
+{
+	local UIStrategyMapItem MapItem;
+	local XComGameState_GeoscapeEntity ThisEntity;
+
+	if(!NewGameState.GetContext().IsStartState())
+	{
+		// Update the tooltip on the map pin
+		ThisEntity = self;
+
+		if(`HQPRES != none && `HQPRES.StrategyMap2D != none)
+		{
+			MapItem = `HQPRES.StrategyMap2D.GetMapItem(ThisEntity, NewGameState);
+
+			if(MapItem != none)
+			{
+				MapItem.GenerateTooltip(MapItem.MapPin_Tooltip);
+			}
+		}
+	}
+}
+
+//---------------------------------------------------------------------------------------
+function bool IsFactionHQ()
+{
+	return (GetResistanceFaction() != none);
+}
+
+//---------------------------------------------------------------------------------------
+function XComGameState_ResistanceFaction GetResistanceFaction()
+{
+	return XComGameState_ResistanceFaction(`XCOMHISTORY.GetGameStateForObjectID(FactionRef.ObjectID));
+}
+
+//---------------------------------------------------------------------------------------
+function bool IsResistanceFactionMet()
+{
+	local XComGameState_ResistanceFaction FactionState;
+
+	FactionState = GetResistanceFaction();
+
+	return (FactionState != none && FactionState.bMetXCom);
+}
+
+//---------------------------------------------------------------------------------------
+function X2ResistanceModeTemplate GetResistanceMode()
+{
+	return GetResistanceFaction().GetResistanceMode();
+}
+
+//#############################################################################################
+//----------------   REWARDS   ----------------------------------------------------------------
+//#############################################################################################
+
+//---------------------------------------------------------------------------------------
+function int GetScanIntelReward()
+{
+	local XComGameStateHistory History;
+	local XComGameState_HeadquartersResistance ResistanceHQ;
+	local int IntelReward;
+
+	IntelReward = `ScaleStrategyArrayInt(default.MinScanIntelReward) + `SYNC_RAND(`ScaleStrategyArrayInt(default.MaxScanIntelReward) - `ScaleStrategyArrayInt(default.MinScanIntelReward) + 1);
+	
+	// Check for Spy Ring Continent Bonus
+	History = `XCOMHISTORY;
+	ResistanceHQ = XComGameState_HeadquartersResistance(History.GetSingleGameStateObjectForClass(class'XComGameState_HeadquartersResistance'));
+
+	IntelReward += Round(float(IntelReward) * (float(ResistanceHQ.IntelRewardPercentIncrease) / 100.0));
+
+	return IntelReward;
+}
+
+//#############################################################################################
+//----------------   Geoscape Entity Implementation   -----------------------------------------
+//#############################################################################################
+
+function string GetDisplayName()
+{
+	local XComGameState_ResistanceFaction FactionState;
+
+	FactionState = GetResistanceFaction();
+
+	if(FactionState != none)
+	{
+		return FactionState.GetMyTemplate().FactionHQDisplayName;
+	}
+
+	return "";
+}
+
+function string GetScanDescription()
+{
+	local XComGameState_ResistanceFaction FactionState;
+
+	FactionState = GetResistanceFaction();
+
+	if(FactionState != none)
+	{
+		return FactionState.GetResistanceModeLabel();
+	}
+
+	return "";
+}
+
+function string GetScanTooltip()
+{
+	local XComGameState_ResistanceFaction FactionState;
+
+	FactionState = GetResistanceFaction();
+
+	if(FactionState != none)
+	{
+		return FactionState.GetResistanceMode().ScanTooltip;
+	}
+
+	return "";
+}
+
+function bool CanBeScanned()
+{
+	return IsResistanceFactionMet();
+}
+
+function bool HasTooltipBounds()
+{
+	// Placed at the start of the game, so need to always have bounds active
+	return (IsFactionHQ() || GetWorldRegion().IsStartingRegion());
+}
+
+function MakeScanRepeatable()
+{
+	bScanRepeatable = true;
+}
+
+function bool ShouldBeVisible()
+{
+	local XComGameState_ResistanceFaction FactionState;
+	local XComGameState_WorldRegion RegionState;
+	
+	FactionState = GetResistanceFaction();
+	RegionState = GetWorldRegion();
+
+	if (FactionState == none)
+	{
+		return (ResistanceActive() && (RegionState != none && RegionState.ResistanceLevel == eResLevel_Outpost));
+	}
+	else
+	{
+		return IsResistanceFactionMet();
+	}
+}
+
+function class<UIStrategyMapItem> GetUIClass()
+{
+	if (IsFactionHQ())
+		return class'UIStrategyMapItem_ResistanceHQ';
+	else
+		return class'UIStrategyMapItem_Haven';
+}
+
+// The static mesh for this entities 3D UI
+function StaticMesh GetStaticMesh()
+{
+	local Object MeshObject;
+
+	if (IsFactionHQ())
+	{
+		MeshObject = `CONTENT.RequestGameArchetype(GetResistanceFaction().GetMyTemplate().OverworldMeshPath);
+		if (MeshObject != none && MeshObject.IsA('StaticMesh'))
+		{
+			return StaticMesh(MeshObject);
+		}
+	}
+	
+	return StaticMesh'UI_3D.Overwold_Final.RadioTower';
+}
+
+// Scale adjustment for the 3D UI static mesh
+function vector GetMeshScale()
+{
+	local vector ScaleVector;
+
+	ScaleVector.X = 1.0;
+	ScaleVector.Y = 1.0;
+	ScaleVector.Z = 1.0;
+
+	return ScaleVector;
+}
+
+// Rotation adjustment for the 3D UI static mesh
+function Rotator GetMeshRotator()
+{
+	local Rotator MeshRotation;
+
+	MeshRotation.Roll = 0;
+	MeshRotation.Pitch = 0;
+	MeshRotation.Yaw = 0;
+
+	return MeshRotation;
+}
+
+protected function bool CanInteract()
+{
+	return (ResistanceActive() && IsResistanceFactionMet());
+}
+
+//---------------------------------------------------------------------------------------
+protected function bool DisplaySelectionPrompt()
+{
+	local XComGameState_HeadquartersXCom XComHQ;
+
+	XComHQ = class'UIUtilities_Strategy'.static.GetXComHQ();
+
+	// if click here and XComHQ is not in the region, fly to it
+	if (XComHQ.CurrentLocation != GetReference())
+	{
+		return false;
+	}
+
+	return true;
+}
+
+function UpdateGameBoard()
+{
+	local XComGameState NewGameState;
+	local XComGameState_Haven HavenState;
+	local bool bSuccess;
+
+	if (ShouldUpdate())
+	{
+		NewGameState = class'XComGameStateContext_ChangeContainer'.static.CreateChangeState("Update Haven");
+
+		HavenState = XComGameState_Haven(NewGameState.ModifyStateObject(class'XComGameState_Haven', ObjectID));
+
+		bSuccess = HavenState.Update(NewGameState);
+		`assert( bSuccess );
+
+		`XCOMGAME.GameRuleset.SubmitGameState(NewGameState);
+	}
+
+	if (AmountForFlyoverPopup > 0)
+	{
+		FlyoverPopup();
+	}
+}
+
+//---------------------------------------------------------------------------------------
+function DestinationReached()
+{
+	super.DestinationReached();
+	OnXCOMArrives();
+}
+
+//---------------------------------------------------------------------------------------
+function OnXCOMArrives()
+{
+	local XComGameState NewGameState;
+
+	if(GetResistanceMode().OnXCOMArrivesFn != none)
+	{
+		NewGameState = class'XComGameStateContext_ChangeContainer'.static.CreateChangeState("Arrive Res HQ: Apply Scan Mode Bonus");
+		GetResistanceMode().OnXCOMArrivesFn(NewGameState, self.GetReference());
+		`XCOMGAME.GameRuleset.SubmitGameState(NewGameState);
+	}
+}
+
+function OnXComLeaveSite()
+{
+	super.OnXComLeaveSite();
+	OnXCOMLeaves();
+}
+
+//---------------------------------------------------------------------------------------
+function OnXCOMLeaves()
+{
+	local XComGameState NewGameState;
+
+	if(GetResistanceMode().OnXCOMLeavesFn != none)
+	{
+		NewGameState = class'XComGameStateContext_ChangeContainer'.static.CreateChangeState("Leave Res HQ: Remove Scan Mode Bonus");
+		GetResistanceMode().OnXCOMLeavesFn(NewGameState, self.GetReference());
+		`XCOMGAME.GameRuleset.SubmitGameState(NewGameState);
+	}
+}
+
+simulated function OutpostBuiltCB(Name eAction, out DynamicPropertySet AlertData, optional bool bInstant = false)
+{
+	local XComGameState_HeadquartersXCom XComHQ;
+
+	if( eAction == 'eUIAction_Accept' || eAction == 'eUIAction_Cancel' )
+	{
+		XComHQ = class'UIUtilities_Strategy'.static.GetXComHQ();
+		if( !XComHQ.bHasSeenSupplyDropReminder && XComHQ.IsSupplyDropAvailable() )
+		{
+			`HQPRES.UISupplyDropReminder();
+		}
+
+		`GAME.GetGeoscape().Resume();
+	}
+}
+
+//---------------------------------------------------------------------------------------
+simulated public function FlyoverPopup()
+{
+	local XComGameState NewGameState;
+	local XComGameState_Haven HavenState;
+	local string FlyoverResourceName;
+	local Vector2D MessageLocation; 
+		
+	`XSTRATEGYSOUNDMGR.PlaySoundEvent("StrategyUI_Flyover_Intel");
+
+	FlyoverResourceName = class'UIUtilities_Strategy'.static.GetResourceDisplayName(ResHQScanResource, AmountForFlyoverPopup);
+	MessageLocation = Get2DLocation();
+	MessageLocation.Y -= 0.006; //scoot above the pin
+	`HQPRES.QueueWorldMessage(FlyoverResourceName $ " +" $ AmountForFlyoverPopup, `EARTH.ConvertEarthToWorld(MessageLocation), , , , , , , , 2.0);
+	`HQPRES.m_kAvengerHUD.UpdateResources();
+
+	NewGameState = class'XComGameStateContext_ChangeContainer'.static.CreateChangeState("Toggle Flyover Popup");
+	HavenState = XComGameState_Haven(NewGameState.ModifyStateObject(class'XComGameState_Haven', self.ObjectID));
+	HavenState.AmountForFlyoverPopup = 0;
+	`XCOMGAME.GameRuleset.SubmitGameState(NewGameState);
+}
+
+simulated function string GetUIButtonTooltipTitle()
+{
+	local XComGameState_WorldRegion WorldRegion;
+
+	WorldRegion = GetWorldRegion();
+	if (WorldRegion != none)
+		return class'UIUtilities_Text'.static.CapsCheckForGermanScharfesS(GetDisplayName()$":" @ GetWorldRegion().GetDisplayName());
+
+	return class'UIUtilities_Text'.static.CapsCheckForGermanScharfesS(GetDisplayName());
+}
+
+simulated function string GetUIButtonTooltipBody()
+{
+	return GetScanDescription();
+}
+
+simulated function string GetUIButtonIcon()
+{
+	if(CanBeScanned())
+		return "img:///UILibrary_StrategyImages.X2StrategyMap.MissionIcon_ResHQ";
+	else
+		return "img:///UILibrary_XPACK_StrategyImages.Faction_unknown";
+}
+
+//---------------------------------------------------------------------------------------
+DefaultProperties
+{
+	bCheckForOverlaps = false;
+}

--- a/X2WOTCCommunityHighlander/Src/XComGame/Classes/XComGameState_Haven.uc
+++ b/X2WOTCCommunityHighlander/Src/XComGame/Classes/XComGameState_Haven.uc
@@ -58,12 +58,14 @@ static function SetUpHavens(XComGameState StartState)
 // THIS FUNCTION SHOULD RETURN TRUE IN ALL THE SAME CASES AS Update
 function bool ShouldUpdate( )
 {
-	local UIStrategyMap StrategyMap;
+	// Issue #1417: no longer used
+	//local UIStrategyMap StrategyMap;
 
-	StrategyMap = `HQPRES.StrategyMap2D;
+	//StrategyMap = `HQPRES.StrategyMap2D;
 
 	// Do not trigger anything while the Avenger or Skyranger are flying, or if another popup is already being presented
-	if (StrategyMap != none && StrategyMap.m_eUIState != eSMS_Flight && !`HQPRES.ScreenStack.IsCurrentClass( class'UIAlert' ))
+	// Issue #1417: Use a more robust check to determine if the game should trigger the update.
+	if (class'CHHelpers'.static.GeoscapeReadyForUpdate())
 	{
 		if (IsScanComplete( ))
 		{
@@ -80,17 +82,20 @@ function bool Update(XComGameState NewGameState)
 {
 	local XComGameState_HeadquartersXCom XComHQ;
 	local XComGameState_HeadquartersResistance ResHQ;
-	local UIStrategyMap StrategyMap;
+	// Issue #1417: no longer used
+	//local UIStrategyMap StrategyMap;
 	local bool bUpdated;
 	local int IntelRewardAmt;
 
 	XComHQ = class'UIUtilities_Strategy'.static.GetXComHQ();
 	ResHQ = class'UIUtilities_Strategy'.static.GetResistanceHQ();
-	StrategyMap = `HQPRES.StrategyMap2D;
+	// Issue #1417: no longer used
+	//StrategyMap = `HQPRES.StrategyMap2D;
 	bUpdated = false;
 
 	// Do not trigger anything while the Avenger or Skyranger are flying, or if another popup is already being presented
-	if (StrategyMap != none && StrategyMap.m_eUIState != eSMS_Flight && !`HQPRES.ScreenStack.IsCurrentClass(class'UIAlert'))
+	// Issue #1417: Use a more robust check to determine if the game should trigger the update.
+	if (class'CHHelpers'.static.GeoscapeReadyForUpdate())
 	{
 		if (IsScanComplete())
 		{

--- a/X2WOTCCommunityHighlander/Src/XComGame/Classes/XComGameState_HeadquartersResistance.uc
+++ b/X2WOTCCommunityHighlander/Src/XComGame/Classes/XComGameState_HeadquartersResistance.uc
@@ -279,14 +279,17 @@ function name SelectNextSoldierClass()
 // returns true if an internal value has changed (lots of time checks)
 function bool Update(XComGameState NewGameState)
 {
-	local UIStrategyMap StrategyMap;
+	// Issue #1417: no longer used
+	//local UIStrategyMap StrategyMap;
 	local bool bUpdated;
 
-	StrategyMap = `HQPRES.StrategyMap2D;
+	// Issue #1417: no longer used
+	//StrategyMap = `HQPRES.StrategyMap2D;
 	bUpdated = false;
 	
 	// Don't trigger end of month while the Avenger or Skyranger are flying, or if another popup is already being presented
-	if (StrategyMap != none && StrategyMap.m_eUIState != eSMS_Flight && !`HQPRES.ScreenStack.IsCurrentClass(class'UIAlert'))
+	// Issue #1417: Use a more robust check to determine if the game should trigger the update.
+	if (class'CHHelpers'.static.GeoscapeReadyForUpdate())
 	{
 		if (!bInactive)
 		{

--- a/X2WOTCCommunityHighlander/Src/XComGame/Classes/XComGameState_MissionCalendar.uc
+++ b/X2WOTCCommunityHighlander/Src/XComGame/Classes/XComGameState_MissionCalendar.uc
@@ -1,0 +1,650 @@
+//---------------------------------------------------------------------------------------
+//  FILE:    XComGameState_MissionCalendar.uc
+//  AUTHOR:  Mark Nauta
+//           
+//---------------------------------------------------------------------------------------
+//  Copyright (c) 2016 Firaxis Games, Inc. All rights reserved.
+//---------------------------------------------------------------------------------------
+class XComGameState_MissionCalendar extends XComGameState_BaseObject config(GameData);
+
+var array<MissionCalendarDate>			CurrentMissionMonth;
+var TDateTime							MonthEndTime;
+var float								RetaliationSpawnTimeDecrease;
+var name								CurrentMissionDeckName;
+var array<RandomMissionDeck>			CurrentRandomMissionDecks;
+
+// Reward Decks
+var array<MissionRewardDeck>			MissionRewardDecks;
+var array<MissionRewardDeck>			MissionRewardExcludeDecks;
+
+// Created Missions
+var array<name>							CreatedMissionSources;
+
+// Popup Flags
+var array<name>							MissionPopupSources;
+
+var config int							MissionSpawnVariance; // Hours
+var config array<name>					StartingMissionDeck;
+var config name							EndGameMissionDeck;
+var config name							BlankMissionName;
+var config array<MissionDeck>			MissionDecks;  // Schedule of mission sources for each month
+var config array<RandomMissionDeck>		RandomMissionDecks; // Some entries in the mission schedule will call for a random mission
+
+
+// #######################################################################################
+// -------------------- INITIALIZATION ---------------------------------------------------
+// #######################################################################################
+
+//---------------------------------------------------------------------------------------
+static function SetupCalendar(XComGameState StartState)
+{
+	local XComGameState_MissionCalendar CalendarState;
+
+	CalendarState = XComGameState_MissionCalendar(StartState.CreateNewStateObject(class'XComGameState_MissionCalendar'));
+
+	CalendarState.OnEndOfMonth(StartState);
+}
+
+// #######################################################################################
+// -------------------- UPDATE -----------------------------------------------------------
+// #######################################################################################
+
+//---------------------------------------------------------------------------------------
+function bool Update(XComGameState NewGameState)
+{
+	local UIStrategyMap StrategyMap;
+	local int idx;
+
+	StrategyMap = `HQPRES.StrategyMap2D;
+
+	// Do not spawn any new missions while the Avenger or Skyranger are flying, or if another popup is already being presented
+	if (StrategyMap != none && StrategyMap.m_eUIState != eSMS_Flight && !`HQPRES.ScreenStack.IsCurrentClass(class'UIAlert'))
+	{
+		// Check for mission events
+		for (idx = 0; idx < CurrentMissionMonth.Length; idx++)
+		{
+			if (class'X2StrategyGameRulesetDataStructures'.static.LessThan(CurrentMissionMonth[idx].SpawnDate, `STRATEGYRULES.GameTime))
+			{
+				SpawnMissions(NewGameState, idx);
+				CurrentMissionMonth.Remove(idx, 1);
+				return true;
+			}
+		}
+
+		// Check for end of month
+		if (class'X2StrategyGameRulesetDataStructures'.static.LessThan(MonthEndTime, `STRATEGYRULES.GameTime))
+		{
+			OnEndOfMonth(NewGameState);
+			return true;
+		}
+	}
+	
+	return false;
+}
+
+//---------------------------------------------------------------------------------------
+function bool HasCreatedMissionOfSource(name MissionSourceName)
+{
+	return (CreatedMissionSources.Find(MissionSourceName) != INDEX_NONE);
+}
+
+//---------------------------------------------------------------------------------------
+function bool HasCreatedMultipleMissionsOfSource(name MissionSourceName)
+{
+	local name CreatedMissionName;
+	local bool bFoundOneMission;
+
+	foreach CreatedMissionSources(CreatedMissionName)
+	{		
+		if (!bFoundOneMission && CreatedMissionName == MissionSourceName)
+		{
+			// If the first instance of the mission has not been found yet, flag one as found
+			bFoundOneMission = true;
+		}
+		else if(CreatedMissionName == MissionSourceName)
+		{
+			// If one match was found, and we just found another, there are multiple missions, so return true
+			return true;
+		}
+	}
+
+	return false;
+}
+
+//---------------------------------------------------------------------------------------
+function int GetNumTimesMissionSourceCreated(name MissionSourceName)
+{
+	local name CreatedMissionName;
+	local int Count;
+
+	Count = 0;
+
+	foreach CreatedMissionSources(CreatedMissionName)
+	{
+		if(CreatedMissionName == MissionSourceName)
+		{
+			Count++;
+		}
+	}
+
+	return Count;
+}
+
+//---------------------------------------------------------------------------------------
+function OnEndOfMonth(XComGameState NewGameState)
+{
+	local MissionCalendarDate MissionDate;
+	local TDateTime CurrentTime;
+	local MissionDeck CurrentMissionDeck;
+	local array<name> ExcludeMissions;
+	local name DeckName, LastMission, LastRandomMission;
+	local int MonthHours, SpawnInterval, HoursToAdd, idx;
+	local XComGameState_HeadquartersResistance ResHQ;
+	local bool bStartCalendar;
+
+	// Grab current datetime
+	CurrentTime = class'XComGameState_GeoscapeEntity'.static.GetCurrentTime();
+	bStartCalendar = false;
+
+	// Select Mission Deck
+	if(CurrentMissionDeckName == '')
+	{
+		CurrentMissionDeckName = GetStartingMissionDeck();
+		bStartCalendar = true;
+	}
+	else
+	{
+		if(GetMissionDeckByName(CurrentMissionDeckName, CurrentMissionDeck))
+		{
+			DeckName = CurrentMissionDeck.NextDeckName;
+
+			if(GetMissionDeckByName(DeckName, CurrentMissionDeck))
+			{
+				CurrentMissionDeckName = DeckName;
+			}
+		}
+	}
+
+	if(!GetMissionDeckByName(CurrentMissionDeckName, CurrentMissionDeck))
+	{
+		`RedScreen("Could not find a valid mission deck for calendar. @Gameplay @mnauta");
+	}
+
+	// Schedule end of month
+	if(!bStartCalendar)
+	{
+		// Don't adjust in the end game
+		if(!class'XComGameState_HeadquartersXCom'.static.IsObjectiveCompleted('T5_M1_AutopsyTheAvatar'))
+		{
+			// Readjust time down to start of ResHQ month
+			ResHQ = XComGameState_HeadquartersResistance(`XCOMHISTORY.GetSingleGameStateObjectForClass(class'XComGameState_HeadquartersResistance'));
+
+			if(class'X2StrategyGameRulesetDataStructures'.static.LessThan(ResHQ.MonthIntervalEndTime, CurrentTime))
+			{
+				CurrentTime = ResHQ.MonthIntervalStartTime;
+			}
+		}
+	}
+
+	MonthEndTime = CurrentTime;
+	class'X2StrategyGameRulesetDataStructures'.static.AddDays(MonthEndTime, CurrentMissionDeck.MissionMonthDays);
+
+	// Clear mission month
+	CurrentMissionMonth.Length = 0;
+
+	// Find default spawn interval, Month length/num of mission events
+	MonthHours = CurrentMissionDeck.MissionMonthDays * 24;
+	SpawnInterval = MonthHours / CurrentMissionDeck.Missions.Length;
+
+	// Plot mission events across the month
+	LastMission = '';
+	LastRandomMission = '';
+	for(idx = 0; idx < CurrentMissionDeck.Missions.Length; idx++)
+	{
+		if(CurrentMissionDeck.Missions[idx].MissionSource != '')
+		{
+			MissionDate.MissionSource = CurrentMissionDeck.Missions[idx].MissionSource;
+		}
+		else if(CurrentMissionDeck.Missions[idx].RandomDeckName != '')
+		{
+			ExcludeMissions.Length = 0;
+
+			if(LastRandomMission != '')
+			{
+				ExcludeMissions.AddItem(LastRandomMission);
+			}
+
+			if(CurrentMissionDeck.bForceNoConsecutive)
+			{
+				if(LastMission != '' && LastMission != LastRandomMission)
+				{
+					ExcludeMissions.AddItem(LastMission);
+				}
+
+			}
+
+			MissionDate.MissionSource = GetNextRandomMission(CurrentMissionDeck.Missions[idx].RandomDeckName, ExcludeMissions);
+		}
+		else
+		{
+			`RedScreen("Bad entry in mission deck for calendar. @Gameplay @mnauta");
+		}
+		
+		MissionDate.SpawnDate = CurrentTime;
+
+		HoursToAdd = SpawnInterval * (idx + 1);
+		HoursToAdd -= `SYNC_RAND(default.MissionSpawnVariance);
+		class'X2StrategyGameRulesetDataStructures'.static.AddHours(MissionDate.SpawnDate, HoursToAdd);
+
+		CurrentMissionMonth.AddItem(MissionDate);
+		LastMission = MissionDate.MissionSource;
+	}
+
+	CreateMissions(NewGameState);
+
+	if(bStartCalendar && !(XComGameState_CampaignSettings(`XCOMHISTORY.GetSingleGameStateObjectForClass(class'XComGameState_CampaignSettings')).bXPackNarrativeEnabled))
+	{
+		MoveFirstRetaliation();
+	}
+}
+
+//---------------------------------------------------------------------------------------
+private function MoveFirstRetaliation()
+{
+	local XComGameState_HeadquartersResistance ResHQ;
+	local TDateTime NewTime;
+	local int idx;
+
+	ResHQ = XComGameState_HeadquartersResistance(`XCOMHISTORY.GetSingleGameStateObjectForClass(class'XComGameState_HeadquartersResistance'));
+	NewTime = ResHQ.MonthIntervalEndTime;
+
+	// Ensure the mission appears more than the max mission expire time before the first resistance report
+	class'X2StrategyGameRulesetDataStructures'.static.RemoveHours(NewTime, (class'X2StrategyElement_DefaultMissionSources'.default.MissionMaxDuration + `SYNC_RAND(10) + 1));
+
+	for(idx = 0; idx < CurrentMissionMonth.Length; idx++)
+	{
+		if(CurrentMissionMonth[idx].MissionSource == 'MissionSource_Retaliation')
+		{
+			CurrentMissionMonth[idx].SpawnDate = NewTime;
+			break;
+		}
+	}
+}
+
+//---------------------------------------------------------------------------------------
+// From config
+function bool GetMissionDeckByName(name DeckName, out MissionDeck FoundDeck)
+{
+	local int idx;
+
+	for(idx = 0; idx < default.MissionDecks.Length; idx++)
+	{
+		if(default.MissionDecks[idx].DeckName == DeckName)
+		{
+			FoundDeck = default.MissionDecks[idx];
+			return true;
+		}
+	}
+
+	return false;
+}
+
+//---------------------------------------------------------------------------------------
+// From config
+function bool GetNextMissionDeck(out MissionDeck FoundDeck)
+{
+	local MissionDeck CurrentMissionDeck;
+
+	if(GetMissionDeckByName(CurrentMissionDeckName, CurrentMissionDeck))
+	{
+		if(GetMissionDeckByName(CurrentMissionDeck.NextDeckName, FoundDeck))
+		{
+			return true;
+		}
+	}
+
+	return false;
+}
+
+//---------------------------------------------------------------------------------------
+// From config
+function bool GetRandomMissionDeckByName(name DeckName, out RandomMissionDeck FoundDeck)
+{
+	local int idx;
+
+	for(idx = 0; idx < default.RandomMissionDecks.Length; idx++)
+	{
+		if(default.RandomMissionDecks[idx].DeckName == DeckName)
+		{
+			FoundDeck = default.RandomMissionDecks[idx];
+			return true;
+		}
+	}
+
+	return false;
+}
+
+//---------------------------------------------------------------------------------------
+function name GetNextRandomMission(name DeckName, optional array<name> ExcludeMissions)
+{
+	local name MissionName;
+	local int Index, MissionIndex, idx;
+	local array<name> Missions;
+
+	Index = CurrentRandomMissionDecks.Find('DeckName', DeckName);
+
+	if(Index == INDEX_NONE)
+	{
+		AddRandomMissionDeck(DeckName);
+	}
+	else if(CurrentRandomMissionDecks[Index].Missions.Length == 0 || (ExcludeMissions.Length != 0 && NeedToExtendRandomMissionDeck(CurrentRandomMissionDecks[Index], ExcludeMissions)))
+	{
+		AddRandomMissionDeck(DeckName);
+	}
+
+	Index = CurrentRandomMissionDecks.Find('DeckName', DeckName);
+	Missions = CurrentRandomMissionDecks[Index].Missions;
+	
+	if(ExcludeMissions.Length != 0)
+	{
+		for(idx = 0; idx < Missions.Length; idx++)
+		{
+			if(ExcludeMissions.Find(Missions[idx]) != INDEX_NONE)
+			{
+				Missions.Remove(idx, 1);
+				idx--;
+			}
+		}
+	}
+
+	if(Missions.Length == 0)
+	{
+		`RedScreen("Problem in getting random mission for calendar. @Gameplay @mnauta");
+	}
+
+	MissionName = Missions[`SYNC_RAND(Missions.Length)];
+	MissionIndex = CurrentRandomMissionDecks[Index].Missions.Find(MissionName);
+	CurrentRandomMissionDecks[Index].Missions.Remove(MissionIndex, 1);
+
+	return MissionName;
+}
+
+//---------------------------------------------------------------------------------------
+function AddRandomMissionDeck(name DeckName)
+{
+	local RandomMissionDeck FoundDeck;
+	local int Index, idx;
+
+	Index = CurrentRandomMissionDecks.Find('DeckName', DeckName);
+
+	if(Index == INDEX_NONE)
+	{
+		if(GetRandomMissionDeckByName(DeckName, FoundDeck))
+		{
+			CurrentRandomMissionDecks.AddItem(FoundDeck);
+		}
+		else
+		{
+			`RedScreen("Problem in getting random mission for calendar. @Gameplay @mnauta");
+		}
+		
+	}
+	else if(CurrentRandomMissionDecks[Index].Missions.Length == 0)
+	{
+		if(GetRandomMissionDeckByName(DeckName, FoundDeck))
+		{
+			CurrentRandomMissionDecks[Index].Missions = FoundDeck.Missions;
+		}
+		else
+		{
+			`RedScreen("Problem in getting random mission for calendar. @Gameplay @mnauta");
+		}
+	}
+	else
+	{
+		if(GetRandomMissionDeckByName(DeckName, FoundDeck))
+		{
+			for(idx = 0; idx < FoundDeck.Missions.Length; idx++)
+			{
+				CurrentRandomMissionDecks[Index].Missions.AddItem(FoundDeck.Missions[idx]);
+			}
+		}
+		else
+		{
+			`RedScreen("Problem in getting random mission for calendar. @Gameplay @mnauta");
+		}
+	}
+}
+
+//---------------------------------------------------------------------------------------
+function bool NeedToExtendRandomMissionDeck(RandomMissionDeck RandomDeck, array<name> ExcludeMissions)
+{
+	local int idx;
+
+	for(idx = 0; idx < RandomDeck.Missions.Length; idx++)
+	{
+		if(ExcludeMissions.Find(RandomDeck.Missions[idx]) == INDEX_NONE)
+		{
+			return false;
+		}
+	}
+
+	return true;
+}
+
+//---------------------------------------------------------------------------------------
+function bool GetNextDateForMissionSource(name MissionSourceName, out TDateTime MissionDateTime)
+{
+	local array<MissionCalendarDate> NextMissionMonth;
+	local int Index;
+
+	Index = CurrentMissionMonth.Find('MissionSource', MissionSourceName);
+
+	if(Index != INDEX_NONE)
+	{
+		MissionDateTime = CurrentMissionMonth[Index].SpawnDate;
+		return true;
+	}
+
+	NextMissionMonth = GetNextProjectedMissionMonth();
+
+	Index = NextMissionMonth.Find('MissionSource', MissionSourceName);
+
+	if(Index != INDEX_NONE)
+	{
+		MissionDateTime = NextMissionMonth[Index].SpawnDate;
+
+		// Retaliation Spawn time decrease var is only used if next retaliation mission is in next mission month
+		if(MissionSourceName == 'MissionSource_Retaliation')
+		{
+			class'X2StrategyGameRulesetDataStructures'.static.RemoveTime(MissionDateTime, RetaliationSpawnTimeDecrease);
+		}
+
+		return true;
+	}
+
+	return false;
+}
+
+//---------------------------------------------------------------------------------------
+// Random spots are will have empty mission source name
+function array<MissionCalendarDate> GetNextProjectedMissionMonth()
+{
+	local MissionDeck NextMissionDeck;
+	local array<MissionCalendarDate> NextMissionMonth;
+	local MissionCalendarDate MissionDate;
+	local TDateTime NextMonthEndTime;
+	local int MonthHours, SpawnInterval, HoursToAdd, idx;
+
+	// Get Next Mission Deck
+	if(!GetNextMissionDeck(NextMissionDeck))
+	{
+		`RedScreen("Problem in finding next mission deck for calendar. @Gameplay @mnauta");
+	}
+
+	// Schedule end of next month
+	NextMonthEndTime = MonthEndTime;
+	class'X2StrategyGameRulesetDataStructures'.static.AddDays(NextMonthEndTime, NextMissionDeck.MissionMonthDays);
+
+	// Find default spawn interval, Month length/num of mission events
+	MonthHours = NextMissionDeck.MissionMonthDays * 24;
+	SpawnInterval = MonthHours / NextMissionDeck.Missions.Length;
+
+	// Plot mission events across the month
+	for(idx = 0; idx < NextMissionDeck.Missions.Length; idx++)
+	{
+		MissionDate.MissionSource = NextMissionDeck.Missions[idx].MissionSource;
+		MissionDate.SpawnDate = MonthEndTime;
+
+		HoursToAdd = SpawnInterval * (idx + 1);
+		class'X2StrategyGameRulesetDataStructures'.static.AddHours(MissionDate.SpawnDate, HoursToAdd);
+
+		NextMissionMonth.AddItem(MissionDate);
+	}
+
+	return NextMissionMonth;
+}
+
+//---------------------------------------------------------------------------------------
+function name GetNextMissionSource()
+{
+	local array<MissionCalendarDate> NextMissionMonth;
+
+	if (CurrentMissionMonth.Length > 0)
+	{
+		return CurrentMissionMonth[0].MissionSource;
+	}
+	else
+	{
+		NextMissionMonth = GetNextProjectedMissionMonth();
+		return NextMissionMonth[0].MissionSource;
+	}
+}
+
+//---------------------------------------------------------------------------------------
+function X2MissionSourceTemplate GetNextMissionSourceTemplate()
+{
+	local X2StrategyElementTemplateManager StratMgr;
+
+	StratMgr = class'X2StrategyElementTemplateManager'.static.GetStrategyElementTemplateManager();
+	return X2MissionSourceTemplate(StratMgr.FindStrategyElementTemplate(GetNextMissionSource()));
+}
+
+//---------------------------------------------------------------------------------------
+function TDateTime GetBestNewMissionDateBetweenMissions(int NumMissionsToCheck)
+{
+	local array<MissionCalendarDate> DatesToCheck, NextMissionMonth;
+	local TDateTime BestTimeFrameStart;
+	local int idx, TimeFrameLength, BestTimeFrameLength, NumMissionsToAdd;
+
+	DatesToCheck = CurrentMissionMonth;
+	if (DatesToCheck.Length < (NumMissionsToCheck + 1))
+	{
+		NextMissionMonth = GetNextProjectedMissionMonth();
+		
+		// Add projected mission dates to our list until we have the required number
+		NumMissionsToAdd = NumMissionsToCheck - DatesToCheck.Length;
+		while (idx < NumMissionsToAdd)
+		{
+			DatesToCheck.AddItem(NextMissionMonth[idx]);
+			idx++;
+		}
+	}
+
+	if (NumMissionsToCheck == 0)
+	{
+		BestTimeFrameLength = class'X2StrategyGameRulesetDataStructures'.static.DifferenceInHours(DatesToCheck[0].SpawnDate, `STRATEGYRULES.GameTime);
+		BestTimeFrameStart = `STRATEGYRULES.GameTime;
+	}
+	else
+	{
+		for (idx = 1; idx <= NumMissionsToCheck; idx++)
+		{
+			TimeFrameLength = class'X2StrategyGameRulesetDataStructures'.static.DifferenceInHours(DatesToCheck[idx].SpawnDate, DatesToCheck[idx - 1].SpawnDate);
+			if (TimeFrameLength > BestTimeFrameLength)
+			{
+				BestTimeFrameLength = TimeFrameLength;
+				BestTimeFrameStart = DatesToCheck[idx - 1].SpawnDate;
+			}
+		}
+	}
+	
+	// Add half of the best time frame length, so the new mission will appear halfway between the two longest-separated missions
+	class'X2StrategyGameRulesetDataStructures'.static.AddHours(BestTimeFrameStart, BestTimeFrameLength / 2);
+	
+	return BestTimeFrameStart;
+}
+
+function SwitchToEndGameMissions(XComGameState NewGameState)
+{
+	CurrentMissionDeckName = default.EndGameMissionDeck;
+
+	OnEndOfMonth(NewGameState); // Clear the current month and generate a new one
+}
+
+// #######################################################################################
+// -------------------- MISSION GENERATION -----------------------------------------------
+// #######################################################################################
+
+//---------------------------------------------------------------------------------------
+function CreateMissions(XComGameState NewGameState)
+{
+	local X2StrategyElementTemplateManager StratMgr;
+	local X2MissionSourceTemplate MissionSource;
+	local int idx;
+
+	StratMgr = class'X2StrategyElementTemplateManager'.static.GetStrategyElementTemplateManager();
+
+	for(idx = 0; idx < CurrentMissionMonth.Length; idx++)
+	{
+		if(CurrentMissionMonth[idx].MissionSource != default.BlankMissionName)
+		{
+			MissionSource = X2MissionSourceTemplate(StratMgr.FindStrategyElementTemplate(CurrentMissionMonth[idx].MissionSource));
+
+			if(MissionSource != none && MissionSource.CreateMissionsFn != none)
+			{
+				MissionSource.CreateMissionsFn(NewGameState, idx);
+			}
+		}
+	}
+}
+
+
+
+// #######################################################################################
+// -------------------- MISSION SPAWNING -------------------------------------------------
+// #######################################################################################
+
+//---------------------------------------------------------------------------------------
+function SpawnMissions(XComGameState NewGameState, int MissionMonthIndex)
+{
+	local X2StrategyElementTemplateManager StratMgr;
+	local X2MissionSourceTemplate MissionSource;
+
+	if(CurrentMissionMonth[MissionMonthIndex].MissionSource != default.BlankMissionName)
+	{
+		StratMgr = class'X2StrategyElementTemplateManager'.static.GetStrategyElementTemplateManager();
+		MissionSource = X2MissionSourceTemplate(StratMgr.FindStrategyElementTemplate(CurrentMissionMonth[MissionMonthIndex].MissionSource));
+
+		if(MissionSource != none && MissionSource.SpawnMissionsFn != none)
+		{
+			MissionSource.SpawnMissionsFn(NewGameState, MissionMonthIndex);
+		}
+	}
+}
+
+// #######################################################################################
+// -------------------- DIFFICULTY HELPERS -----------------------------------------------
+// #######################################################################################
+
+//---------------------------------------------------------------------------------------
+function name GetStartingMissionDeck()
+{
+	return default.StartingMissionDeck[`StrategyDifficultySetting];
+}
+
+//---------------------------------------------------------------------------------------
+DefaultProperties
+{
+
+}

--- a/X2WOTCCommunityHighlander/Src/XComGame/Classes/XComGameState_MissionCalendar.uc
+++ b/X2WOTCCommunityHighlander/Src/XComGame/Classes/XComGameState_MissionCalendar.uc
@@ -52,13 +52,16 @@ static function SetupCalendar(XComGameState StartState)
 //---------------------------------------------------------------------------------------
 function bool Update(XComGameState NewGameState)
 {
-	local UIStrategyMap StrategyMap;
+	// Issue #1417: no longer used
+	//local UIStrategyMap StrategyMap;
 	local int idx;
 
-	StrategyMap = `HQPRES.StrategyMap2D;
+	// Issue #1417: no longer used
+	//StrategyMap = `HQPRES.StrategyMap2D;
 
 	// Do not spawn any new missions while the Avenger or Skyranger are flying, or if another popup is already being presented
-	if (StrategyMap != none && StrategyMap.m_eUIState != eSMS_Flight && !`HQPRES.ScreenStack.IsCurrentClass(class'UIAlert'))
+	// Issue #1417: Use a more robust check to determine if the game should trigger the update.
+	if (class'CHHelpers'.static.GeoscapeReadyForUpdate())
 	{
 		// Check for mission events
 		for (idx = 0; idx < CurrentMissionMonth.Length; idx++)

--- a/X2WOTCCommunityHighlander/Src/XComGame/Classes/XComGameState_ResistanceFaction.uc
+++ b/X2WOTCCommunityHighlander/Src/XComGame/Classes/XComGameState_ResistanceFaction.uc
@@ -1384,12 +1384,14 @@ function string GetResistanceModeLabel()
 // THIS FUNCTION SHOULD RETURN TRUE IN ALL THE SAME CASES AS Update
 function bool ShouldUpdate()
 {
-	local UIStrategyMap StrategyMap;
+	// Issue #1417: no longer used
+	//local UIStrategyMap StrategyMap;
 
-	StrategyMap = `HQPRES.StrategyMap2D;
+	//StrategyMap = `HQPRES.StrategyMap2D;
 
 	// Do not trigger anything while the Avenger or Skyranger are flying, or if another popup is already being presented
-	if (StrategyMap != none && StrategyMap.m_eUIState != eSMS_Flight && !`HQPRES.ScreenStack.IsCurrentClass(class'UIAlert'))
+	// Issue #1417: Use a more robust check to determine if the game should trigger the update.
+	if (class'CHHelpers'.static.GeoscapeReadyForUpdate())
 	{
 		if (bMetXCom && !bSeenFactionHQReveal)
 		{
@@ -1404,14 +1406,17 @@ function bool ShouldUpdate()
 // IF ADDING NEW CASES WHERE bModified = true, UPDATE FUNCTION ShouldUpdate ABOVE
 function bool Update(XComGameState NewGameState)
 {
-	local UIStrategyMap StrategyMap;
+	// Issue #1417: no longer used
+	//local UIStrategyMap StrategyMap;
 	local bool bModified;
 
-	StrategyMap = `HQPRES.StrategyMap2D;
+	// Issue #1417: no longer used
+	//StrategyMap = `HQPRES.StrategyMap2D;
 	bModified = false;
 
 	// Do not trigger anything while the Avenger or Skyranger are flying, or if another popup is already being presented
-	if (StrategyMap != none && StrategyMap.m_eUIState != eSMS_Flight && !`HQPRES.ScreenStack.IsCurrentClass(class'UIAlert'))
+	// Issue #1417: Use a more robust check to determine if the game should trigger the update.
+	if (class'CHHelpers'.static.GeoscapeReadyForUpdate())
 	{
 		if (bMetXCom && !bSeenFactionHQReveal)
 		{

--- a/X2WOTCCommunityHighlander/Src/XComGame/Classes/XComGameState_UFO.uc
+++ b/X2WOTCCommunityHighlander/Src/XComGame/Classes/XComGameState_UFO.uc
@@ -449,7 +449,8 @@ function XComGameState_MissionSiteAvengerDefense CreateAvengerDefenseMission(Sta
 //---------------------------------------------------------------------------------------
 function bool Update(XComGameState NewGameState)
 {
-	local UIStrategyMap StrategyMap;
+	// Issue #1417: no longer used
+	//local UIStrategyMap StrategyMap;
 	local bool bModified;
 
 	bModified = false;
@@ -473,8 +474,9 @@ function bool Update(XComGameState NewGameState)
 		}
 
 		// Do not trigger interception while the Avenger or Skyranger are flying, or if another popup is already being presented
-		StrategyMap = `HQPRES.StrategyMap2D;
-		if (StrategyMap != none && StrategyMap.m_eUIState != eSMS_Flight && !`HQPRES.ScreenStack.IsCurrentClass(class'UIAlert'))
+		// Issue #1417: Use a more robust check to determine if the game should trigger the update.
+		//StrategyMap = `HQPRES.StrategyMap2D;
+		if (class'CHHelpers'.static.GeoscapeReadyForUpdate())
 		{
 			// If we have hit our interception time, become visible, transport to be close to XComHQ, and start the attack
 			if (class'X2StrategyGameRulesetDataStructures'.static.LessThan(InterceptionTime, GetCurrentTime()))

--- a/X2WOTCCommunityHighlander/Src/XComGame/Classes/XComGameState_WorldRegion.uc
+++ b/X2WOTCCommunityHighlander/Src/XComGame/Classes/XComGameState_WorldRegion.uc
@@ -466,11 +466,13 @@ function BuildHavenETA(out int MinDays, out int MaxDays)
 // THIS FUNCTION SHOULD RETURN TRUE IN ALL THE SAME CASES AS Update
 function bool ShouldUpdate( )
 {
-	local UIStrategyMap StrategyMap;
-	StrategyMap = `HQPRES.StrategyMap2D;
+	// Issue #1417: no longer used
+	// local UIStrategyMap StrategyMap;
+	// StrategyMap = `HQPRES.StrategyMap2D;
 
 	// Do not trigger anything while the Avenger or Skyranger are flying, or if another popup is already being presented
-	if (StrategyMap != none && StrategyMap.m_eUIState != eSMS_Flight && !`HQPRES.ScreenStack.IsCurrentClass( class'UIAlert' ))
+	// Issue #1417: Use a more robust check to determine if the game should trigger the update.
+	if (class'CHHelpers'.static.GeoscapeReadyForUpdate())
 	{
 		if (bUpdateShortestPathsToMissions)
 		{
@@ -503,14 +505,17 @@ function bool ShouldUpdate( )
 // IF ADDING NEW CASES WHERE bModified = true, UPDATE FUNCTION ShouldUpdate ABOVE
 function bool Update(XComGameState NewGameState)
 {
-	local UIStrategyMap StrategyMap;
+	// Issue #1417: no longer used
+	//local UIStrategyMap StrategyMap;
 	local bool bModified;
 
-	StrategyMap = `HQPRES.StrategyMap2D;
+	// Issue #1417: no longer used
+	//StrategyMap = `HQPRES.StrategyMap2D;
 	bModified = false;
 
 	// Do not trigger anything while the Avenger or Skyranger are flying, or if another popup is already being presented
-	if (StrategyMap != none && StrategyMap.m_eUIState != eSMS_Flight && !`HQPRES.ScreenStack.IsCurrentClass(class'UIAlert'))
+	// Issue #1417: Use a more robust check to determine if the game should trigger the update.
+	if (class'CHHelpers'.static.GeoscapeReadyForUpdate())
 	{
 		if (bUpdateShortestPathsToMissions)
 		{

--- a/X2WOTCCommunityHighlander/X2WOTCCommunityHighlander.x2proj
+++ b/X2WOTCCommunityHighlander/X2WOTCCommunityHighlander.x2proj
@@ -811,6 +811,9 @@
     <Content Include="Src\XComGame\Classes\XComGameState_AIUnitData.uc">
       <SubType>Content</SubType>
     </Content>
+    <Content Include="Src\XComGame\Classes\XComGameState_AlienNetworkComponent.uc">
+      <SubType>Content</SubType>
+    </Content>
     <Content Include="Src\XComGame\Classes\XComGameState_BlackMarket.uc">
       <SubType>Content</SubType>
     </Content>
@@ -824,6 +827,9 @@
       <SubType>Content</SubType>
     </Content>
     <Content Include="Src\XComGame\Classes\XComGameState_EvacZone.uc">
+      <SubType>Content</SubType>
+    </Content>
+    <Content Include="Src\XComGame\Classes\XComGameState_Haven.uc">
       <SubType>Content</SubType>
     </Content>
     <Content Include="Src\XComGame\Classes\XComGameState_HeadquartersAlien.uc">
@@ -857,6 +863,9 @@
       <SubType>Content</SubType>
     </Content>
     <Content Include="Src\XComGame\Classes\XComGameState_LadderProgress.uc">
+      <SubType>Content</SubType>
+    </Content>
+    <Content Include="Src\XComGame\Classes\XComGameState_MissionCalendar.uc">
       <SubType>Content</SubType>
     </Content>
     <Content Include="Src\XComGame\Classes\XComGameState_MissionSite.uc">


### PR DESCRIPTION
Fixes issue #1417 by updating all uses of 

```
(StrategyMap != none && StrategyMap.m_eUIState != eSMS_Flight && !`HQPRES.ScreenStack.IsCurrentClass(class'UIAlert')
```

to a helper function written by @Xymanek for Covert Infiltration that checks if the current screen is the strategy map instead of just checking that an alert is present.

```
static function bool GeoscapeReadyForUpdate()
{
	local UIStrategyMap StrategyMap;

	StrategyMap = `HQPRES.StrategyMap2D;

	return
		StrategyMap != none &&
		StrategyMap.m_eUIState != eSMS_Flight &&
		StrategyMap.Movie.Pres.ScreenStack.GetCurrentScreen() == StrategyMap;
}
```


![image](https://github.com/user-attachments/assets/6910dbab-f1cf-419e-830b-e7c889a974df)

This will solve edge cases where two geoscape entities try to throw UI popups at the same time, such as a Covert Action returning during the UFO chase and allowing an Avenger Defense mission to be skipped.