### PR TITLE
Change debug-promotion key in non-release CHL build from Tab to F11

### DIFF
--- a/X2WOTCCommunityHighlander/Src/XComGame/Classes/UIArmory_Promotion.uc
+++ b/X2WOTCCommunityHighlander/Src/XComGame/Classes/UIArmory_Promotion.uc
@@ -774,7 +774,8 @@ simulated function bool OnUnrealCommand(int cmd, int arg)
 	{
 		// DEBUG: Press Tab to rank up the soldier
 		`if (`notdefined(FINAL_RELEASE))
-		case class'UIUtilities_Input'.const.FXS_KEY_TAB:
+		// Single line for Issue #578 - Change key from TAB to F11. Prevents custom CHL builds from promoting soldiers on TAB Keypress
+		case class'UIUtilities_Input'.const.FXS_KEY_F11:
 			History = `XCOMHISTORY;
 			ChangeContainer = class'XComGameStateContext_ChangeContainer'.static.CreateEmptyChangeContainer("DEBUG Unit Rank Up");
 			UpdateState = History.CreateNewGameState(true, ChangeContainer);


### PR DESCRIPTION
Fixes #578 - Since this only affects debug / default CHL builds & community promo screen prevents it as well, may as well just change the key.