### PR TITLE
Issue #1325: New XCGS_Unit feature and opt in interruption bug fix

### DIFF
--- a/X2WOTCCommunityHighlander/Config/XComGameCore.ini
+++ b/X2WOTCCommunityHighlander/Config/XComGameCore.ini
@@ -25,7 +25,7 @@
 ;InterruptionsCleanupBeginTurnUnitValues = false
 ;InterruptionsUpdateTurnStartLocation = false
 ;InterruptionsResetPanicTestsPerformedThisTurn = false
-;InterruptionsTriggerGroupTurnBegunEvent = false
+;InterruptionsTriggerGroupTurnBegunEvent = true
 ;End Issue #1325
 
 [XComGame.X2AbilityToHitCalc_StandardAim]

--- a/X2WOTCCommunityHighlander/Config/XComGameCore.ini
+++ b/X2WOTCCommunityHighlander/Config/XComGameCore.ini
@@ -15,6 +15,19 @@
 +PlayerTurnOrder=eTeam_One
 +PlayerTurnOrder=eTeam_Two
 
+;Start Issue #1325
+;Uncomment ALL lines in this issue to provide several bugfixes for interruptions
+;EnableImprovedInterruptionLogic = true ;This NEEDS to be true for any other option in this issue to work. If it is true, make sure all other options in this issue are AT LEAST UNCOMMENTED.
+;InterruptionsGiveActionPoints = true
+;InterruptionsResetUntouchable = false
+;InterruptionsResetGotFreeFireAction = false
+;InterruptionsHandleMovementUnitValues = false
+;InterruptionsCleanupBeginTurnUnitValues = false
+;InterruptionsUpdateTurnStartLocation = false
+;InterruptionsResetPanicTestsPerformedThisTurn = false
+;InterruptionsTriggerGroupTurnBegunEvent = false
+;End Issue #1325
+
 [XComGame.X2AbilityToHitCalc_StandardAim]
 ;+CritUpgradesThatDontUseEffects="MyFancyTemplateName" ;For modders to use to specify upgrades in their mods that use Issue #237 functionality
 

--- a/X2WOTCCommunityHighlander/Src/XComGame/Classes/X2TacticalGameRuleset.uc
+++ b/X2WOTCCommunityHighlander/Src/XComGame/Classes/X2TacticalGameRuleset.uc
@@ -84,6 +84,15 @@ var config array<string> PlayerTurnOrder;						// defines the order in which pla
 var config array<float> MissionTimerDifficultyAdjustment;			// defines the number of additional turns players get per difficulty
 var config float SecondWaveExtendedTimerScalar;					// scales the number of turns on mission timers (for ExtendedMissionTimers)
 var config float SecondWaveBetaStrikeTimerScalar;				// scales the number of turns on mission timers (for BetaStrike)
+var config bool EnableImprovedInterruptionLogic;			//Issue #1325 variable
+var config bool InterruptionsGiveActionPoints;				//Issue #1325 variable
+var config bool InterruptionsResetUntouchable;				//Issue #1325 variable
+var config bool InterruptionsResetGotFreeFireAction;		//Issue #1325 variable
+var config bool InterruptionsHandleMovementUnitValues;		//Issue #1325 variable
+var config bool InterruptionsCleanupBeginTurnUnitValues;	//Issue #1325 variable
+var config bool InterruptionsUpdateTurnStartLocation;		//Issue #1325 variable
+var config bool InterruptionsResetPanicTestsPerformedThisTurn;	//Issue #1325 variable
+var config bool InterruptionsTriggerGroupTurnBegunEvent;	//Issue #1325 variable
 //****************************************
 
 var int LastNeutralReactionEventChainIndex; // Last event chain index to prevent multiple civilian reactions from same event. Also used for simultaneous civilian movement.
