### PR TITLE
Fix powered ragdoll not working after previous ragdoll

### DIFF
--- a/X2WOTCCommunityHighlander/Src/XComGame/Classes/XComUnitPawn.uc
+++ b/X2WOTCCommunityHighlander/Src/XComGame/Classes/XComUnitPawn.uc
@@ -1058,6 +1058,13 @@ simulated function EndRagDoll()
 	Mesh.bUpdateJointsFromAnimation = true;
 	Mesh.PhysicsWeight = 0.0f;
 
+	/// HL-Docs: ref:Bugfixes; issue:1461
+	/// Animations that use a powered ragdoll work again after unit had been previously ragdolled
+	// Start Issue #1461
+	// Set this variable to its default value when the unit ends their ragdoll and gets up again, since it's not set again anywhere else
+	fPhysicsMotorForce = default.fPhysicsMotorForce;
+	// End Issue #1461
+
 	TermRagdoll();
 	SetPhysics(PHYS_Walking);
 	Mesh.ForceSkelUpdate();


### PR DESCRIPTION
Fixes #1461

To replicate the issue:
Spawn a trooper on a roof -> blow it up with a grenade -> shoot and kill it = no death animation and instant ragdoll
With this fix:
Spawn -> explode the roof -> kill it -> plays death animation