### PR TITLE
Issue #1325: Adding a new feature to XCGS_Unit and an opt in fix to interruption logic

### DIFF
--- a/X2WOTCCommunityHighlander/Config/XComGameCore.ini
+++ b/X2WOTCCommunityHighlander/Config/XComGameCore.ini
@@ -15,6 +15,23 @@
 +PlayerTurnOrder=eTeam_One
 +PlayerTurnOrder=eTeam_Two
 
+;Start Issue #1325
+;In the base game, turn interruptions behave inconsistently in certain scenarios. Things like burn, poison, and acid don't tick. And yet, things like untouchable and unit values get reset.
+;It makes the most sense that those things DON'T get reset, as the unit isn't taking a typical turn. This is why this area is here and why the default values for the below variables are the way they are.
+;Of course, if there's disagreements on what should be allowed to happen in interruptions, then feel free to change the default values!
+;If you plan to use this area, uncomment ALL lines involved in this issue.
+;EnableImprovedInterruptionLogic = true					;Enables this area. This NEEDS to be true for any other option in this issue to work. If it is true, make sure all other options in this issue are AT LEAST UNCOMMENTED.
+
+;InterruptionsGiveActionPoints = true					;Should interruptions give action points, just like a normal turn would?											Default is true, because skirmisher interrupt assumes it is for its ability logic.
+;InterruptionsResetUntouchable = false					;Should interruptions reset untouchable, just like a normal turn would?												Default is false, because the unit isn't taking a typical turn.
+;InterruptionsResetGotFreeFireAction = false			;Just like a normal turn, should interruptions reset the hair trigger proc, so it can be used again?				Default is false, because the unit isn't taking a typical turn.
+;InterruptionsHandleMovementUnitValues = false			;Should interruptions manipulate movement values, just like a normal turn?											Default is false, because the unit isn't taking a typical turn.
+;InterruptionsCleanupBeginTurnUnitValues = false		;Should interruptions clear unit values that use eCleanup_BeginTurn, just like a normal turn?						Default is false, because the unit isn't taking a typical turn.
+;InterruptionsUpdateTurnStartLocation = false			;Should interruptions update turn start location, just like a normal turn?											Default is false, because the unit isn't taking a typical turn.
+;InterruptionsResetPanicTestsPerformedThisTurn = false	;Should interruptions reset the tracker for the amount of panic tests performed this turn, just like a normal turn? Default is false, because the unit isn't taking a typical turn.
+;InterruptionsTriggerGroupTurnBegunEvent = true			;Should interruptions trigger the GroupTurnBegunEvent, just like what happens in a normal turn.						Default is true, because interruptions work closely with "groups" (XComGameState_AIGroup) in the code side of things.
+;End Issue #1325
+
 [XComGame.X2AbilityToHitCalc_StandardAim]
 ;+CritUpgradesThatDontUseEffects="MyFancyTemplateName" ;For modders to use to specify upgrades in their mods that use Issue #237 functionality
 


### PR DESCRIPTION
Turn interruptions don't tick for things like fire/poison/acid, giving the impression they aren't like typical turns. And yet, things like untouchable and unit values with eCleanup_BeginTurn get reset.

This change adds a new function to XCGS_Unit called CHL_SetupActionsForBeginTurn, which is very similar to the vanilla SetupActionsForBeginTurn, except it comes with parameters that are needed for the opt in fix. The new function isn't exclusive to the opt in fix, however, and can be utilized by other mods or added onto in future CHL updates to make the function even more customizable.

This change then goes into X2TacticalGameRuleset.SetupUnitActionsForGroupTurnBegin and performs its much more exclusive change, that is only accessible if opted into via config. The change utilizes the newly added CHL_SetupActionsForBeginTurn, so we can control what exactly happens on turn start for a unit beginning an interruption.