### PR TITLE
Issue #1466 - Stop duplicating mission data in arrGeneratedMissionData

### DIFF
--- a/X2WOTCCommunityHighlander/Src/XComGame/Classes/XComGameStateContext_StrategyGameRule.uc
+++ b/X2WOTCCommunityHighlander/Src/XComGame/Classes/XComGameStateContext_StrategyGameRule.uc
@@ -484,6 +484,12 @@ static function ProcessMissionResults()
 
 	class'X2StrategyElement_DefaultMissionSources'.static.IncreaseForceLevel(NewGameState, MissionState);
 
+	// Start Issue #1466
+	// temporarily add the mission data into the cache
+	// the XCGS_MissionSite will be deleted right after this by the OnSuccessFn or OnFailureFn
+	XComHQ.arrGeneratedMissionData.AddItem(MissionState.GeneratedMission);
+	// End Issue #1466
+
 	if( bMissionSuccess )
 	{
 		if( MissionSource.OnSuccessFn != none )

--- a/X2WOTCCommunityHighlander/Src/XComGame/Classes/XComGameState_HeadquartersXCom.uc
+++ b/X2WOTCCommunityHighlander/Src/XComGame/Classes/XComGameState_HeadquartersXCom.uc
@@ -7521,13 +7521,13 @@ function GeneratedMissionData GetGeneratedMissionData(int MissionID)
 			GeneratedMission.BattleOpName = class'XGMission'.static.GenerateOpName(false);
 		}
 		
-		/// HL-Docs: ref:Bugfixes; issue:1188
-		/// Add a none-check for `MissionState` before adding the generated mission entry to the array
-		/// to avoid bloating it with empty entries.
-		if (MissionState != none)
-		{
-			arrGeneratedMissionData.AddItem(GeneratedMission);
-		}
+		/// HL-Docs: ref:Bugfixes; issue:1466
+		/// Do not cache mission data in GetGeneratedMissionData().
+		/// Doing so bloats the save file and causes problems for mods like LWOTC and CI,
+		/// which need hacks to clear stale data from the cache.
+		/// The cache is still used temporarily during the post-mission sequence,
+		/// because the XCGS_MissionSite is deleted too early.
+		//arrGeneratedMissionData.AddItem(GeneratedMission);
 	}
 	else
 	{

--- a/X2WOTCCommunityHighlander/Src/XComGame/Classes/XComHQPresentationLayer.uc
+++ b/X2WOTCCommunityHighlander/Src/XComGame/Classes/XComHQPresentationLayer.uc
@@ -287,6 +287,7 @@ simulated function ExitPostMissionSequence()
 	EventManager.TriggerEvent('PostMissionDone', XComHQ, XComHQ, NewGameState);
 	XComHQ.ResetToDoWidgetWarnings();
 	XComHQ.PlayedAmbientSpeakers.Length = 0; // Reset availability of ambient speaker lines
+	XComHQ.arrGeneratedMissionData.Length = 0; // Issue #1466 - clear the cached data that was added in XCGSC_StrategyGameRule.ProcessMissionResults()
 	
 	// Clear rewards recap data
 	ResistanceHQ = XComGameState_HeadquartersResistance(NewGameState.ModifyStateObject(class'XComGameState_HeadquartersResistance', ResistanceHQ.ObjectID));


### PR DESCRIPTION
Started a new campaign with this change in place and played through a few missions. Did not notice any problems. Tested SSAAT separately and did not notice any problems with that either. I have not tested LWOTC or CI, but this approach should not cause any problems for them either.