### PR TITLE
Support alien character templates for XCOM soldier voicepacks

### DIFF
--- a/X2WOTCCommunityHighlander/Src/XComGame/Classes/XGUnit.uc
+++ b/X2WOTCCommunityHighlander/Src/XComGame/Classes/XGUnit.uc
@@ -1056,7 +1056,9 @@ simulated function bool IsAlien_CheckByCharType()
 	UnitState = XComGameState_Unit(History.GetGameStateForObjectID(ObjectID));
 	if (UnitState != none)
 	{
-		return UnitState.IsAlien();
+	/// HL-Docs: ref:Bugfixes; issue:1508
+	/// XGUnit.UnitSpeak can now allow alien pawns that are used for XCOM soldiers to use voicepacks and speak.
+		return UnitState.IsAlien() && !UnitState.IsSoldier();
 	}
 	
 	return false;


### PR DESCRIPTION
Fixes issue #1508 by adding a "is not a soldier" check before blocking alien pawns from speaking.

Mods still need to handle setting, loading, and updating the voicepacks themselves (I do have a functioning prototype which works with this change). So far, it's being tested by one streamer who is playing 12 hours a day with no reported issues.