### PR TITLE
Fix for erroneous burst-fire effect stacking

### DIFF
--- a/X2WOTCCommunityHighlander/Src/XComGame/Classes/XComGameState_Effect.uc
+++ b/X2WOTCCommunityHighlander/Src/XComGame/Classes/XComGameState_Effect.uc
@@ -266,19 +266,28 @@ function PostCreateInit(EffectAppliedData InApplyEffectParameters, GameRuleState
 	if (EffectTemplate.bStackOnRefresh)
 	{
 		iStacks = 1;
-		AbilityContext = XComGameStateContext_Ability(NewGameState.GetContext());
-		if (AbilityContext != none && AbilityContext.InputContext.PrimaryTarget.ObjectID == ApplyEffectParameters.TargetStateObjectRef.ObjectID)
-		{
-			AbilityTemplate = class'X2AbilityTemplateManager'.static.GetAbilityTemplateManager().FindAbilityTemplate(AbilityContext.InputContext.AbilityTemplateName);
-			if (AbilityTemplate != none)
-			{
-				BurstFire = X2AbilityMultiTarget_BurstFire(AbilityTemplate.AbilityMultiTargetStyle);
-				if (BurstFire != none)
-				{
-					iStacks += BurstFire.NumExtraShots;
-				}
-			}
-		}
+		
+		// Start Issue #1380
+		/// HL-Docs: ref:Bugfixes; issue:1380
+		/// Fix bug where burst fire abilities with stacking effects were applying the wrong number of effect stacks to the
+		/// target. This fix comments out base-game 'special handling' for burst-fire abilities - since each shot in the burst
+		/// is handled independently, the stacking effects are already incremented in the onRefresh function so it is not 
+		/// necessary to additionally adjust them by the number of extra burst-fire shots when the ability is initiated.
+
+		//	AbilityContext = XComGameStateContext_Ability(NewGameState.GetContext());
+		//	if (AbilityContext != none && AbilityContext.InputContext.PrimaryTarget.ObjectID == ApplyEffectParameters.TargetStateObjectRef.ObjectID)
+		//	{
+		//		AbilityTemplate = class'X2AbilityTemplateManager'.static.GetAbilityTemplateManager().FindAbilityTemplate(AbilityContext.InputContext.AbilityTemplateName);
+		//		if (AbilityTemplate != none)
+		//		{
+		//			BurstFire = X2AbilityMultiTarget_BurstFire(AbilityTemplate.AbilityMultiTargetStyle);
+		//			if (BurstFire != none)
+		//			{
+		//				iStacks += BurstFire.NumExtraShots;
+		//			}
+		//		}
+		//	}
+		// End Issue #1380
 	}
 
 	PlayerState = XComGameState_Player(History.GetGameStateForObjectID(ApplyEffectParameters.PlayerStateObjectRef.ObjectID));
@@ -393,19 +402,23 @@ function OnRefresh(EffectAppliedData NewApplyEffectParameters, XComGameState New
 	if (EffectTemplate.bStackOnRefresh)
 	{
 		iStacks++;
-		AbilityContext = XComGameStateContext_Ability(NewGameState.GetContext());
-		if (AbilityContext != none && AbilityContext.InputContext.PrimaryTarget.ObjectID == ApplyEffectParameters.TargetStateObjectRef.ObjectID)
-		{
-			AbilityTemplate = class'X2AbilityTemplateManager'.static.GetAbilityTemplateManager().FindAbilityTemplate(AbilityContext.InputContext.AbilityTemplateName);
-			if (AbilityTemplate != none)
-			{
-				BurstFire = X2AbilityMultiTarget_BurstFire(AbilityTemplate.AbilityMultiTargetStyle);
-				if (BurstFire != none)
-				{
-					iStacks += BurstFire.NumExtraShots;
-				}
-			}
-		}
+		// Start Issue #1380 - Since onRefresh called for each burst-fire shot, we don't need to adjust the 
+		// number of effect stacks by the number of burst fire shots in this function either.
+
+		//	AbilityContext = XComGameStateContext_Ability(NewGameState.GetContext());
+		//	if (AbilityContext != none && AbilityContext.InputContext.PrimaryTarget.ObjectID == ApplyEffectParameters.TargetStateObjectRef.ObjectID)
+		//	{
+		//		AbilityTemplate = class'X2AbilityTemplateManager'.static.GetAbilityTemplateManager().FindAbilityTemplate(AbilityContext.InputContext.AbilityTemplateName);
+		//		if (AbilityTemplate != none)
+		//		{
+		//			BurstFire = X2AbilityMultiTarget_BurstFire(AbilityTemplate.AbilityMultiTargetStyle);
+		//			if (BurstFire != none)
+		//			{
+		//				iStacks += BurstFire.NumExtraShots;
+		//			}
+		//		}
+		//	}
+		// End Issue #1380
 	}
 
 	// Start Issue #475


### PR DESCRIPTION
Fixes #1380 

Tested with Knife rounds from MZ Perk pack (which applies 1 stack of bleeding @ 1 damage per instance) combined with Fan Fire and Cyclic Fire from the LW2 Gunner class pack. Correct amount of stacks seem to be applied - further testing required but looks good so far.