### PR TITLE
Create a dummy weapon to drop when units die

### DIFF
--- a/X2WOTCCommunityHighlander/Src/XComGame/Classes/X2Action_Knockback.uc
+++ b/X2WOTCCommunityHighlander/Src/XComGame/Classes/X2Action_Knockback.uc
@@ -347,6 +347,14 @@ Begin:
 	if(!NewUnitState.IsDead() && !NewUnitState.IsIncapacitated())
 	{		
 		//Reset visualizers for primary weapon, in case it was dropped
+		// Start Issue #1290
+		// Delete the dummy weapon that was created when unit dies and drops their weapon
+		if(Unit.DummyWeapon != None)
+		{
+			Unit.DummyWeapon.Destroy();
+		}
+		// End Issue #1290
+
 		Unit.GetInventory().GetPrimaryWeapon().Destroy(); //Aggressively get rid of the primary weapon, because dropping it can really screw things up
 		Unit.ApplyLoadoutFromGameState(NewUnitState, None);
 


### PR DESCRIPTION
Fixes #1290 

Most code is from #1341 but to make dummy weapons disappear if unit is revived, I assign the gun to a variable and then delete that weapon when units gets up in `X2Action_Knockback`
