### PR TITLE
Issue #559 - Add eCleanup_BeginTacticalChain

### DIFF
--- a/X2WOTCCommunityHighlander/Src/XComGame/Classes/X2Effect_Sustain.uc
+++ b/X2WOTCCommunityHighlander/Src/XComGame/Classes/X2Effect_Sustain.uc
@@ -44,7 +44,7 @@ function bool PreDeathCheck(XComGameState NewGameState, XComGameState_Unit UnitS
 		}
 	}
 
-	UnitState.SetUnitFloatValue(default.SustainUsed, 1, eCleanup_BeginTactical);
+	UnitState.SetUnitFloatValue(default.SustainUsed, 1, eCleanup_BeginTacticalChain); // issue #559: changed cleanup (was BeginTactical)
 	UnitState.SetCurrentStat(eStat_HP, 1);
 
 	/// HL-Docs: ref:Bugfixes; issue:1404

--- a/X2WOTCCommunityHighlander/Src/XComGame/Classes/X2Effect_Sustain.uc
+++ b/X2WOTCCommunityHighlander/Src/XComGame/Classes/X2Effect_Sustain.uc
@@ -44,7 +44,7 @@ function bool PreDeathCheck(XComGameState NewGameState, XComGameState_Unit UnitS
 		}
 	}
 
-	UnitState.SetUnitFloatValue(default.SustainUsed, 1, eCleanup_BeginTacticalChain); // issue #559: changed cleanup (was BeginTactical)
+	UnitState.SetUnitFloatValue(default.SustainUsed, 1, eCleanup_BeginTacticalChain); // Issue #559: changed cleanup (was BeginTactical)
 	UnitState.SetCurrentStat(eStat_HP, 1);
 
 	/// HL-Docs: ref:Bugfixes; issue:1404

--- a/X2WOTCCommunityHighlander/Src/XComGame/Classes/X2Item_DefaultUpgrades.uc
+++ b/X2WOTCCommunityHighlander/Src/XComGame/Classes/X2Item_DefaultUpgrades.uc
@@ -1081,7 +1081,7 @@ static function bool FreeReloadCost(X2WeaponUpgradeTemplate UpgradeTemplate, XCo
 		{
 			return false;
 		}
-		UnitState.SetUnitFloatValue('FreeReload', FreeReloadValue.fValue + 1, eCleanup_BeginTactical);
+		UnitState.SetUnitFloatValue('FreeReload', FreeReloadValue.fValue + 1, eCleanup_BeginTacticalChain); // issue #559: changed cleanup (was BeginTactical)
 	}
 
 	return true;

--- a/X2WOTCCommunityHighlander/Src/XComGame/Classes/X2Item_DefaultUpgrades.uc
+++ b/X2WOTCCommunityHighlander/Src/XComGame/Classes/X2Item_DefaultUpgrades.uc
@@ -1081,7 +1081,7 @@ static function bool FreeReloadCost(X2WeaponUpgradeTemplate UpgradeTemplate, XCo
 		{
 			return false;
 		}
-		UnitState.SetUnitFloatValue('FreeReload', FreeReloadValue.fValue + 1, eCleanup_BeginTacticalChain); // issue #559: changed cleanup (was BeginTactical)
+		UnitState.SetUnitFloatValue('FreeReload', FreeReloadValue.fValue + 1, eCleanup_BeginTacticalChain); // Issue #559: changed cleanup (was BeginTactical)
 	}
 
 	return true;

--- a/X2WOTCCommunityHighlander/Src/XComGame/Classes/X2TacticalGameRulesetDataStructures.uc
+++ b/X2WOTCCommunityHighlander/Src/XComGame/Classes/X2TacticalGameRulesetDataStructures.uc
@@ -579,6 +579,11 @@ enum EUnitValueCleanup
 	eCleanup_BeginTurn,
 	eCleanup_BeginTactical,
 	eCleanup_Never,
+	/// HL-Docs: feature:eCleanup_BeginTacticalChain; issue:559; tags:tactical
+	/// eCleanup_BeginTactical cleans up unit values after every transfer from strategy and every direct tactical transfer.
+	/// In some cases, the latter behavior is undesirable. For example, free reloads should not reset in each part of a multi-part mission.
+	/// eCleanup_BeginTacticalChain handles these cases. It only cleans up unit values after transferring from strategy.
+	eCleanup_BeginTacticalChain, // issue #559
 };
 
 struct native UnitValue

