### PR TITLE
Cosmetic physics

### DIFF
--- a/X2WOTCCommunityHighlander/Src/XComGame/Classes/XComLegsContentAdvanced.uc
+++ b/X2WOTCCommunityHighlander/Src/XComGame/Classes/XComLegsContentAdvanced.uc
@@ -1,0 +1,3 @@
+class XComLegsContentAdvanced extends XComLegsContent;
+
+var() SkeletalMesh RequiredSkeleton;

--- a/X2WOTCCommunityHighlander/Src/XComGame/Classes/XComTorsoContentAdvanced.uc
+++ b/X2WOTCCommunityHighlander/Src/XComGame/Classes/XComTorsoContentAdvanced.uc
@@ -1,0 +1,4 @@
+class XComTorsoContentAdvanced extends XComTorsoContent;
+
+var() SkeletalMesh SkeletonOverride;
+var() PhysicsAsset SkeletonPhysicsAsset;

--- a/X2WOTCCommunityHighlander/X2WOTCCommunityHighlander.x2proj
+++ b/X2WOTCCommunityHighlander/X2WOTCCommunityHighlander.x2proj
@@ -931,6 +931,9 @@
     <Content Include="Src\XComGame\Classes\XComGroupSpawn.uc">
       <SubType>Content</SubType>
     </Content>
+    <Content Include="Src\XComGame\Classes\XComLegsContentAdvanced.uc">
+      <SubType>Content</SubType>
+    </Content>
     <Content Include="Src\XComGame\Classes\XComOnlineEventMgr.uc">
       <SubType>Content</SubType>
     </Content>
@@ -965,6 +968,9 @@
       <SubType>Content</SubType>
     </Content>
     <Content Include="Src\XComGame\Classes\XComTacticalSoundManager.uc">
+      <SubType>Content</SubType>
+    </Content>
+    <Content Include="Src\XComGame\Classes\XComTorsoContentAdvanced.uc">
       <SubType>Content</SubType>
     </Content>
     <Content Include="Src\XComGame\Classes\XComUnitPawn.uc">


### PR DESCRIPTION
Proof of concept for physics cosmetics and skeleton replacement #1489 

Mod for testing:
https://steamcommunity.com/sharedfiles/filedetails/?id=3549637280

In the mod, there's a physics cape and belt attachments as a torso cosmetic
Obviously they can be created as a physics prop as people have before, it's just for an example

Things to do:
Have skeleton replacement separate from the torso content
Create some sort of filter which cosmetics work with what skeleton
UI

<img width="1087" height="485" alt="image" src="https://github.com/user-attachments/assets/16c7625b-5fd1-4e5e-ab74-98d2fd8310e6" />
