### PR TITLE
#1539 - Add configs to force most DoTs to tick on turn end

### DIFF
--- a/.vscode/tasks.json
+++ b/.vscode/tasks.json
@@ -6,54 +6,54 @@
         {
             "label": "Build (final release)",
             "type": "shell",
-            "command": "powershell.exe –NonInteractive –ExecutionPolicy Unrestricted -file '${workspaceRoot}\\.scripts\\build.ps1' -srcDirectory '${workspaceRoot}' -sdkPath '${config:xcom.highlander.sdkroot}' -gamePath '${config:xcom.highlander.gameroot}' -config final_release",
+            "command": "powershell.exe –NonInteractive –ExecutionPolicy Unrestricted -file \"${workspaceRoot}\\.scripts\\build.ps1\" -srcDirectory \"${workspaceRoot}\" -sdkPath \"${config:xcom.highlander.sdkroot}\" -gamePath \"${config:xcom.highlander.gameroot}\" -config final_release",
             "group": "build",
             "problemMatcher": []
         },
         {
             "label": "Build (cooked)",
             "type": "shell",
-            "command": "powershell.exe –NonInteractive –ExecutionPolicy Unrestricted -file '${workspaceRoot}\\.scripts\\build.ps1' -srcDirectory '${workspaceRoot}' -sdkPath '${config:xcom.highlander.sdkroot}' -gamePath '${config:xcom.highlander.gameroot}' -config default",
+            "command": "powershell.exe –NonInteractive –ExecutionPolicy Unrestricted -file \"${workspaceRoot}\\.scripts\\build.ps1\" -srcDirectory \"${workspaceRoot}\" -sdkPath \"${config:xcom.highlander.sdkroot}\" -gamePath \"${config:xcom.highlander.gameroot}\" -config default",
             "group": "build",
             "problemMatcher": []
         },
         {
             "label": "Build (debug)",
             "type": "shell",
-            "command": "powershell.exe –NonInteractive –ExecutionPolicy Unrestricted -file '${workspaceRoot}\\.scripts\\build.ps1' -srcDirectory '${workspaceRoot}' -sdkPath '${config:xcom.highlander.sdkroot}' -gamePath '${config:xcom.highlander.gameroot}' -config debug",
+            "command": "powershell.exe –NonInteractive –ExecutionPolicy Unrestricted -file \"${workspaceRoot}\\.scripts\\build.ps1\" -srcDirectory \"${workspaceRoot}\" -sdkPath \"${config:xcom.highlander.sdkroot}\" -gamePath \"${config:xcom.highlander.gameroot}\" -config debug",
             "group": "build",
             "problemMatcher": []
         },
         {
             "label": "Build (compiletest)",
             "type": "shell",
-            "command": "powershell.exe –NonInteractive –ExecutionPolicy Unrestricted -file '${workspaceRoot}\\.scripts\\build.ps1' -srcDirectory '${workspaceRoot}' -sdkPath '${config:xcom.highlander.sdkroot}' -gamePath '${config:xcom.highlander.gameroot}' -config compiletest",
+            "command": "powershell.exe –NonInteractive –ExecutionPolicy Unrestricted -file \"${workspaceRoot}\\.scripts\\build.ps1\" -srcDirectory \"${workspaceRoot}\" -sdkPath \"${config:xcom.highlander.sdkroot}\" -gamePath \"${config:xcom.highlander.gameroot}\" -config compiletest",
             "group": "build",
             "problemMatcher": []
         },
         {
             "label": "Build for workshop stable version",
             "type": "shell",
-            "command": "powershell.exe –NonInteractive –ExecutionPolicy Unrestricted -file '${workspaceRoot}\\.scripts\\build.ps1' -srcDirectory '${workspaceRoot}' -sdkPath '${config:xcom.highlander.sdkroot}' -gamePath '${config:xcom.highlander.gameroot}' -config stable",
+            "command": "powershell.exe –NonInteractive –ExecutionPolicy Unrestricted -file \"${workspaceRoot}\\.scripts\\build.ps1\" -srcDirectory \"${workspaceRoot}\" -sdkPath \"${config:xcom.highlander.sdkroot}\" -gamePath \"${config:xcom.highlander.gameroot}\" -config stable",
             "group": "build",
             "problemMatcher": []
         },
         {
             "label": "runGame",
             "type": "shell",
-            "command": "powershell.exe –NonInteractive –ExecutionPolicy Unrestricted -file '${workspaceRoot}\\.scripts\\run.ps1' -gamePath '${config:xcom.highlander.gameroot}'",
+            "command": "powershell.exe –NonInteractive –ExecutionPolicy Unrestricted -file \"${workspaceRoot}\\.scripts\\run.ps1\" -gamePath \"${config:xcom.highlander.gameroot}\"",
             "problemMatcher": []
         },
         {
             "label": "runUnrealEditor",
             "type": "shell",
-            "command": "powershell.exe –NonInteractive –ExecutionPolicy Unrestricted -file '${workspaceRoot}\\.scripts\\runUnrealEditor.ps1' -sdkPath '${config:xcom.highlander.sdkroot}'",
+            "command": "powershell.exe –NonInteractive –ExecutionPolicy Unrestricted -file \"${workspaceRoot}\\.scripts\\runUnrealEditor.ps1\" -sdkPath \"${config:xcom.highlander.sdkroot}\"",
             "problemMatcher": []
         },
         {
             "label": "updateVersions",
             "type": "shell",
-            "command": "powershell.exe –NonInteractive –ExecutionPolicy Unrestricted -file '${workspaceRoot}\\.scripts\\update_version.ps1' -ps '${workspaceRoot}\\VERSION.ps1' -srcDirectory '${workspaceRoot}' -no_cache",
+            "command": "powershell.exe –NonInteractive –ExecutionPolicy Unrestricted -file \"${workspaceRoot}\\.scripts\\update_version.ps1\" -ps \"${workspaceRoot}\\VERSION.ps1\" -srcDirectory \"${workspaceRoot}\" -no_cache",
             "problemMatcher": []
         },
         {
@@ -70,6 +70,6 @@
             },
             "command": "python ..\\..\\.scripts\\make_docs.py .\\test_src --outdir .\\test_output --docsdir .\\test_tags --dumpelt .\\test_output\\CHL_Event_Compiletest.uc | % {$_.replace('\\', '/')} | Out-File .\\test_output\\stdout.log -Encoding ASCII",
             "problemMatcher": []