--- a/X2WOTCCommunityHighlander/Src/XComGame/Classes/X2TacticalGameRulesetDataStructures.uc
+++ b/X2WOTCCommunityHighlander/Src/XComGame/Classes/X2TacticalGameRulesetDataStructures.uc
@@ -583,7 +583,7 @@ enum EUnitValueCleanup
 	/// eCleanup_BeginTactical cleans up unit values after every transfer from strategy and every direct tactical transfer.
 	/// In some cases, the latter behavior is undesirable. For example, free reloads should not reset in each part of a multi-part mission.
 	/// eCleanup_BeginTacticalChain handles these cases. It only cleans up unit values after transferring from strategy.
-	eCleanup_BeginTacticalChain, // issue #559
+	eCleanup_BeginTacticalChain, // Issue #559
 };
 
 struct native UnitValue

--- a/X2WOTCCommunityHighlander/Src/XComGame/Classes/XComGameState_Unit.uc
+++ b/X2WOTCCommunityHighlander/Src/XComGame/Classes/XComGameState_Unit.uc
@@ -2406,6 +2406,8 @@ function OnBeginTacticalPlay(XComGameState NewGameState)
 		// This is the value consistent with base-game behavior (before any stat bonuses from abilities, since this is set before any abilities are triggered)
 		// We can't ever let it be cleared, since a "BeginTactical" rule would clean it up when we want to explicitely keep it
 		SetUnitFloatValue('CH_StartMissionWill', GetCurrentStat(eStat_Will), eCleanup_Never);
+
+		CleanupUnitValues(eCleanup_BeginTacticalChain); // issue #559
 	}
 	// End Issue #44
 
@@ -6909,7 +6911,7 @@ protected function OnUnitDied(XComGameState NewGameState, Object CauseOfDeath, c
 					if (RankUpValue.fValue == 0)
 					{
 						EventManager.TriggerEvent('RankUpMessage', Killer, Killer, NewGameState);
-						Killer.SetUnitFloatValue('RankUpMessage', 1, eCleanup_BeginTactical);
+						Killer.SetUnitFloatValue('RankUpMessage', 1, eCleanup_BeginTacticalChain); // issue #559: changed cleanup (was BeginTactical)
 					}
 				}
 

--- a/X2WOTCCommunityHighlander/Src/XComGame/Classes/XComGameState_Unit.uc
+++ b/X2WOTCCommunityHighlander/Src/XComGame/Classes/XComGameState_Unit.uc
@@ -2407,7 +2407,7 @@ function OnBeginTacticalPlay(XComGameState NewGameState)
 		// We can't ever let it be cleared, since a "BeginTactical" rule would clean it up when we want to explicitely keep it
 		SetUnitFloatValue('CH_StartMissionWill', GetCurrentStat(eStat_Will), eCleanup_Never);
 
-		CleanupUnitValues(eCleanup_BeginTacticalChain); // issue #559
+		CleanupUnitValues(eCleanup_BeginTacticalChain); // Issue #559
 	}
 	// End Issue #44
 
@@ -6911,7 +6911,7 @@ protected function OnUnitDied(XComGameState NewGameState, Object CauseOfDeath, c
 					if (RankUpValue.fValue == 0)
 					{
 						EventManager.TriggerEvent('RankUpMessage', Killer, Killer, NewGameState);
-						Killer.SetUnitFloatValue('RankUpMessage', 1, eCleanup_BeginTacticalChain); // issue #559: changed cleanup (was BeginTactical)
+						Killer.SetUnitFloatValue('RankUpMessage', 1, eCleanup_BeginTacticalChain); // Issue #559: changed cleanup (was BeginTactical)
 					}
 				}
 


### PR DESCRIPTION
As per #559 (and also #1217), add eCleanup_BeginTacticalChain and apply it to the handful of base-game cases where it matters.

I thought I had submitted this patch years ago, but evidently I did not. I just played a whole campaign with this change in place and did not notice any problems.