### PR TITLE
Check effect damage is non-zero before applying rupture to the damage preview

### DIFF
--- a/X2WOTCCommunityHighlander/Src/XComGame/Classes/XComGameState_Ability.uc
+++ b/X2WOTCCommunityHighlander/Src/XComGame/Classes/XComGameState_Ability.uc
@@ -1230,13 +1230,14 @@ function NormalDamagePreview(StateObjectReference TargetRef, out WeaponDamageVal
 			MaxDamagePreview.Shred  += MaxDamagePreview.Shred * BurstFire.NumExtraShots;
 		}
 	}
+
+	// Begin Issue #1394
 	/// HL-Docs: ref:Bugfixes; issue:1394
 	/// Abilities which do not specify a custom damage preview function will show rupture damage on the damage
 	/// preview, even if the ability is not capable of doing any damage (e.g. self target abilities like reload). 
 	/// Checking that the previewed damage is non-zero before adding rupture damage to it mitigates this and improves
 	/// the display (mainly for modded gameplay, but it also occurs in niche base game circumstances e.g. if a ruptured 
 	/// unit becomes mind controlled).
-	// Begin Issue #1394
 	if (Rupture > 0)
 	{
 		DamageModInfo.bIsRupture = true;
@@ -1253,8 +1254,8 @@ function NormalDamagePreview(StateObjectReference TargetRef, out WeaponDamageVal
         MaxDamagePreview.Damage += Rupture;
         MaxDamagePreview.BonusDamageInfo.AddItem(DamageModInfo);
     }
+	}
 	// End Issue #1394
-}
 
 	if (DestructibleState != none)
 	{

--- a/X2WOTCCommunityHighlander/Src/XComGame/Classes/XComGameState_Ability.uc
+++ b/X2WOTCCommunityHighlander/Src/XComGame/Classes/XComGameState_Ability.uc
@@ -1230,15 +1230,31 @@ function NormalDamagePreview(StateObjectReference TargetRef, out WeaponDamageVal
 			MaxDamagePreview.Shred  += MaxDamagePreview.Shred * BurstFire.NumExtraShots;
 		}
 	}
+	/// HL-Docs: ref:Bugfixes; issue:1394
+	/// Abilities which do not specify a custom damage preview function will show rupture damage on the damage
+	/// preview, even if the ability is not capable of doing any damage (e.g. self target abilities like reload). 
+	/// Checking that the previewed damage is non-zero before adding rupture damage to it mitigates this and improves
+	/// the display (mainly for modded gameplay, but it also occurs in niche base game circumstances e.g. if a ruptured 
+	/// unit becomes mind controlled).
+	// Begin Issue #1394
 	if (Rupture > 0)
 	{
-		MinDamagePreview.Damage += Rupture;
-		MaxDamagePreview.Damage += Rupture;
 		DamageModInfo.bIsRupture = true;
 		DamageModInfo.Value = Rupture;
-		MinDamagePreview.BonusDamageInfo.AddItem(DamageModInfo);
-		MaxDamagePreview.BonusDamageInfo.AddItem(DamageModInfo);
-	}	
+
+    if (MinDamagePreview.Damage > 0)
+    {
+        MinDamagePreview.Damage += Rupture;
+        MinDamagePreview.BonusDamageInfo.AddItem(DamageModInfo);
+    }
+
+    if (MaxDamagePreview.Damage > 0)
+    {
+        MaxDamagePreview.Damage += Rupture;
+        MaxDamagePreview.BonusDamageInfo.AddItem(DamageModInfo);
+    }
+	// End Issue #1394
+}
 
 	if (DestructibleState != none)
 	{


### PR DESCRIPTION
Fixes #1394 