### PR TITLE
Config gate creation of auto-generated photos (#1453)

### DIFF
--- a/X2WOTCCommunityHighlander/Config/XComGame.ini
+++ b/X2WOTCCommunityHighlander/Config/XComGame.ini
@@ -297,3 +297,10 @@ iMixedCharacterPoolChance = 50
 
 ;;; Issue #1398 - Change to adjust the delay of the 'Squad member dead' voiceline after a unit is killed
 fSquadMemberDeadVoicelineDelay = 3.0f
+
+;;; HL-Docs: ref:DisableAutoPhotos
+; Uncomment to disable automatic photobooth poster generation when certain events happen
+;bDisableAutomaticMissionPhoto = true
+;bDisableAutomaticMemorialPhoto = true
+;bDisableAutomaticPromotionPhoto = true
+;bDisableAutomaticBondPhoto = true

--- a/X2WOTCCommunityHighlander/Src/XComGame/Classes/CHHelpers.uc
+++ b/X2WOTCCommunityHighlander/Src/XComGame/Classes/CHHelpers.uc
@@ -267,6 +267,13 @@ var config bool bForce24hclockLeadingZero;
 // Variable for Issue #1398 - Number of seconds to wait after a unit is killed before playing the 'OnSquadMemberDead' voiceline
 var config float fSquadMemberDeadVoicelineDelay;
 
+// Start Issue #1453 - Variables to disable automatic photobooth photos
+var config bool bDisableAutomaticMissionPhoto;
+var config bool bDisableAutomaticMemorialPhoto;
+var config bool bDisableAutomaticPromotionPhoto;
+var config bool bDisableAutomaticBondPhoto;
+// End Issue #1453
+
 // Start Issue #885
 enum EHLDelegateReturn
 {

--- a/X2WOTCCommunityHighlander/Src/XComGame/Classes/UIAfterAction.uc
+++ b/X2WOTCCommunityHighlander/Src/XComGame/Classes/UIAfterAction.uc
@@ -111,9 +111,19 @@ simulated function InitScreen(XComPlayerController InitController, UIMovie InitM
 	Navigator.SetSelected(m_kSlotList);
 
 	isBondIconFocused = UIAfterAction_ListItem(m_kSlotList.GetSelectedItem()).BondIcon.bIsFocused; // bsg-jrebar (05/19/17): Keep focus on bond or promote
-
-	LoadPhotoboothAutoGenDeadSoldiers();
-
+	
+	// Start Issue #1453 - Additional config gate to disable automatic memorial photo
+	/// HL-Docs: feature:DisableAutoPhotos; issue:1453; tags:strategy,tactical
+	/// Several places in the game (UIAfterAction, XComHQPresentationLayer, UISoldierBondConfirmScree and UIMissionSummary)
+	/// request the auto-generation of photos for the photobooth. Such photos are coded to be taken when the user doesn't take 
+	/// a photo manually at the end of a mission, when a soldier above Sergeant rank dies, when a soldier is promoted to Sergeant
+	/// or Major rank and when two soldiers are bonded. The auto-photos are usually of poor quality and the ability to disable 
+	/// them is a useful feature for modders.
+	if(!class'CHHelpers'.default.bDisableAutomaticMemorialPhoto)
+	{
+		LoadPhotoboothAutoGenDeadSoldiers();
+	}
+	// End Issue #1453
 	//In case of emergency, and we've missed the cinematic event etc., this will trigger the nave help UI to activate. 
 	SetTimer(10.0f, false, nameof(ForceNavHelpOn));
 }

--- a/X2WOTCCommunityHighlander/Src/XComGame/Classes/UIMissionSummary.uc
+++ b/X2WOTCCommunityHighlander/Src/XComGame/Classes/UIMissionSummary.uc
@@ -731,7 +731,8 @@ simulated function CloseScreenTakePhoto()
 {
 	bClosingScreen = true;
 
-	if (!BattleData.IsMultiplayer() && !bAllSoldiersDead && !bUserPhotoTaken)
+	// Single Line for Issue #1453 - Additional config gate to disable automatic mission-end photo
+	if (!BattleData.IsMultiplayer() && !bAllSoldiersDead && !bUserPhotoTaken && !class'CHHElpers'.default.bDisableAutomaticMissionPhoto)
 	{
 		NavHelp.ContinueButton.DisableButton();
 

--- a/X2WOTCCommunityHighlander/Src/XComGame/Classes/UISoldierBondConfirmScreen.uc
+++ b/X2WOTCCommunityHighlander/Src/XComGame/Classes/UISoldierBondConfirmScreen.uc
@@ -199,8 +199,12 @@ function ConfirmClicked(UIButton Button)
 	// Ask the player if they want to make a poster when forming the first bond
 	if (BondData.BondLevel == 0)
 	{
-		KickOffAutoGen();
-
+		// Start Issue #1453 - Config gate to disable auto-generation of soldier bond photo
+		if(!class'CHHelpers'.default.bDisableAutomaticBondPhoto)
+		{
+			KickOffAutoGen();
+		}
+		// End Issue #1453
 		DialogData.eType = eDialog_Normal;
 		DialogData.bMuteAcceptSound = true;
 		DialogData.strTitle = m_strMakePosterTitle;

--- a/X2WOTCCommunityHighlander/Src/XComGame/Classes/XComHQPresentationLayer.uc
+++ b/X2WOTCCommunityHighlander/Src/XComGame/Classes/XComHQPresentationLayer.uc
@@ -1450,7 +1450,8 @@ function UIArmory_Promotion(StateObjectReference UnitRef, optional bool bInstant
 
 		// Check for rank up to Sergeant or Major
 		bValidRankUp = (PreviousRank < 3 && Unit.GetSoldierRank() >= 3) || (PreviousRank < 6 && Unit.GetSoldierRank() >= 6);
-		if (!Unit.bCaptured && Unit.IsAlive() && bValidRankUp)
+		// Single Line for Issue #1453 - Additional config gate to disable auto-generation of promotion photo
+		if (!Unit.bCaptured && Unit.IsAlive() && bValidRankUp && !class'CHHelpers'.default.bDisableAutomaticPromotionPhoto)
 		{
 			`HQPRES.GetPhotoboothAutoGen().AddPromotedSoldier(Unit.GetReference());
 			`HQPRES.GetPhotoboothAutoGen().RequestPhotos();


### PR DESCRIPTION
Fixes #1453 - Preliminary tests are convincing. 

Further testing ongoing - will comment again once completed and confident the fix covers all possible scenarios (In particular, need to test soldier captured events, as I didn't adjust anything related to that, assuming that the auto-gen code used for captures is mainly there for creating the poster in the UI alert which is displayed when a capture occurs and not for actually saving the photo to the campaign photobooth folder).