### PR TITLE
Update AI Behaviour to respect immunity to AOE effects

### DIFF
--- a/X2WOTCCommunityHighlander/Src/XComGame/Classes/XGAIBehavior.uc
+++ b/X2WOTCCommunityHighlander/Src/XComGame/Classes/XGAIBehavior.uc
@@ -6751,7 +6751,12 @@ function bool GetAllAoETargets(out array<TTile> TargetList, AoETargetingInfo Pro
 	local bool bValid;
 	local X2Effect MultiTargetEffect;
 	local X2AbilityTemplate AbilityTemplate;
-
+	// Start Issue #1369 - Variables to assist valid target filtering in bTestTargetEffectsApply
+	local array<X2Effect> TargetEffects;
+	local X2Effect TestEffect;
+	local X2GrenadeTemplate TestGrenadeTemplate;
+	local XComGameState_Item TestSourceWeapon;
+	// End Issue #1369
 	if (!GetUnfilteredAoETargetList(UnitList, Profile, RequiredTarget, DeprioritizedEffects))
 	{
 		return false;
@@ -6774,13 +6779,75 @@ function bool GetAllAoETargets(out array<TTile> TargetList, AoETargetingInfo Pro
 		if ( Profile.bTestTargetEffectsApply )
 		{
 			AbilityTemplate = AbilityState.GetMyTemplate();
-			// Ignore units that are immune to this ability. (passes as long as any effect applies to this unit)
-			foreach AbilityTemplate.AbilityMultiTargetEffects(MultiTargetEffect)
+			// Start Issue #1369
+			/// HL-Docs: feature:ImproveAIAreaOfEffectProfiles; issue:1369; tags:tactical
+			/// Setting bTestTargetEffectsApply on AOE Profiles in XComAI is supposed to filter the list of acceptable targets 
+			/// for a given Area of Effect ability by looking through the targeting conditions on each effect and checking whether 
+			/// or not the prospective targets are immune to the damage (this is done in X2Effect::TargetIsValidForAbility). However, 
+			/// this feature was not built to handle grenade templates and the logic for multitargeteffects was also being short-circuited
+			/// due to bValid not being reset between each unit (i.e. so if a single unit passed the check, all subsequent units in the 
+			/// AOE were being added to the supposedly-filtered target list).
+			If (AbilityTemplate.bUseLaunchedGrenadeEffects)
 			{
-				if (MultiTargetEffect.TargetIsValidForAbility(TargetState, UnitState, AbilityState))
+				TestSourceWeapon = AbilityState.GetSourceWeapon();
+				bValid = false;
+				If (TestSourceWeapon != none)
 				{
-					bValid = true;
-					break;
+					TestGrenadeTemplate = X2GrenadeTemplate(TestSourceWeapon.GetLoadedAmmoTemplate(AbilityState));
+					If (TestGrenadeTemplate != none)
+					{
+						TargetEffects = TestGrenadeTemplate.LaunchedGrenadeEffects;
+						If (TargetEffects.Length > 0)
+						{					
+							foreach TargetEffects(TestEffect)
+							{
+								if(TestEffect.DamageTypes.Length > 0 && TestEffect.TargetIsValidForAbility(TargetState, UnitState, AbilityState))
+								{
+									bValid = true;
+									break;
+								}
+							}
+						}
+					}
+				}
+			}
+			else if (AbilityTemplate.bUseThrownGrenadeEffects)
+			{
+				TestSourceWeapon = AbilityState.GetSourceWeapon();
+				bValid = false;
+				If (TestSourceWeapon != none)
+				{
+					TestGrenadeTemplate = X2GrenadeTemplate(TestSourceWeapon.GetMyTemplate());
+					If (TestGrenadeTemplate != none)
+					{
+						TargetEffects = TestGrenadeTemplate.ThrownGrenadeEffects;
+						If (TargetEffects.Length > 0)
+						{
+							foreach TargetEffects(TestEffect)
+							{
+								if(TestEffect.DamageTypes.Length > 0 && TestEffect.TargetIsValidForAbility(TargetState, UnitState, AbilityState))
+								{
+									bValid = true;
+									break;
+								}
+							}
+						}
+					}
+				}
+			}
+			else
+			{
+				// Ignore units that are immune to this ability. (passes as long as any effect applies to this unit)
+				foreach AbilityTemplate.AbilityMultiTargetEffects(MultiTargetEffect)
+				{
+					// Issue #1369 - Reset bValid for Each Unit and check the DamageTypes Array on the MultiTargetEffects to
+					// exclude dummy abilities with no damage type from passing the validity check 
+					bValid = false;	
+					if (MultiTargetEffect.DamageTypes.Length > 0 && MultiTargetEffect.TargetIsValidForAbility(TargetState, UnitState, AbilityState))
+					{
+						bValid = true;
+						break;
+					}
 				}
 			}
 			if (!bValid)
@@ -6788,6 +6855,7 @@ function bool GetAllAoETargets(out array<TTile> TargetList, AoETargetingInfo Pro
 				continue;
 			}
 		}
+		// End Issue #1369
 
 		// Ignore inactive AI units that are not visible.
 		if (TargetState.ControllingPlayerIsAI() && TargetState.IsUnrevealedAI()


### PR DESCRIPTION
Fixes #1369 

Excluding immune units from AOE targetting profiles is a useful enhancement for modded XCOM. It is reasonably common in the base-game to see vipers trying to poison spit the lost, which are immune . Many modded units also have exotic explosives, area-effect abilities and so on, but the AI prioritises hitting the maximum number of 'available' units with an AOE profile ability, rather than the maximum number of 'vulnerable' units.

In XGAIBehaviour, a flag was set up called 'btesttargeteffectsapply' which is *supposed* to filter AOE profiles by units which are not immune to the effects - however, the implementation was broken and did not work with explosives/grenades and was thus only used on Harbor wave (which has a unique damage type anyway so has no practical effect) and the purifier flamethrower.

So, this code fixes the broken logic of that function (More fully, XGAIBehavior::GetAllAoETargets was incorrecly adding units to its out array, which should have been filtered out) and also expands the functionality to include grenades rather than just multitargeteffects.

The adjustment will have no impact on base-game behavior (since only the abilities above actually use the broken logic) and minimal effect on existing mods, as most enemy mods are not using this flag anyway (also due to it not working).

With the fix in place, enemy & AI modders can simply specify bTestTargetEffectsApply on their AOE Profiles and enemies will stop targeting that AOE ability at groups of enemies which are immune to the effect.