### PR TITLE
Adjust CameraLookAt for Will / Panic Rolls to respect the current Camera ZoomedDistanceFromCursor

### DIFF
--- a/X2WOTCCommunityHighlander/Src/XComGame/Classes/XComGameStateContext_WillRoll.uc
+++ b/X2WOTCCommunityHighlander/Src/XComGame/Classes/XComGameStateContext_WillRoll.uc
@@ -633,7 +633,8 @@ protected function ContextBuildVisualization()
 			LookAtAction.LookAtLocation = WorldLocation;
 			LookAtAction.BlockUntilActorOnScreen = true;
 			LookAtAction.LookAtDuration = 10.0f;		// longer than we need - camera will be removed by tag below
-			LookAtAction.TargetZoomAfterArrival = -0.7f;
+			// Single Line for Issue #919 - Correct the camera zoom level by the maximum zoomed out distance (default can be over-ridden by mods)
+			LookAtAction.TargetZoomAfterArrival = -0.7f * 2600.0f / class'X2Camera_LookAt'.default.ZoomedDistanceFromCursor; 
 			LookAtAction.CameraTag = 'WillTestCamera';
 			LookAtAction.bRemoveTaggedCamera = false;
 


### PR DESCRIPTION
Fixes #1157

This one-line fix replicates what was done by Iridar to prevent the camera panning issue for reaper concealment. This will do the same thing for panic rolls. That is, if camera mods adjust the maximum zoomed out distance, it can result in the camera panning past / through the unit (sometimes into the floor, depending how long it takes to do the panic roll).