### PR TITLE
VSCode improvements

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -4,6 +4,7 @@
 
 # Project specific user settings
 .vscode/settings.json
+*.code-workspace
 
 # Python
 *.pyc

--- a/.vscode/tasks.json
+++ b/.vscode/tasks.json
@@ -6,54 +6,54 @@
         {
             "label": "Build (final release)",
             "type": "shell",
-            "command": "powershell.exe –NonInteractive –ExecutionPolicy Unrestricted -file '${workspaceRoot}\\.scripts\\build.ps1' -srcDirectory '${workspaceRoot}' -sdkPath '${config:xcom.highlander.sdkroot}' -gamePath '${config:xcom.highlander.gameroot}' -config final_release",
+            "command": "powershell.exe –NonInteractive –ExecutionPolicy Unrestricted -file \"${workspaceRoot}\\.scripts\\build.ps1\" -srcDirectory \"${workspaceRoot}\" -sdkPath \"${config:xcom.highlander.sdkroot}\" -gamePath \"${config:xcom.highlander.gameroot}\" -config final_release",
             "group": "build",
             "problemMatcher": []
         },
         {
             "label": "Build (cooked)",
             "type": "shell",
-            "command": "powershell.exe –NonInteractive –ExecutionPolicy Unrestricted -file '${workspaceRoot}\\.scripts\\build.ps1' -srcDirectory '${workspaceRoot}' -sdkPath '${config:xcom.highlander.sdkroot}' -gamePath '${config:xcom.highlander.gameroot}' -config default",
+            "command": "powershell.exe –NonInteractive –ExecutionPolicy Unrestricted -file \"${workspaceRoot}\\.scripts\\build.ps1\" -srcDirectory \"${workspaceRoot}\" -sdkPath \"${config:xcom.highlander.sdkroot}\" -gamePath \"${config:xcom.highlander.gameroot}\" -config default",
             "group": "build",
             "problemMatcher": []
         },
         {
             "label": "Build (debug)",
             "type": "shell",
-            "command": "powershell.exe –NonInteractive –ExecutionPolicy Unrestricted -file '${workspaceRoot}\\.scripts\\build.ps1' -srcDirectory '${workspaceRoot}' -sdkPath '${config:xcom.highlander.sdkroot}' -gamePath '${config:xcom.highlander.gameroot}' -config debug",
+            "command": "powershell.exe –NonInteractive –ExecutionPolicy Unrestricted -file \"${workspaceRoot}\\.scripts\\build.ps1\" -srcDirectory \"${workspaceRoot}\" -sdkPath \"${config:xcom.highlander.sdkroot}\" -gamePath \"${config:xcom.highlander.gameroot}\" -config debug",
             "group": "build",
             "problemMatcher": []
         },
         {
             "label": "Build (compiletest)",
             "type": "shell",
-            "command": "powershell.exe –NonInteractive –ExecutionPolicy Unrestricted -file '${workspaceRoot}\\.scripts\\build.ps1' -srcDirectory '${workspaceRoot}' -sdkPath '${config:xcom.highlander.sdkroot}' -gamePath '${config:xcom.highlander.gameroot}' -config compiletest",
+            "command": "powershell.exe –NonInteractive –ExecutionPolicy Unrestricted -file \"${workspaceRoot}\\.scripts\\build.ps1\" -srcDirectory \"${workspaceRoot}\" -sdkPath \"${config:xcom.highlander.sdkroot}\" -gamePath \"${config:xcom.highlander.gameroot}\" -config compiletest",
             "group": "build",
             "problemMatcher": []
         },
         {
             "label": "Build for workshop stable version",
             "type": "shell",
-            "command": "powershell.exe –NonInteractive –ExecutionPolicy Unrestricted -file '${workspaceRoot}\\.scripts\\build.ps1' -srcDirectory '${workspaceRoot}' -sdkPath '${config:xcom.highlander.sdkroot}' -gamePath '${config:xcom.highlander.gameroot}' -config stable",
+            "command": "powershell.exe –NonInteractive –ExecutionPolicy Unrestricted -file \"${workspaceRoot}\\.scripts\\build.ps1\" -srcDirectory \"${workspaceRoot}\" -sdkPath \"${config:xcom.highlander.sdkroot}\" -gamePath \"${config:xcom.highlander.gameroot}\" -config stable",
             "group": "build",
             "problemMatcher": []
         },
         {
             "label": "runGame",
             "type": "shell",
-            "command": "powershell.exe –NonInteractive –ExecutionPolicy Unrestricted -file '${workspaceRoot}\\.scripts\\run.ps1' -gamePath '${config:xcom.highlander.gameroot}'",
+            "command": "powershell.exe –NonInteractive –ExecutionPolicy Unrestricted -file \"${workspaceRoot}\\.scripts\\run.ps1\" -gamePath \"${config:xcom.highlander.gameroot}\"",
             "problemMatcher": []
         },
         {
             "label": "runUnrealEditor",
             "type": "shell",
-            "command": "powershell.exe –NonInteractive –ExecutionPolicy Unrestricted -file '${workspaceRoot}\\.scripts\\runUnrealEditor.ps1' -sdkPath '${config:xcom.highlander.sdkroot}'",
+            "command": "powershell.exe –NonInteractive –ExecutionPolicy Unrestricted -file \"${workspaceRoot}\\.scripts\\runUnrealEditor.ps1\" -sdkPath \"${config:xcom.highlander.sdkroot}\"",
             "problemMatcher": []
         },
         {
             "label": "updateVersions",
             "type": "shell",
-            "command": "powershell.exe –NonInteractive –ExecutionPolicy Unrestricted -file '${workspaceRoot}\\.scripts\\update_version.ps1' -ps '${workspaceRoot}\\VERSION.ps1' -srcDirectory '${workspaceRoot}' -no_cache",
+            "command": "powershell.exe –NonInteractive –ExecutionPolicy Unrestricted -file \"${workspaceRoot}\\.scripts\\update_version.ps1\" -ps \"${workspaceRoot}\\VERSION.ps1\" -srcDirectory \"${workspaceRoot}\" -no_cache",
             "problemMatcher": []
         },
         {
@@ -70,6 +70,6 @@
             },
             "command": "python ..\\..\\.scripts\\make_docs.py .\\test_src --outdir .\\test_output --docsdir .\\test_tags --dumpelt .\\test_output\\CHL_Event_Compiletest.uc | % {$_.replace('\\', '/')} | Out-File .\\test_output\\stdout.log -Encoding ASCII",
             "problemMatcher": []
-        },
+        }
     ]
 }


### PR DESCRIPTION
Fulfilling Ted's request from #1541 at long last. That just took *forever* to get around to, didn't it...

- VSCode tasks should no longer misbehave when paths to the workspace, SDK, or game include spaces.
- Added VSCode workspaces to gitignore, on the grounds that a good X2 modding workspace contains user-specific information such as SDK paths and is unfortunately not generically applicable to other devs' environments.