### PR TITLE
Cleanup bond data for dismissed soldiers

### DIFF
--- a/X2WOTCCommunityHighlander/Src/XComGame/Classes/X2StrategyElement_DefaultRewards.uc
+++ b/X2WOTCCommunityHighlander/Src/XComGame/Classes/X2StrategyElement_DefaultRewards.uc
@@ -2106,6 +2106,9 @@ static function CleanUpUnitReward(XComGameState NewGameState, XComGameState_Rewa
 		// First remove the units items
 		UnitState.BlastLoadout(NewGameState);
 		
+		// Single line for Issue #1457 - Remove the reward unit from the bond data arrays of all remaining XCom units
+		class'XComGameStateContext_HeadquartersOrder'.static.RemoveDisposedSoldierFromBondData(UnitState.GetReference());
+
 		// Then remove the actual unit
 		NewGameState.RemoveStateObject(UnitState.ObjectID);
 	}


### PR DESCRIPTION
Fixes #1457 - This implementation removes dismissed soldiers from the AllSoldierBonds arrays of the remaining crew on dismissal. Fixes the original redscreen issue but will need some more robust testing to ensure all is working OK.