### PR TITLE
Pillar Cover Bug - Finally Fixed!

### DIFF
--- a/X2WOTCCommunityHighlander/Src/XComGame/Classes/X2Ability_TemplarAbilitySet.uc
+++ b/X2WOTCCommunityHighlander/Src/XComGame/Classes/X2Ability_TemplarAbilitySet.uc
@@ -950,7 +950,9 @@ static function X2AbilityTemplate Pillar()
 
 	Template.AbilityShooterConditions.AddItem(default.LivingShooterProperty);
 	Template.AddShooterEffectExclusions();
-
+	// Single line for Issue #1288 - Remove step out animation as it looks silly
+	Template.bSkipExitCoverWhenFiring = true;
+	
 	PillarEffect = new class'X2Effect_Pillar';
 	PillarEffect.BuildPersistentEffect(1, false, true, false, eGameRule_PlayerTurnBegin);	
 	PillarEffect.DestructibleArchetype = "FX_Templar_Pillar.Pillar_Destructible";

--- a/X2WOTCCommunityHighlander/Src/XComGame/Classes/X2Effect_SpawnDestructible.uc
+++ b/X2WOTCCommunityHighlander/Src/XComGame/Classes/X2Effect_SpawnDestructible.uc
@@ -1,0 +1,91 @@
+class X2Effect_SpawnDestructible extends X2Effect_Persistent
+	native(Core);
+
+var() string DestructibleArchetype;
+var() bool bDestroyOnRemoval;	//	destroy the destructible actor when the effect is removed
+var Texture2D TargetingIcon;
+var bool bTargetableBySpawnedTeamOnly;
+
+simulated protected function OnEffectAdded(const out EffectAppliedData ApplyEffectParameters, XComGameState_BaseObject kNewTargetState, XComGameState NewGameState, XComGameState_Effect NewEffectState)
+{
+	local XComGameState_Unit SourceUnit;
+	local XComGameState_Destructible DestructibleState;
+
+	SourceUnit = XComGameState_Unit(NewGameState.GetGameStateForObjectID(ApplyEffectParameters.SourceStateObjectRef.ObjectID));
+	`assert(SourceUnit != none);
+
+	DestructibleState = class'XComDestructibleActor'.static.SpawnDynamicGameStateDestructible( DestructibleArchetype, 
+							ApplyEffectParameters.AbilityInputContext.TargetLocations[0], SourceUnit.GetTeam(), NewGameState );
+
+	DestructibleState.OnlyAllowTargetWithEnemiesInTheBlastRadius = false;
+	DestructibleState.bTargetableBySpawnedTeamOnly = bTargetableBySpawnedTeamOnly;
+
+	NewEffectState.CreatedObjectReference = DestructibleState.GetReference();
+	NewEffectState.ApplyEffectParameters.ItemStateObjectRef = DestructibleState.GetReference();
+}
+
+simulated function AddX2ActionsForVisualization(XComGameState VisualizeGameState, out VisualizationActionMetadata ActionMetadata, name EffectApplyResult)
+{
+	local XComDestructibleActor DestructibleInstance;
+	local XComGameState_Destructible DestructibleState;
+	local ParticleSystemComponent PSC;
+
+	super.AddX2ActionsForVisualization( VisualizeGameState, ActionMetadata, EffectApplyResult );
+
+	foreach VisualizeGameState.IterateByClassType(class'XComGameState_Destructible', DestructibleState)
+	{
+		break;
+	}
+	`assert(DestructibleState != none);
+
+	DestructibleInstance = XComDestructibleActor( DestructibleState.FindOrCreateVisualizer( ) );
+
+	DestructibleInstance.SetPrimitiveHidden(true);
+
+	// these effects aren't hidden when hiding the destructible. hide them directly.
+	foreach DestructibleInstance.m_arrRemovePSCOnDeath(PSC)
+	{
+		if (PSC != none && PSC.bIsActive)
+			PSC.SetHidden(true);
+	}
+
+	`XCOMHISTORY.SetVisualizer(DestructibleState.ObjectID, DestructibleInstance);
+	DestructibleInstance.SetObjectIDFromState(DestructibleState);
+	if( TargetingIcon != None )
+	{
+		DestructibleInstance.TargetingIcon = TargetingIcon;
+	}
+}
+
+simulated function OnEffectRemoved(const out EffectAppliedData ApplyEffectParameters, XComGameState NewGameState, bool bCleansed, XComGameState_Effect RemovedEffectState)
+{
+	local XComGameState_Destructible DestructibleState;
+	local XComDestructibleActor Actor;
+	local XComGameState_EnvironmentDamage NewDamageEvent;
+
+	super.OnEffectRemoved(ApplyEffectParameters, NewGameState, bCleansed, RemovedEffectState);
+
+	if (bDestroyOnRemoval)
+	{
+		DestructibleState = XComGameState_Destructible(NewGameState.GetGameStateForObjectID(ApplyEffectParameters.ItemStateObjectRef.ObjectID));
+		if (DestructibleState == none)
+			DestructibleState = XComGameState_Destructible(`XCOMHISTORY.GetGameStateForObjectID(ApplyEffectParameters.ItemStateObjectRef.ObjectID));
+		if (DestructibleState == none)
+			return;
+
+		Actor = XComDestructibleActor(DestructibleState.GetVisualizer());
+		NewDamageEvent = XComGameState_EnvironmentDamage(NewGameState.CreateNewStateObject(class'XComGameState_EnvironmentDamage'));
+		NewDamageEvent.DEBUG_SourceCodeLocation = "UC: X2Effect_SpawnDestructible:OnEffectRemoved()";
+		NewDamageEvent.HitLocation = Actor.Location;
+		NewDamageEvent.DamageSource.ObjectID = ApplyEffectParameters.SourceStateObjectRef.ObjectID;
+		NewDamageEvent.DestroyedActors.AddItem(Actor.GetActorId());
+		NewDamageEvent.DamageTiles.AddItem(DestructibleState.TileLocation);
+
+		DestructibleState.ForceDestroyed(NewGameState, NewDamageEvent);
+	}
+}
+
+DefaultProperties
+{
+	bDestroyOnRemoval = false
+}

