### PR TITLE
Reset all bonds for dead soldiers post-mission

### DIFF
--- a/X2WOTCCommunityHighlander/Src/XComGame/Classes/XComGameStateContext_StrategyGameRule.uc
+++ b/X2WOTCCommunityHighlander/Src/XComGame/Classes/XComGameStateContext_StrategyGameRule.uc
@@ -616,6 +616,11 @@ static function SquadTacticalToStrategyTransfer()
 				XComHQ.DeadCrew.AddItem(DeadUnitRef);
 				// Removed from squad in UIAfterAction
 
+				/// HL-Docs: ref:Bugfixes; issue:1457
+				/// Clear all bonds for the dead soldier to clean up future bond-related redscreens.
+				class'X2StrategyGameRulesetDataStructures'.static.ResetAllBonds(NewGameState, UnitState);
+				// End issue #1457
+
 				if (UnitState.GetRank() >= 5)
 				{
 					MissionData.bLostVeteran = true; // Flag for ambient VO triggers in strategy

--- a/X2WOTCCommunityHighlander/Src/XComGame/Classes/XComPresentationLayer.uc
+++ b/X2WOTCCommunityHighlander/Src/XComGame/Classes/XComPresentationLayer.uc
@@ -203,8 +203,9 @@ simulated function UIFlagMgr()
 simulated function ResetUnitFlag(StateObjectReference kUnitRef)
 {
 	local UIUnitFlag kFlag;
-	local XComGameState_BaseObject StartingState;
-	local int VisualizedHistoryIndex;
+	// Issue #1543 - no longer needed.
+	//local XComGameState_BaseObject StartingState;
+	//local int VisualizedHistoryIndex;
 
 	if(m_kUnitFlagManager != None)
 	{


### PR DESCRIPTION
Fixes issue #1457 for units that are killed by calling the same `ResetAllBonds` that is used when a soldier is captured later in the same function, and also is used when a unit is dismissed in the avenger (https://github.com/X2CommunityCore/X2WOTCCommunityHighlander/blob/856cebd123e5010da2395a99f1e8a53c73f6c79e/X2WOTCCommunityHighlander/Src/XComGame/Classes/XComGameStateContext_HeadquartersOrder.uc#L332).

This PR also comments out some now-unused variables from issue #1543