@@ -4682,16 +4691,43 @@ simulated state TurnPhase_UnitActions
 
 		if( !bReturningFromInterruptedTurn )
 		{
-			foreach GroupState.m_arrMembers(UnitRef)
+			//Start issue #1325: New condition. Else path is behavior with no highlander.
+			if(default.EnableImprovedInterruptionLogic && BattleData.InterruptingGroupRef.ObjectID == GroupState.ObjectID)
 			{
-				// Create a new state object on NewPhaseState for UnitState
-				NewUnitState = XComGameState_Unit(NewGameState.ModifyStateObject(class'XComGameState_Unit', UnitRef.ObjectID));
-				NewUnitState.SetupActionsForBeginTurn();
-			}
+				foreach GroupState.m_arrMembers(UnitRef)
+				{
+					// Create a new state object on NewPhaseState for UnitState
+					NewUnitState = XComGameState_Unit(NewGameState.ModifyStateObject(class'XComGameState_Unit', UnitRef.ObjectID));
+					NewUnitState.CHL_SetupActionsForBeginTurn(default.InterruptionsGiveActionPoints,
+															default.InterruptionsResetUntouchable,
+															default.InterruptionsResetGotFreeFireAction,
+															default.InterruptionsHandleMovementUnitValues,
+															default.InterruptionsCleanupBeginTurnUnitValues,
+															default.InterruptionsUpdateTurnStartLocation,
+															default.InterruptionsResetPanicTestsPerformedThisTurn);
+				}
 
-			// Trigger the UnitGroupTurnBegun event
-			EventManager = `XEVENTMGR;
-			EventManager.TriggerEvent('UnitGroupTurnBegun', GroupState, GroupState, NewGameState);
+				if(default.InterruptionsTriggerGroupTurnBegunEvent)
+				{
+					// Trigger the UnitGroupTurnBegun event
+					EventManager = `XEVENTMGR;
+					EventManager.TriggerEvent('UnitGroupTurnBegun', GroupState, GroupState, NewGameState);
+				}
+			}
+			else
+			{
+				foreach GroupState.m_arrMembers(UnitRef)
+				{
+					// Create a new state object on NewPhaseState for UnitState
+					NewUnitState = XComGameState_Unit(NewGameState.ModifyStateObject(class'XComGameState_Unit', UnitRef.ObjectID));
+					NewUnitState.SetupActionsForBeginTurn();
+				}
+
+				// Trigger the UnitGroupTurnBegun event
+				EventManager = `XEVENTMGR;
+				EventManager.TriggerEvent('UnitGroupTurnBegun', GroupState, GroupState, NewGameState);
+			}
+			//End issue #1325
 		}
 
 		SubmitGameState(NewGameState);

--- a/X2WOTCCommunityHighlander/Src/XComGame/Classes/XComGameState_Unit.uc
+++ b/X2WOTCCommunityHighlander/Src/XComGame/Classes/XComGameState_Unit.uc
@@ -7467,46 +7467,37 @@ function CHL_SetupActionsForBeginTurn(	optional bool GiveActionPoints = true,
 	local X2Effect_Persistent EffectTemplate;
 	local UnitValue MovesThisTurn;
 
-	//Issue #1325 comment: in the event that callers don't consider this, it gets checked here.
-	if(class'X2TacticalGameRuleset'.default.EnableImprovedInterruptionLogic == false)
+	if(GiveActionPoints)
 	{
-		SetupActionsForBeginTurn();
-		return;
-	}
-	else
-	{
-		if(GiveActionPoints)
-		{
-			GiveStandardActionPoints();
+		GiveStandardActionPoints();
 
-			if( ActionPoints.Length > 0 )
+		if( ActionPoints.Length > 0 )
+		{
+			History = `XCOMHISTORY;
+			foreach AffectedByEffects(EffectRef)
 			{
-				History = `XCOMHISTORY;
-				foreach AffectedByEffects(EffectRef)
-				{
-					EffectState = XComGameState_Effect(History.GetGameStateForObjectID(EffectRef.ObjectID));
-					EffectTemplate = EffectState.GetX2Effect();
-					EffectTemplate.ModifyTurnStartActionPoints(self, ActionPoints, EffectState);
-				}
+				EffectState = XComGameState_Effect(History.GetGameStateForObjectID(EffectRef.ObjectID));
+				EffectTemplate = EffectState.GetX2Effect();
+				EffectTemplate.ModifyTurnStartActionPoints(self, ActionPoints, EffectState);
 			}
 		}
-
-		if(ResetUntouchable)
-			Untouchable = 0;                    //  untouchable only lasts until the start of your next turn, so always clear it out
-		if(ResetGotFreeFireAction)
-			bGotFreeFireAction = false;                                                      //Reset FreeFireAction flag
-		if(HandleMovesUnitValues)
-		{
-			GetUnitValue('MovesThisTurn', MovesThisTurn);
-			SetUnitFloatValue('MovesLastTurn', MovesThisTurn.fValue, eCleanup_BeginTactical); 
-		}
-		if(CleanupBeginTurnUnitValues)
-			CleanupUnitValues(eCleanup_BeginTurn);
-		if(UpdateTurnStartLocation)
-			TurnStartLocation = TileLocation;
-		if(ResetPanicTestsPerformedThisTurn)
-			PanicTestsPerformedThisTurn = 0;
 	}
+
+	if(ResetUntouchable)
+		Untouchable = 0;                    //  untouchable only lasts until the start of your next turn, so always clear it out
+	if(ResetGotFreeFireAction)
+		bGotFreeFireAction = false;                                                      //Reset FreeFireAction flag
+	if(HandleMovesUnitValues)
+	{
+		GetUnitValue('MovesThisTurn', MovesThisTurn);
+		SetUnitFloatValue('MovesLastTurn', MovesThisTurn.fValue, eCleanup_BeginTactical); 
+	}
+	if(CleanupBeginTurnUnitValues)
+		CleanupUnitValues(eCleanup_BeginTurn);
+	if(UpdateTurnStartLocation)
+		TurnStartLocation = TileLocation;
+	if(ResetPanicTestsPerformedThisTurn)
+		PanicTestsPerformedThisTurn = 0;
 }
 
 function SetupActionsForBeginTurn()

--- a/X2WOTCCommunityHighlander/Src/XComGame/Classes/XComGameState_Unit.uc
+++ b/X2WOTCCommunityHighlander/Src/XComGame/Classes/XComGameState_Unit.uc
@@ -7452,6 +7452,63 @@ function GiveStandardActionPoints()
 	}
 }
 
+//Issue #1325: New function to provide control over base game functionality.
+function CHL_SetupActionsForBeginTurn(	optional bool GiveActionPoints = true,
+										optional bool ResetUntouchable = true,
+										optional bool ResetGotFreeFireAction = true,
+										optional bool HandleMovesUnitValues = true,
+										optional bool CleanupBeginTurnUnitValues = true,
+										optional bool UpdateTurnStartLocation = true,
+										optional bool ResetPanicTestsPerformedThisTurn = true)
+{
+	local XComGameStateHistory History;
+	local StateObjectReference EffectRef;
+	local XComGameState_Effect EffectState;
+	local X2Effect_Persistent EffectTemplate;
+	local UnitValue MovesThisTurn;
+
+	//Issue #1325 comment: in the event that callers don't consider this, it gets checked here.
+	if(class'X2TacticalGameRuleset'.default.EnableImprovedInterruptionLogic == false)
+	{
+		SetupActionsForBeginTurn();
+		return;
+	}
+	else
+	{
+		if(GiveActionPoints)
+		{
+			GiveStandardActionPoints();
+
+			if( ActionPoints.Length > 0 )
+			{
+				History = `XCOMHISTORY;
+				foreach AffectedByEffects(EffectRef)
+				{
+					EffectState = XComGameState_Effect(History.GetGameStateForObjectID(EffectRef.ObjectID));
+					EffectTemplate = EffectState.GetX2Effect();
+					EffectTemplate.ModifyTurnStartActionPoints(self, ActionPoints, EffectState);
+				}
+			}
+		}
+
+		if(ResetUntouchable)
+			Untouchable = 0;                    //  untouchable only lasts until the start of your next turn, so always clear it out
+		if(ResetGotFreeFireAction)
+			bGotFreeFireAction = false;                                                      //Reset FreeFireAction flag
+		if(HandleMovesUnitValues)
+		{
+			GetUnitValue('MovesThisTurn', MovesThisTurn);
+			SetUnitFloatValue('MovesLastTurn', MovesThisTurn.fValue, eCleanup_BeginTactical); 
+		}
+		if(CleanupBeginTurnUnitValues)
+			CleanupUnitValues(eCleanup_BeginTurn);
+		if(UpdateTurnStartLocation)
+			TurnStartLocation = TileLocation;
+		if(ResetPanicTestsPerformedThisTurn)
+			PanicTestsPerformedThisTurn = 0;
+	}
+}
+
 function SetupActionsForBeginTurn()
 {
 	local XComGameStateHistory History;


### PR DESCRIPTION
#1325 
This is a bit of a 2 part pull request. 1. Adds a new function to XComGameState_Unit called CHL_SetupActionsForBeginTurn. The function comes with additional parameters for greater control compared to its vanilla counterpart. Useful in its own right. 2. Also adds an optional rework in X2TacticalGameRuleset.TurnPhase_UnitActions.SetupUnitActionsForGroupTurnBegin that utilizes the previous feature. By default, there shouldn't be any change to logic until the associated config values are uncommented/changed.