### PR TITLE
Add Latent gamestate processing check to event trigger

### DIFF
--- a/X2WOTCCommunityHighlander/Src/XComGame/Classes/XComGameState_InteractiveObject.uc
+++ b/X2WOTCCommunityHighlander/Src/XComGame/Classes/XComGameState_InteractiveObject.uc
@@ -543,6 +543,17 @@ function bool AllowInteractHack(XComGameState_Unit Unit)
 	Tuple.Data[1].kind = XComLWTVObject;
 	Tuple.Data[1].o = Unit;
 
+	// Start Issue #1477 - Short circuit if there is a latent gamestate in progress to prevent deadlock.
+	if (`TACTICALRULES.BuildingLatentGameState)
+	{
+		// If we are here, there is a gamestate being submitted and triggering this event will likely cause a deadlock.
+		// This will suppress any calls to this event that would be triggered by the gamestate thread itself, but 
+		// this should not be a problem because hacking events/checks are not likely to be triggered by the game state
+		// thread alone, so we'll return the default value of the tuple (True) so that this call doesn't disrupt already valid hacks.
+		return Tuple.Data[0].b;
+	}
+	// End issue #1477
+
 	`XEVENTMGR.TriggerEvent('AllowInteractHack', Tuple, self);
 
 	return Tuple.Data[0].b;


### PR DESCRIPTION
Fixes #1477 (that we know of)

In the words of dburchanowski

```
    // This isn't thread safe. If you comment out this code block, the game is likely to crash because
    // the head tracking determines visibility via the visibility conditions. These always operate against the
    // most recent history frame, and not the cached frame for non-latent state threads. So memory will be shifting
    // out from under the visibility query below, and will cause access violations. At some point this needs to be
    // made properly thread safe, but for now I'm band-aiding it since I am leaving tomorrow - dburchanowski
    if (`TACTICALRULES.BuildingLatentGameState)
        return;
```

This adds a similar check to an event trigger identified by Robojumper in a crash log. As we get more crashes, I expect we can patch them as we find them, since I don't see very many events that might cause this issue.