### PR TITLE
Add improved FreeKillOnDamage_CH()

### DIFF
--- a/X2WOTCCommunityHighlander/Src/XComGame/Classes/X2Effect_ApplyWeaponDamage.uc
+++ b/X2WOTCCommunityHighlander/Src/XComGame/Classes/X2Effect_ApplyWeaponDamage.uc
@@ -130,7 +130,8 @@ simulated protected function OnEffectAdded(const out EffectAppliedData ApplyEffe
 						EffectState = XComGameState_Effect(History.GetGameStateForObjectID(EffectRef.ObjectID));
 						if (EffectState != none)
 						{
-							if (EffectState.GetX2Effect().FreeKillOnDamage(SourceUnit, TargetUnit, NewGameState, TotalToKill, ApplyEffectParameters))
+							// Single line for Issue #1615 
+							if (EffectState.GetX2Effect().FreeKillOnDamage_CH(SourceUnit, TargetUnit, NewGameState, TotalToKill, ApplyEffectParameters, AppliedDamageTypes, iDamage, iMitigated, NewShred, NewRupture, bDoesDamageIgnoreShields))
 							{
 								TargetUnit.TakeEffectDamage(self, TotalToKill, 0, NewShred, ApplyEffectParameters, NewGameState, false, false, true, AppliedDamageTypes, SpecialDamageMessages);
 								if (TargetUnit.IsAlive())

--- a/X2WOTCCommunityHighlander/Src/XComGame/Classes/X2Effect_Persistent.uc
+++ b/X2WOTCCommunityHighlander/Src/XComGame/Classes/X2Effect_Persistent.uc
@@ -711,6 +711,15 @@ function      AdjustEffectDuration(const out EffectAppliedData ApplyEffectParame
 function Actor GetProjectileVolleyTemplate(XComGameState_Unit UnitState, XComGameState_Effect EffectState, XComGameStateContext_Ability AbilityContext) { return none; }
 function bool AdjustSuperConcealModifier(XComGameState_Unit UnitState, XComGameState_Effect EffectState, XComGameState_Ability AbilityState, XComGameState RespondToGameState, const int BaseModifier, out int CurrentModifier) { return false; }
 function bool FreeKillOnDamage(XComGameState_Unit Shooter, XComGameState_Unit Target, XComGameState GameState, const int ToKillTarget, const out EffectAppliedData ApplyEffectParameters) { return false; }
+// Start Issue #1615
+/// HL-Docs: feature:ImprovedFreeKillOnDamageHook; issue:1615; tags:tactical
+/// Adds an improved version of FreeKillOnDamage() that provides
+/// additional arguments related to the calculated damage value.
+function bool FreeKillOnDamage_CH(XComGameState_Unit Shooter, XComGameState_Unit Target, XComGameState NewGameState, const int ToKillTarget, const out EffectAppliedData ApplyEffectParameters, const out array<name> AppliedDamageTypes, const int iDamage, const int iMitigated, const int NewShred, const int NewRupture, bool bDoesDamageIgnoreShields)
+{
+	return FreeKillOnDamage(Shooter, Target, NewGameState, ToKillTarget, ApplyEffectParameters);
+}
+// End Issue #1615
 function bool GrantsFreeActionPointForApplyCost(XComGameStateContext_Ability AbilityContext, XComGameState_Unit Shooter, XComGameState_Unit Target, XComGameState GameState) { return false; }
 function bool GrantsFreeActionPoint_Target(XComGameStateContext_Ability AbilityContext, XComGameState_Unit Shooter, XComGameState_Unit Target, XComGameState GameState) { return false; }
 function bool ImmediateSelectNextTarget(XComGameStateContext_Ability AbilityContext, XComGameState_Unit Target) { return false; }


### PR DESCRIPTION
Adds an improved version of `X2Effect_Persistent::FreeKillOnDamage()` that provides additional arguments related to the calculated damage value.

Resolves #1615 