### PR TITLE
Issue #1465 - Delete item after merging quantity into HQ inventory item

### DIFF
--- a/X2WOTCCommunityHighlander/Src/XComGame/Classes/XComGameState_HeadquartersXCom.uc
+++ b/X2WOTCCommunityHighlander/Src/XComGame/Classes/XComGameState_HeadquartersXCom.uc
@@ -4222,6 +4222,7 @@ function bool PutItemInInventory(XComGameState AddToGameState, XComGameState_Ite
 				{
 					NewInventoryItemState = XComGameState_Item(AddToGameState.ModifyStateObject(class'XComGameState_Item', InventoryItemState.ObjectID));
 					NewInventoryItemState.Quantity += ItemState.Quantity;
+					AddToGameState.RemoveStateObject(ItemState.ObjectID); // Issue #1465 - delete item to prevent save bloat
 				}
 			}
 			else


### PR DESCRIPTION
Tested by clearing a room on the Avenger. X2DE confirms that the supply items were all removed. Played through a few missions and didn't notice any problems.