--- a/X2WOTCCommunityHighlander/Src/XComGame/Classes/XComGameState_Effect.uc
+++ b/X2WOTCCommunityHighlander/Src/XComGame/Classes/XComGameState_Effect.uc
@@ -1544,6 +1544,38 @@ function EventListenerReturn GenerateCover_AbilityActivated(Object EventData, Ob
 	return ELR_NoInterrupt;
 }
 
+// Start Issue #1288 - Create an eventlistener which allows refreshing of all tactical visibility via the visibility manager
+/// HL-Docs: ref:Bugfixes; issue:1288
+/// Fixes a bug in which a unit's cover may not be not correctly updated by the visibility manager when destructible actors are created directly adjacent 
+/// to them (e.g. Pillar). The fix uses an eventlistener deferred to the end of the visualization block to clear and refresh the visibility manager. 
+/// Resetting it in this way is a bit of a sledgehammer but since much of the cover/visibility system is native, limited viable alternatives exist.
+function EventListenerReturn RequestVisibilityRefreshFn(Object EventData, Object EventSource, XComGameState GameState, Name EventID, Object CallbackData)
+{
+	local XComGameState_Ability				ActivatedAbilityState;
+	local XComGameStateContext_Ability		AbilityContext;
+	local XComGameState_Unit				SourceUnit;
+	local X2GameRulesetVisibilityManager	VisibilityMgr;
+
+	AbilityContext = XComGameStateContext_Ability(GameState.GetContext());
+    if(AbilityContext == none || AbilityContext.InterruptionStatus == eInterruptionStatus_Interrupt)
+	    return ELR_NoInterrupt;
+
+	SourceUnit = XComGameState_Unit(EventSource);
+	if (SourceUnit == none)
+	    return ELR_NoInterrupt;
+	
+	ActivatedAbilityState = XComGameState_Ability(EventData);
+	if (ActivatedAbilityState == none)
+		return ELR_NoInterrupt;	
+
+	VisibilityMgr = `TACTICALRULES.VisibilityMgr;
+	VisibilityMgr.Clear();
+    VisibilityMgr.InitialUpdate();
+
+	return ELR_NoInterrupt;
+}
+// End Issue #1288
+
 function EventListenerReturn SustainActivated(Object EventData, Object EventSource, XComGameState GameState, Name Event, Object CallbackData)
 {
 	local XComGameState_Unit UnitState;

--- a/X2WOTCCommunityHighlander/X2WOTCCommunityHighlander.x2proj
+++ b/X2WOTCCommunityHighlander/X2WOTCCommunityHighlander.x2proj
@@ -661,6 +661,9 @@
     <Content Include="Src\XComGame\Classes\X2Effect_PersistentVoidConduit.uc">
       <SubType>Content</SubType>
     </Content>
+    <Content Include="Src\XComGame\Classes\X2Effect_SpawnDestructible.uc">
+      <SubType>Content</SubType>
+    </Content>
     <Content Include="Src\XComGame\Classes\X2Effect_Sustain.uc">
       <SubType>Content</SubType>
     </Content>


### PR DESCRIPTION
Fixes #1288 

So goodness knows how many hours have been spent on this, but finally it's done - this bug has been getting on my nerves for months so many thanks to Furudee and Tedster for helping to come up with a workable solution!

This probably needs a bit of more thorough gameplay testing, since building additional gamestates & visualizations which trigger on a deferred listener after the visualization block is complete is not conventional and I worry there may be some unusual interactions with other in-game abilities but it's a big improvement from where we were. Having an ability where its entire intended purpose is to generate cover, not generate cover properly, is pretty egregious.

I think the overall visualization of the ability is satisfactory - I decided to remove the 'step out of cover' animation since it looks quite strange & given the psionic nature of the ability you'd think that standing in front of a bin probably isn't much of a hindrance to a templar summoning a pillar of psionic force with the power of his mind!

There may be things we can do to improve the 'snap' of the pawn between the end of the ability and the update of the cover situation but honestly I think it's barely noticeable - see video on Discord for more info :)