### PR TITLE
Fix for weapon stacking behaviour

### DIFF
--- a/X2WOTCCommunityHighlander/Src/XComGame/Classes/XComGameState_Item.uc
+++ b/X2WOTCCommunityHighlander/Src/XComGame/Classes/XComGameState_Item.uc
@@ -792,10 +792,14 @@ simulated function bool HasBeenModified()
 		return true;
 	//end issue #104
 		
-	WeaponTemplate = X2WeaponTemplate( m_ItemTemplate );
-
-	// Single line for Issues #93 and #306
-	if ((WeaponTemplate != none) && (GetNumUpgradeSlots() > 0) && (GetMyWeaponUpgradeCount() > 0))
+	WeaponTemplate = X2WeaponTemplate( m_ItemTemplate );	
+	/// HL-Docs: ref:Bugfixes; issue:1429
+	/// Fix bug that caused weapons that have weapon upgrades installed, despite not having any weapon upgrade slots, 
+	/// to stack in the HQ inventory, causing them to lose their installed upgrades when equipped. The fix removes the 
+	/// check for the number of weapon upgrade slots on the weapon from the logic that determines whether the item has 
+	/// been modified or not, and leaves just the check for number of installed weapon upgrades.
+	// Single line for Issues #93, #306 and #1429
+	if ((WeaponTemplate != none) /* && (GetNumUpgradeSlots() > 0)*/ && (GetMyWeaponUpgradeCount() > 0))
 		return true;
 
 	return false;


### PR DESCRIPTION
Fixes #1429 

This PR removes a check on number of upgrade slots from HasBeenModified. This was erroneously returning false for weapons where attachments are added by an onAcquired function andwith 0 upgrade slots on the template (e.g. TLE / chosen weapons), which would cause duplicates of those items to be stacked. This could cause downstream issues with attachments when equipping / removing them as the inventory functions expect all weapons with attachments to not be stacked.