-        },
+        }
     ]
 }

--- a/X2WOTCCommunityHighlander/Config/XComGameCore.ini
+++ b/X2WOTCCommunityHighlander/Config/XComGameCore.ini
@@ -1,9 +1,16 @@
 [XComGame.X2Effect_Burning]
 ;BURNED_IGNORES_SHIELDS=true ; Make burn and acid DOT ignore shields
+; Issue #1539
+; Add damage types whose burn DOTs should tick on turn end.
+; These must be the same `DamageType` passed to SetBurnDamage() for a given DOT.
+;+BURN_TYPES_TICKING_AFTER_TURN="Fire" ; Make burn DOT tick on turn end!
 
 [XComGame.X2StatusEffects]
 ;POISONED_IGNORES_SHIELDS=true ; Make poison DOT ignore shields
 ;BLEEDING_IGNORES_SHIELDS=true ; Make bleeding DOT ignore shields
+; Issue #1539
+;POISONED_TICKS_AFTER_TURN=true ; Make poison DOT tick on turn end
+;BLEEDING_TICKS_AFTER_TURN=true ; Make bleeding DOT tick on turn end
 
 [XComGame.X2TacticalGameRuleset]
 ;PlayerTurnOrder=eTeam_XCom

--- a/X2WOTCCommunityHighlander/Src/XComGame/Classes/X2Effect_Burning.uc
+++ b/X2WOTCCommunityHighlander/Src/XComGame/Classes/X2Effect_Burning.uc
@@ -14,6 +14,7 @@ class X2Effect_Burning extends X2Effect_Persistent
 
 var privatewrite name BurningEffectAddedEventName;
 var config bool BURNED_IGNORES_SHIELDS; //Issue #89
+var config array<name> BURN_TYPES_TICKING_AFTER_TURN; //Issue #1539
 
 function bool IsThisEffectBetterThanExistingEffect(const out XComGameState_Effect ExistingEffect)
 {
@@ -52,7 +53,17 @@ simulated function SetBurnDamage(int Damage, int Spread, name DamageType)
 
 	ApplyOnTick.AddItem(BurnDamage);
 	`assert( ApplyOnTick.Length == 1 );
+
+	//Begin Issue #1539
+	// This isn't how I expected to do this, but I made one critical oversight
+	// in my initial research: SetBurnDamage isn't what calls BuildPersistentEffect. :o
+	if (BURN_TYPES_TICKING_AFTER_TURN.Find(DamageType) != INDEX_NONE)
+	{
+		self.WatchRule = eGameRule_PlayerTurnEnd;
+	}
+	//End Issue #1539
 }
+
 
 simulated function X2Effect_ApplyWeaponDamage GetBurnDamage()
 {


### PR DESCRIPTION
Implements #1539.

### Testing

I didn't think I'd be able to include testing screenshots for this one, but it occurred to me that YAF1 might base its tooltips off an effect's `WatchRule`. I was right!

✅ When `POISONED_TICKS_AFTER_TURN` is true, poison ticks on turn end:
<details>
<img width="1920" height="1080" alt="image" src="https://github.com/user-attachments/assets/00550435-9583-482b-833a-8c70e00847df" />
</details>

✅ When `BLEEDING_TICKS_AFTER_TURN` is true, bleeding ticks on turn end:
<details>
<img width="1920" height="1080" alt="image" src="https://github.com/user-attachments/assets/399042f3-1e88-4c82-b745-3db59c207d51" />
</details>

✅ When `"Fire"` is added to `BURN_TYPES_TICKING_AFTER_TURN`, fire ticks on turn end:
<details>
<img width="1920" height="1080" alt="image" src="https://github.com/user-attachments/assets/050228f0-dbfc-41df-8c18-26cbcb80a559" />
</details>

✅ While `"Acid"` is absent from `BURN_TYPES_TICKING_AFTER_TURN`, acid still uses the vanilla behavior of ticking on turn start:
<details>
<img width="1920" height="1080" alt="image" src="https://github.com/user-attachments/assets/adfd3017-24cb-4065-a512-c57490fa3916" />
</details>

✅ When `POISONED_TICKS_AFTER_TURN` is false, poison uses the vanilla behavior of ticking on turn start:
<details><img width="1920" height="1080" alt="image" src="https://github.com/user-attachments/assets/541ed128-e072-4269-a7db-7724c1b9efc2" />
</details>

✅ When `BLEEDING_TICKS_AFTER_TURN` is false, bleeding uses the vanilla behavior of ticking on turn start:
<details><img width="1920" height="1080" alt="image" src="https://github.com/user-attachments/assets/d1ac8d4d-05af-4506-869c-ad063276d48c" />
</details>

💡 These configs can be changed (to some extent?) during tactical combat! I wasn't sure if that was going to work... but a keen eye will notice both sets of poison/bleed tests were on the same map.

❓ Effects ticking on turn end will still force the camera to look at the victim on turn start? This is in addition to looking at them when they're damaged... I don't remember that being a thing before, so might've done something wrong. Something with the visualizer, maybe?
